### PR TITLE
Fix raw distance docstring escape

### DIFF
--- a/src/lysis/geometry/edge_grid.py
+++ b/src/lysis/geometry/edge_grid.py
@@ -556,7 +556,7 @@ class EdgeGrid(object):
     def get_distance(
         run: Run, a: Tuple[int, int], b: Tuple[int, int], metric: str = "euclidian"
     ) -> Quantity:
-        """
+        r"""
         Calculate the distance between the centers of two edges on an EdgeGrid. 
         The distance returned will be a Pint Quantity which includes appropriate units.
 


### PR DESCRIPTION
Fixes #34.

## Summary
- marks `EdgeGrid.get_distance()`'s docstring as raw so its Sphinx math backslashes are preserved as literal text
- avoids Python 3.13/3.14 invalid escape sequence warnings/errors from LaTeX sequences such as `\sqrt`

## Validation
- Not run locally
- `git diff --check HEAD~1..HEAD`
- Relying on the GitHub Actions PR workflow for remote validation.