### PR TITLE
Add --slurm support to lysis run-macro --backend python (#65)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -51,6 +51,20 @@ Added
   ``total_time = 0`` runs the simulation to completion (until every fiber
   degrades) rather than for a fixed duration; the snapshot buffers grow on
   demand to accommodate the unknown number of save points. (#35)
+- ``lysis run-macro --backend python`` now accepts ``--slurm`` and the
+  storage-redirection flags (``--staging-root``, ``--fast-tmp-root``,
+  ``--keep-tmpdir``, ``--partition``, ``--compiler``, ``--sbatch``). With
+  ``--slurm`` each Run is submitted as one Slurm job (no array — HDF5's
+  single-writer constraint requires every simulation for a Run to execute
+  in series within one job); in batch mode the existing CLI loop submits one
+  independent master job per ``.h5`` file. Without ``--fast-tmp-root`` the
+  job writes directly to the original ``.h5`` on the shared filesystem; with
+  ``--fast-tmp-root`` the job ``cp``\\ s the ``.h5`` to node-local scratch,
+  runs there, and ``cp``\\ s the populated file back over the original on
+  success (a mid-job crash leaves the original in its ``MACRO_EMPTY`` state
+  for clean resubmission). The Fortran-only flags ``--executable``,
+  ``--fortran-commit``, ``--in-file-code``, ``--out-file-code``, and
+  ``--allow-stale-binary`` remain rejected for ``--backend python``. (#65)
 
 Changed
 -------

--- a/src/lysis/cli/run_macro.py
+++ b/src/lysis/cli/run_macro.py
@@ -48,8 +48,11 @@ from lysis.tools.slurm import DEFAULT_COMPILER_MODULE, parse_sbatch_tokens
     help=(
         "Execution backend.  'fortran' runs the compiled Fortran binary "
         "(requires --executable).  'python' runs the pure-Python NumPy "
-        "macroscale model in-process (no Fortran toolchain needed); the "
-        "Fortran-/Slurm-specific options are not supported with it."
+        "macroscale model — either in-process (the default) or, with "
+        "--slurm, as a single Slurm job per Run that runs every "
+        "simulation in series.  --executable, --fortran-commit, "
+        "--in-file-code, --out-file-code, and --allow-stale-binary are "
+        "Fortran-only."
     ),
 )
 @click.option(
@@ -97,7 +100,9 @@ from lysis.tools.slurm import DEFAULT_COMPILER_MODULE, parse_sbatch_tokens
         "Root directory for fast node-local scratch storage.  "
         "When set, each Slurm array task writes here and moves results to "
         "the staging directory on completion (two-tier storage).  "
-        "Only meaningful with --slurm."
+        "With --backend python --slurm, the .h5 file itself is cp'd to "
+        "this directory before running and cp'd back over the original "
+        "on success.  Only meaningful with --slurm."
     ),
 )
 @click.option(
@@ -207,10 +212,13 @@ def run_macro(ctx, target_path, backend, executable, use_slurm, partition,
     \b
     Backends (--backend):
       - fortran (default): run the compiled Fortran binary (--executable).
-      - python: run the pure-Python NumPy macroscale model in-process, with
-        no Fortran toolchain.  Simulations run in series.  The Fortran-/Slurm-
-        specific options (--executable, --slurm, --fortran-commit, etc.) are
-        not supported with this backend.
+      - python: run the pure-Python NumPy macroscale model.  Without --slurm,
+        runs in-process with no Fortran toolchain.  With --slurm, submits one
+        Slurm job per Run that runs every simulation in series (HDF5 has a
+        single-writer constraint; --fast-tmp-root cp's the .h5 to node-local
+        scratch and back on completion).  --executable, --fortran-commit,
+        --in-file-code, --out-file-code, and --allow-stale-binary are not
+        supported with this backend.
 
     \b
     Examples:
@@ -223,6 +231,10 @@ def run_macro(ctx, target_path, backend, executable, use_slurm, partition,
             --partition normal --staging-root /scratch/staging
         lysis run-macro data/run01.h5 --executable bin/macro.exe --slurm \\
             --fast-tmp-root /nvme/scratch
+        lysis run-macro data/run01.h5 --backend python --slurm
+        lysis run-macro data/run01.h5 --backend python --slurm \\
+            --partition normal --fast-tmp-root /nvme/scratch
+        lysis run-macro data/my-experiment/ --backend python --slurm
         lysis run-macro data/my-experiment/ --executable bin/macro.exe
         lysis run-macro data/my-experiment/ --executable bin/macro.exe --slurm
     """
@@ -237,13 +249,7 @@ def run_macro(ctx, target_path, backend, executable, use_slurm, partition,
     else:  # backend == "python"
         fortran_only = [
             (executable, "--executable"),
-            (use_slurm, "--slurm"),
-            (partition, "--partition"),
             (fortran_commit, "--fortran-commit"),
-            (compiler != DEFAULT_COMPILER_MODULE, "--compiler"),
-            (sbatch_tokens, "--sbatch"),
-            (staging_root, "--staging-root"),
-            (fast_tmp_root, "--fast-tmp-root"),
             (in_file_code, "--in-file-code"),
             (out_file_code, "--out-file-code"),
             (allow_stale_binary, "--allow-stale-binary"),
@@ -279,9 +285,43 @@ def run_macro(ctx, target_path, backend, executable, use_slurm, partition,
         with DataStore(hdf5_path.stem, str(hdf5_path.parent), mode="r") as ds:
             enforce_init_commit_match(ctx, ds, "macro", allow_commit_mismatch)
 
-    # Pure-Python backend: run each simulation in-process (in series) and
-    # write results straight into the HDF5 file.  No Fortran/Slurm machinery.
+    # Pure-Python backend: either dispatch one Slurm master job per Run
+    # (each runs all sims in series within the job) or run in-process.
     if backend == "python":
+        if use_slurm:
+            from lysis.tools.slurm import submit_python_macro_slurm_job
+
+            try:
+                sbatch_overrides = parse_sbatch_tokens(sbatch_tokens)
+            except ValueError as e:
+                raise click.BadParameter(str(e), param_hint="--sbatch")
+
+            submitted = []
+            for hdf5_path in hdf5_paths:
+                try:
+                    job_id = submit_python_macro_slurm_job(
+                        hdf5_path,
+                        staging_root=staging_root,
+                        partition=partition,
+                        fast_tmp_root=fast_tmp_root,
+                        keep_tmpdir=keep_tmpdir,
+                        compiler_module=compiler,
+                        sbatch_overrides=sbatch_overrides,
+                    )
+                except ValueError as e:
+                    raise click.ClickException(str(e))
+                submitted.append((hdf5_path.stem, job_id))
+                console.print(
+                    f"Submitted master Slurm job [bold]{job_id}[/bold]"
+                    f" for {hdf5_path.stem}"
+                )
+
+            if len(submitted) > 1:
+                console.print(
+                    f"[green]Submitted {len(submitted)} master Slurm jobs.[/green]"
+                )
+            return
+
         from lysis.execution.python_macro import PythonMacro
 
         n = len(hdf5_paths)

--- a/src/lysis/tools/slurm.py
+++ b/src/lysis/tools/slurm.py
@@ -443,6 +443,15 @@ class _SlurmJobSpec:
         array only).  Threaded into ``from_hdf5`` so the runner sees the
         partition contract; ``None`` for macro.
     :vartype num_children: int or None
+    :ivar backend: ``"fortran"`` (default) or ``"python"``.  Selects the
+        body of the array-task bash script (Fortran binary vs. in-process
+        :class:`~lysis.execution.python_macro.PythonMacro`) and of the
+        master Python script's post-poll block (Fortran imports per-task
+        outputs into HDF5; Python tasks write to HDF5 themselves and the
+        master has nothing left to do).  Python backends ignore
+        ``out_file_code``, ``in_file_code``, ``num_children``,
+        ``needs_concat_step`` and ``prestage_executable``.
+    :vartype backend: str
     """
 
     scale: str
@@ -455,31 +464,30 @@ class _SlurmJobSpec:
     out_file_code: str
     in_file_code: Optional[str] = None
     num_children: Optional[int] = None
+    backend: str = "fortran"
 
 
-#: Template for the master Python script in array mode (both scales).
+#: Template for the master Python script in array mode (both backends).
 #: Substitution keys use ``$name`` syntax so Python braces in the
-#: template body are untouched.
+#: template body are untouched.  The post-poll body is supplied per-backend
+#: via the ``$import_block`` substitution (Fortran: instantiate runner and
+#: call ``import_results``; Python: print a status line, since the array
+#: task wrote to HDF5 itself).
 _ARRAY_MASTER_PY_TEMPLATE = Template('''\
 #!/usr/bin/env python3
-"""Master Slurm job: submit array tasks, poll for completion, $concat_blurb import."""
+"""Master Slurm job: submit array tasks, poll for completion, $post_poll_blurb."""
 import time
 import shutil
 from pathlib import Path
 
 import GooseSLURM as gs
-from lysis.config.run import Run
-from $runner_module import $runner_class
 
 STAGING_DIR = Path($staging_dir)
 HDF5_PATH = Path($hdf5_path)
 RUN_CODE = $run_code
-OUT_FILE_CODE = $out_file_code
-BINARY_NAME = $binary_name
 KEEP_TMPDIR = $keep_tmpdir
 NUM_ARRAY_TASKS = $num_array_tasks
 NFS_WAIT_SECONDS = $nfs_wait_seconds
-HISTORICAL_BINARY_ATTRS = $historical_binary_attrs
 
 # ---------------------------------------------------------------------------
 # Submit array job
@@ -515,24 +523,10 @@ print("All array tasks complete.", flush=True)
 time.sleep(NFS_WAIT_SECONDS)
 
 # ---------------------------------------------------------------------------
-# Import results into HDF5
+# Per-backend post-poll body (Fortran: import per-task outputs into HDF5;
+# Python: nothing to do — array task already wrote directly to HDF5).
 # ---------------------------------------------------------------------------
-data_dir = STAGING_DIR / "data" / RUN_CODE
-run = Run(str(HDF5_PATH.parent), run_code=RUN_CODE)
-fm = $runner_class(
-    run=run,
-    out_file_code=OUT_FILE_CODE,
-    executable=str(STAGING_DIR / BINARY_NAME),
-    skip_binary_verification=(HISTORICAL_BINARY_ATTRS is not None),
-    historical_binary_attrs=HISTORICAL_BINARY_ATTRS,
-)
-$concat_block
-fm.import_results(
-    data_dir,
-    keep_on_failure=True,
-    keep_tmpdir=KEEP_TMPDIR,
-)
-print("Results imported successfully.", flush=True)
+$import_block
 
 # ---------------------------------------------------------------------------
 # Clean up staging directory
@@ -550,63 +544,129 @@ def _generate_array_master_py(
     staging_dir: Path,
     hdf5_path: Path,
     run_code: str,
-    binary_name: str,
+    binary_name: Optional[str],
     keep_tmpdir: bool,
     historical_binary_attrs: Optional[dict] = None,
 ) -> str:
     """Return the master Python script for an array-mode dispatch.
 
+    The post-poll body is assembled per-backend:
+
+    * ``"fortran"``: imports the runner class, instantiates it, optionally
+      concatenates per-task outputs, and calls ``import_results`` to merge
+      the per-task Fortran output into the HDF5 file.
+    * ``"python"``: prints a status line.  The array task ran
+      :meth:`~lysis.execution.python_macro.PythonRunner.execute` itself
+      and wrote directly to HDF5, so the master has nothing left to do
+      before the staging-dir cleanup.
+
+    :param binary_name: Basename of the pre-staged Fortran binary inside
+        the staging dir.  Required for ``backend="fortran"``; ignored
+        (and may be ``None``) for ``backend="python"``.
+    :type binary_name: str or None
     :param historical_binary_attrs: Pre-computed binary-provenance dict
         from
         :func:`~lysis.tools.provenance.gather_historical_binary_provenance`
         for the historical-build workflow.  Baked into the master script
         as a literal so the master can stamp it in place of the default
-        ``<binary> --version`` query.  ``None`` (default) preserves the
-        normal-mode behaviour.
+        ``<binary> --version`` query.  Only meaningful for
+        ``backend="fortran"``.
     :type historical_binary_attrs: dict or None
     """
-    if spec.needs_concat_step:
-        concat_block = (
-            f"fm.concatenate_child_outputs(data_dir, num_children={spec.num_array_tasks})"
+    if spec.backend == "python":
+        import_block = (
+            'print("Python task wrote results directly into HDF5.",'
+            " flush=True)"
         )
-        concat_blurb = "concatenate per-task outputs, then"
+        post_poll_blurb = "exit (HDF5 already written by the array task)"
     else:
-        concat_block = "# (no concatenation step — runner imports per-task subdirs directly)"
-        concat_blurb = "then"
+        if spec.needs_concat_step:
+            concat_block = (
+                "fm.concatenate_child_outputs("
+                f"data_dir, num_children={spec.num_array_tasks})"
+            )
+            post_poll_blurb = "concatenate per-task outputs, then import"
+        else:
+            concat_block = (
+                "# (no concatenation step — runner imports per-task subdirs"
+                " directly)"
+            )
+            post_poll_blurb = "import"
+
+        import_block = (
+            "from lysis.config.run import Run\n"
+            f"from {spec.runner_module} import {spec.runner_class}\n"
+            "\n"
+            f"OUT_FILE_CODE = {repr(spec.out_file_code)}\n"
+            f"BINARY_NAME = {repr(binary_name)}\n"
+            f"HISTORICAL_BINARY_ATTRS = {repr(historical_binary_attrs)}\n"
+            "\n"
+            "data_dir = STAGING_DIR / \"data\" / RUN_CODE\n"
+            "run = Run(str(HDF5_PATH.parent), run_code=RUN_CODE)\n"
+            f"fm = {spec.runner_class}(\n"
+            "    run=run,\n"
+            "    out_file_code=OUT_FILE_CODE,\n"
+            "    executable=str(STAGING_DIR / BINARY_NAME),\n"
+            "    skip_binary_verification=(HISTORICAL_BINARY_ATTRS is not None),\n"
+            "    historical_binary_attrs=HISTORICAL_BINARY_ATTRS,\n"
+            ")\n"
+            f"{concat_block}\n"
+            "fm.import_results(\n"
+            "    data_dir,\n"
+            "    keep_on_failure=True,\n"
+            "    keep_tmpdir=KEEP_TMPDIR,\n"
+            ")\n"
+            'print("Results imported successfully.", flush=True)'
+        )
 
     return _ARRAY_MASTER_PY_TEMPLATE.substitute(
         scale=spec.scale,
-        runner_module=spec.runner_module,
-        runner_class=spec.runner_class,
         staging_dir=repr(str(staging_dir)),
         hdf5_path=repr(str(hdf5_path)),
         run_code=repr(run_code),
-        out_file_code=repr(spec.out_file_code),
-        binary_name=repr(binary_name),
         keep_tmpdir=repr(keep_tmpdir),
         num_array_tasks=spec.num_array_tasks,
         nfs_wait_seconds=spec.nfs_wait_seconds,
-        concat_block=concat_block,
-        concat_blurb=concat_blurb,
-        historical_binary_attrs=repr(historical_binary_attrs),
+        import_block=import_block,
+        post_poll_blurb=post_poll_blurb,
     )
 
 
 def _runner_init_line(
     spec: _SlurmJobSpec,
-    hdf5_path: Path,
-    binary_path: str,
+    hdf5_path: str,
+    binary_path: Optional[str],
     *,
     skip_binary_verification: bool = False,
 ) -> str:
     """Build the ``from_hdf5(...)`` call used inside the array task ``python -c``.
 
-    Single-line so it composes cleanly inside the bash heredoc.  When
-    *skip_binary_verification* is True the call emits
-    ``skip_binary_verification=True`` so the historical-build workflow's
+    Single-line so it composes cleanly inside the bash heredoc.
+
+    For ``spec.backend == "fortran"`` the call carries the binary path,
+    in/out file codes, the per-task ``SLURM_ARRAY_TASK_ID``, optionally
+    ``num_children`` for the microscale array partition, and (when
+    *skip_binary_verification* is True under the historical-build
+    workflow) ``skip_binary_verification=True`` so the intentional
     binary↔source mismatch does not crash ``_verify_binary_version`` at
     task start.
+
+    For ``spec.backend == "python"`` only ``hdf5_path`` is emitted —
+    :meth:`~lysis.execution.python_macro.PythonRunner.from_hdf5` takes
+    no other arguments, the single array task runs every simulation in
+    series, and there is no binary to verify.
+
+    :param hdf5_path: HDF5 path as it should appear inside the ``python
+        -c`` string.  May be a literal absolute path or a ``${...}`` bash
+        variable reference (the caller is responsible for picking which).
+    :type hdf5_path: str
+    :param binary_path: Fortran binary path inside the bash script.
+        Required for ``backend="fortran"``; ignored (and may be ``None``)
+        for ``backend="python"``.
+    :type binary_path: str or None
     """
+    if spec.backend == "python":
+        return f"{spec.runner_class}.from_hdf5('{hdf5_path}')"
     args = [f"'{hdf5_path}'", f"'{binary_path}'"]
     if spec.in_file_code is not None:
         args.append(f"in_file_code='{spec.in_file_code}'")
@@ -624,7 +684,7 @@ def generate_array_script(
     staging_dir: "Path | str",
     run_code: str,
     hdf5_path: "Path | str",
-    executable: "Path | str",
+    executable: "Path | str | None",
     *,
     partition: Optional[str] = None,
     fast_tmp_root: Optional[str] = None,
@@ -636,24 +696,42 @@ def generate_array_script(
 ) -> str:
     """Generate a Slurm array job bash script for an array-mode dispatch.
 
-    Each array task indexed by ``SLURM_ARRAY_TASK_ID`` calls
-    ``{spec.runner_class}.from_hdf5(...).exec_in_workdir(...)``.
-
-    For the *macroscale* path each task isolates its output in a
-    per-simulation subdirectory ``data/{run_code}/{sim:02}/`` (managed by
+    For ``spec.backend == "fortran"`` each array task indexed by
+    ``SLURM_ARRAY_TASK_ID`` calls
+    ``{spec.runner_class}.from_hdf5(...).exec_in_workdir(...)``.  For the
+    *macroscale* path each task isolates its output in a per-simulation
+    subdirectory ``data/{run_code}/{sim:02}/`` (managed by
     :class:`~lysis.execution.fortran_macro.FortranMacro` itself).  For the
     *microscale* array path each task writes flat files with a ``__NN``
     suffix into ``data/{run_code}/``; the master concatenates them after
     all tasks complete.
 
-    **Single-tier** (default, ``fast_tmp_root=None``): Fortran writes its
-    output directly into ``{staging_dir}/data/{run_code}/``.  The
-    executable is *not* copied here — :func:`submit_slurm_job` pre-stages
-    it before any task starts (avoids a cp race).
+    For ``spec.backend == "python"`` the single array task calls
+    ``{spec.runner_class}.from_hdf5(hdf5).execute()`` directly — the
+    Python runner writes every simulation, in series, straight into the
+    HDF5 file via its open DataStore (HDF5 has a single-writer
+    constraint, so an n-task array is not possible at this scale).
+    ``executable`` is ignored and may be ``None``.
 
-    **Two-tier** (``fast_tmp_root`` provided): Fortran writes to a private
-    ``mktemp -d -p {fast_tmp_root}`` directory on the compute node; the
-    output is moved to the shared staging dir before exit.
+    **Single-tier** (default, ``fast_tmp_root=None``):
+
+    * Fortran: writes its output directly into
+      ``{staging_dir}/data/{run_code}/``.  The executable is *not* copied
+      here — :func:`submit_slurm_job` pre-stages it before any task
+      starts (avoids a cp race).
+    * Python: writes directly into the original ``hdf5_path`` (typically
+      on a shared filesystem).
+
+    **Two-tier** (``fast_tmp_root`` provided):
+
+    * Fortran: writes to a private ``mktemp -d -p {fast_tmp_root}``
+      directory on the compute node; the output is moved to the shared
+      staging dir before exit.
+    * Python: ``cp``\\ s ``hdf5_path`` into the local fast dir, runs the
+      Python task against that copy, then ``cp``\\ s the result back
+      over the original on success.  A mid-job crash leaves the
+      original ``.h5`` in its ``MACRO_EMPTY`` state for clean
+      resubmission.
 
     :param spec: Scale-specific dispatch description.
     :type spec: _SlurmJobSpec
@@ -663,8 +741,9 @@ def generate_array_script(
     :type run_code: str
     :param hdf5_path: Full path to the run's ``.h5`` file.
     :type hdf5_path: Path or str
-    :param executable: Path to the compiled Fortran binary.
-    :type executable: Path or str
+    :param executable: Path to the compiled Fortran binary.  May be
+        ``None`` when ``spec.backend == "python"``.
+    :type executable: Path or str or None
     :param partition: Slurm partition for ``#SBATCH --partition``.
     :type partition: str, optional
     :param fast_tmp_root: Root directory for fast node-local scratch.
@@ -700,8 +779,11 @@ def generate_array_script(
     """
     staging_dir = Path(staging_dir)
     hdf5_path = Path(hdf5_path)
-    executable = Path(executable)
-    binary_name = executable.name
+    if executable is not None:
+        executable = Path(executable)
+        binary_name = executable.name
+    else:
+        binary_name = None
     if slurm_log_dir is None:
         slurm_log_dir = hdf5_path.parent / ".slurm"
     slurm_log_dir = Path(slurm_log_dir)
@@ -727,14 +809,61 @@ def generate_array_script(
         sbatch_opts["partition"] = partition
     sbatch_opts = apply_sbatch_overrides(sbatch_opts, sbatch_overrides)
 
-    if fast_tmp_root is None:
+    if spec.backend == "python":
+        # ------------------------------------------------------------------
+        # Python backend: single array task runs every simulation in series
+        # via PythonRunner.execute(), writing directly to HDF5.  No binary,
+        # no per-task subdirs, no setup files.
+        # ------------------------------------------------------------------
+        if fast_tmp_root is None:
+            # Single-tier: write directly to the original .h5 path.
+            init = _runner_init_line(
+                spec, str(hdf5_path), None,
+            )
+            execute = f"""\
+# Execute {spec.scale}scale Python runner via lysis
+{env_preamble}
+{py} -c "
+from {spec.runner_module} import {spec.runner_class}
+{init}.execute()
+" """
+            sections = [execute]
+        else:
+            # Two-tier: cp the .h5 to node-local scratch, run there, cp back.
+            # Use cp (not mv) so a mid-job crash leaves the original .h5 in
+            # its MACRO_EMPTY state for clean resubmission.
+            setup = f"""\
+# Setup — create local fast dir, copy HDF5 file in
+local_work_dir=$(mktemp -d -p "{fast_tmp_root}")
+local_h5_path="${{local_work_dir}}/{hdf5_path.name}"
+cp "{hdf5_path}" "${{local_h5_path}}" """
+
+            init = _runner_init_line(
+                spec, "${local_h5_path}", None,
+            )
+            execute = f"""\
+# Execute {spec.scale}scale Python runner against the local HDF5 copy
+{env_preamble}
+{py} -c "
+from {spec.runner_module} import {spec.runner_class}
+{init}.execute()
+" """
+
+            move = f"""\
+# Copy populated HDF5 back over the original, then clean up local dir
+cp "${{local_h5_path}}" "{hdf5_path}"
+rm -rf "${{local_work_dir}}" """
+
+            sections = [setup, execute, move]
+
+    elif fast_tmp_root is None:
         # ------------------------------------------------------------------
         # Single-tier: Fortran writes directly to the shared staging dir.
         # The executable is pre-staged by submit_slurm_job() before any
         # array tasks start, so no cp is needed here.
         # ------------------------------------------------------------------
         init = _runner_init_line(
-            spec, hdf5_path, f"{staging_dir}/{binary_name}",
+            spec, str(hdf5_path), f"{staging_dir}/{binary_name}",
             skip_binary_verification=skip_binary_verification,
         )
         execute = f"""\
@@ -775,7 +904,7 @@ cp "${{staging_datadir}}/"* "${{local_datadir}}/"
 cp "{staging_dir}/{binary_name}" "${{local_work_dir}}/" """
 
         init = _runner_init_line(
-            spec, hdf5_path, f"${{local_work_dir}}/{binary_name}",
+            spec, str(hdf5_path), f"${{local_work_dir}}/{binary_name}",
             skip_binary_verification=skip_binary_verification,
         )
         execute = f"""\
@@ -802,7 +931,7 @@ rm -rf "${{local_work_dir}}" """
 def submit_slurm_job(
     spec: _SlurmJobSpec,
     hdf5_path: Path,
-    executable: Path,
+    executable: Optional[Path],
     staging_root_dir: Path,
     *,
     partition: Optional[str] = None,
@@ -814,16 +943,24 @@ def submit_slurm_job(
 ) -> int:
     """Stage scripts and submit a master Slurm job for an array-mode dispatch.
 
-    Pre-stages setup files (and optionally the executable, per ``spec``),
-    writes the array bash script and master Python+bash scripts into a
-    unique staging directory, and ``sbatch``-submits the master.
+    For ``spec.backend == "fortran"`` pre-stages setup files (and
+    optionally the executable, per ``spec``), then writes the array bash
+    script and master Python+bash scripts into a unique staging directory
+    and ``sbatch``-submits the master.
+
+    For ``spec.backend == "python"`` skips the setup-file and executable
+    pre-staging — the Python runner writes directly to the HDF5 file and
+    has no per-task input files — and otherwise follows the same flow:
+    snapshot ``src/lysis/`` for PYTHONPATH pinning, write the array bash
+    script and master Python+bash scripts, ``sbatch``-submit the master.
 
     :param spec: Scale-specific dispatch description.
     :type spec: _SlurmJobSpec
     :param hdf5_path: Resolved absolute path to the ``.h5`` file.
     :type hdf5_path: Path
     :param executable: Resolved absolute path to the Fortran binary.
-    :type executable: Path
+        May be ``None`` when ``spec.backend == "python"``.
+    :type executable: Path or None
     :param staging_root_dir: Root directory under which the staging temp
         dir is created (must already exist; the temp dir itself is
         created here).
@@ -871,23 +1008,26 @@ def submit_slurm_job(
     slurm_log_dir.mkdir(parents=True, exist_ok=True)
 
     # ------------------------------------------------------------------
-    # Pre-stage setup files (params.json, plus macroscale_in for macro)
+    # Pre-stage setup files (Fortran only — params.json, plus
+    # macroscale_in for macro).  Python runners write directly to HDF5
+    # and have no per-task setup files.
     # ------------------------------------------------------------------
-    staging_data_dir = staging_dir / "data" / run_code
-    staging_data_dir.mkdir(parents=True, exist_ok=True)
+    if spec.backend != "python":
+        staging_data_dir = staging_dir / "data" / run_code
+        staging_data_dir.mkdir(parents=True, exist_ok=True)
 
-    # Build a setup runner via from_hdf5 to call _write_setup_files.
-    # We import lazily to avoid pulling in numpy etc. at module load.
-    import importlib
-    runner_module = importlib.import_module(spec.runner_module)
-    runner_class = getattr(runner_module, spec.runner_class)
-    setup_kwargs = {"out_file_code": spec.out_file_code}
-    if spec.in_file_code is not None:
-        setup_kwargs["in_file_code"] = spec.in_file_code
-    fm_setup = runner_class.from_hdf5(
-        hdf5_path, str(executable), **setup_kwargs,
-    )
-    fm_setup._write_setup_files(staging_data_dir)
+        # Build a setup runner via from_hdf5 to call _write_setup_files.
+        # We import lazily to avoid pulling in numpy etc. at module load.
+        import importlib
+        runner_module = importlib.import_module(spec.runner_module)
+        runner_class = getattr(runner_module, spec.runner_class)
+        setup_kwargs = {"out_file_code": spec.out_file_code}
+        if spec.in_file_code is not None:
+            setup_kwargs["in_file_code"] = spec.in_file_code
+        fm_setup = runner_class.from_hdf5(
+            hdf5_path, str(executable), **setup_kwargs,
+        )
+        fm_setup._write_setup_files(staging_data_dir)
 
     # Pre-stage the executable so no array task needs to cp it — avoids a
     # race where multiple tasks simultaneously try to create the same file.
@@ -918,8 +1058,9 @@ def submit_slurm_job(
     # ------------------------------------------------------------------
     # Write master.py
     # ------------------------------------------------------------------
+    binary_name = executable.name if executable is not None else None
     master_py_content = _generate_array_master_py(
-        spec, staging_dir, hdf5_path, run_code, executable.name, keep_tmpdir,
+        spec, staging_dir, hdf5_path, run_code, binary_name, keep_tmpdir,
         historical_binary_attrs=historical_binary_attrs,
     )
     master_py_path = staging_dir / f"lysis-{spec.scale}-master__{run_code}.py"
@@ -1630,4 +1771,117 @@ def submit_macro_slurm_job(
         compiler_module=compiler_module,
         sbatch_overrides=sbatch_overrides,
         historical_binary_attrs=historical_binary_attrs,
+    )
+
+
+def _python_macro_spec() -> _SlurmJobSpec:
+    """Build the macroscale Python-backend dispatch spec.
+
+    Single-task array (``num_array_tasks=1``) — HDF5's single-writer
+    constraint forces every simulation in one Run to run in series within
+    one job.  Each Run is a separate ``.h5`` file, so the CLI batch loop
+    will fan out one independent master job per Run when invoked against
+    a directory.
+
+    No executable to pre-stage, no per-task setup files, no per-task
+    output to concatenate, no NFS flush wait — the task writes directly
+    to HDF5 via :class:`~lysis.execution.python_macro.PythonMacro` and
+    the master has nothing left to do once the task completes.
+    """
+    return _SlurmJobSpec(
+        scale="macro",
+        runner_module="lysis.execution.python_macro",
+        runner_class="PythonMacro",
+        num_array_tasks=1,
+        needs_concat_step=False,
+        nfs_wait_seconds=0,
+        prestage_executable=False,
+        out_file_code="",
+        in_file_code=None,
+        num_children=None,
+        backend="python",
+    )
+
+
+def submit_python_macro_slurm_job(
+    hdf5_path: "Path | str",
+    *,
+    staging_root: Optional["Path | str"] = None,
+    partition: Optional[str] = None,
+    fast_tmp_root: Optional[str] = None,
+    keep_tmpdir: bool = False,
+    compiler_module: str = DEFAULT_COMPILER_MODULE,
+    sbatch_overrides: Optional[Mapping[str, Optional[str]]] = None,
+) -> int:
+    """Submit the Python-backend macroscale workflow as a Slurm master job.
+
+    The master job submits a single array task (``--array=0-0``) that
+    runs :meth:`~lysis.execution.python_macro.PythonRunner.execute` —
+    every simulation for this Run, in series, writing straight into the
+    HDF5 file's open DataStore.  The master then exits without touching
+    the file.  ``src/lysis/`` is snapshotted into the staging directory
+    and bound to ``PYTHONPATH`` so the job imports the frozen package
+    (immune to source edits while queued).
+
+    Directory naming
+    ~~~~~~~~~~~~~~~~
+    Same as :func:`submit_macro_slurm_job` — staging dir is::
+
+        tempfile.mkdtemp(
+            prefix=f"lysis-macro-{run_code}-",
+            dir=staging_root or hdf5_path.parent,
+        )
+
+    HDF5 staging
+    ~~~~~~~~~~~~
+    * **Without** ``fast_tmp_root``: the array task writes directly to
+      ``hdf5_path`` (typically a shared filesystem).
+    * **With** ``fast_tmp_root``: the array task ``cp``\\ s ``hdf5_path``
+      into ``mktemp -d -p {fast_tmp_root}`` on the compute node, runs
+      against that copy, then ``cp``\\ s the populated file back over
+      ``hdf5_path`` on success.  A mid-job crash leaves the original
+      ``.h5`` in its ``MACRO_EMPTY`` state for clean resubmission.
+
+    :param hdf5_path: Full path to the run's ``.h5`` file.  Must contain
+        both ``micro_params`` and ``macro_params``.
+    :type hdf5_path: Path or str
+    :param staging_root: Root directory under which the staging temp dir
+        is created.  Defaults to ``hdf5_path.parent``.
+    :type staging_root: Path or str, optional
+    :param partition: Slurm partition for both master and array jobs.
+    :type partition: str, optional
+    :param fast_tmp_root: Root directory for node-local fast scratch
+        (opt-in two-tier HDF5 staging).  When ``None`` (default) the
+        array task writes directly to ``hdf5_path``.
+    :type fast_tmp_root: str, optional
+    :param keep_tmpdir: If ``True``, preserve the staging directory
+        after the master job completes (useful for debugging).
+    :type keep_tmpdir: bool, optional
+    :param compiler_module: LMod module spec for the Fortran compiler
+        runtime, baked into the generated master and array task scripts
+        — also exported by the Python-only path so the preamble matches
+        the Fortran path verbatim and node module state remains
+        predictable.  Defaults to :data:`DEFAULT_COMPILER_MODULE`.
+    :type compiler_module: str, optional
+    :param sbatch_overrides: User overrides for the ``#SBATCH`` header,
+        applied to BOTH the master and array task scripts (shape returned
+        by :func:`parse_sbatch_tokens`).  Defaults to ``None``.
+    :type sbatch_overrides: Mapping[str, str or None], optional
+    :return: Master Slurm job ID.
+    :rtype: int
+    :raises subprocess.CalledProcessError: If ``sbatch`` fails.
+    """
+    hdf5_path = Path(hdf5_path).resolve()
+
+    staging_root_dir = (
+        Path(staging_root) if staging_root is not None else hdf5_path.parent
+    )
+
+    spec = _python_macro_spec()
+    return submit_slurm_job(
+        spec, hdf5_path, None, staging_root_dir,
+        partition=partition, fast_tmp_root=fast_tmp_root,
+        keep_tmpdir=keep_tmpdir,
+        compiler_module=compiler_module,
+        sbatch_overrides=sbatch_overrides,
     )

--- a/tests/cli/test_run_macro.py
+++ b/tests/cli/test_run_macro.py
@@ -739,14 +739,6 @@ class TestRunMacroPythonValidation:
         assert "--executable" in result.output
         assert "python" in result.output.lower()
 
-    def test_python_with_slurm_errors(self, runner, macro_hdf5):
-        result = runner.invoke(
-            cli,
-            ["run-macro", str(macro_hdf5), "--backend", "python", "--slurm"],
-        )
-        assert result.exit_code != 0
-        assert "--slurm" in result.output
-
     def test_python_with_fortran_commit_errors(self, runner, macro_hdf5):
         result = runner.invoke(
             cli,
@@ -875,3 +867,99 @@ class TestRunMacroPythonBatch:
         assert result.exit_code == 0, result.output
         for rc in run_codes:
             assert _state(exp_dir / f"{rc}.h5") == HDF5State.MACRO_FILLED
+
+
+class TestRunMacroPythonSlurmDispatch:
+    """``--backend python --slurm`` reaches ``submit_python_macro_slurm_job``.
+
+    The Python+Slurm CLI path skips the in-process executor and instead
+    calls :func:`lysis.tools.slurm.submit_python_macro_slurm_job` once
+    per HDF5 file.  These tests monkeypatch the submit function (so no
+    real Slurm or staging is touched) and assert on what the CLI passes
+    through.
+    """
+
+    def test_single_file_calls_submit_python(self, runner, macro_ready_hdf5):
+        with patch(
+            "lysis.tools.slurm.submit_python_macro_slurm_job",
+            return_value=4242,
+        ) as mock_submit:
+            result = runner.invoke(
+                cli,
+                ["run-macro", str(macro_ready_hdf5), "--backend", "python",
+                 "--slurm",
+                 "--allow-dirty", "--allow-commit-mismatch"],
+            )
+        assert result.exit_code == 0, result.output
+        assert mock_submit.call_count == 1
+        (called_path,), kwargs = mock_submit.call_args
+        assert Path(called_path) == macro_ready_hdf5
+        assert kwargs["staging_root"] is None
+        assert kwargs["fast_tmp_root"] is None
+        assert kwargs["keep_tmpdir"] is False
+        assert "4242" in result.output
+
+    def test_threads_storage_and_partition_options(
+        self, runner, macro_ready_hdf5, tmp_path
+    ):
+        staging = tmp_path / "stg"
+        fast = tmp_path / "fast"
+        with patch(
+            "lysis.tools.slurm.submit_python_macro_slurm_job",
+            return_value=1,
+        ) as mock_submit:
+            result = runner.invoke(
+                cli,
+                ["run-macro", str(macro_ready_hdf5), "--backend", "python",
+                 "--slurm",
+                 "--partition", "normal",
+                 "--staging-root", str(staging),
+                 "--fast-tmp-root", str(fast),
+                 "--keep-tmpdir",
+                 "--compiler", "intel-compilers/2024",
+                 "--sbatch", "mem=8GB",
+                 "--allow-dirty", "--allow-commit-mismatch"],
+            )
+        assert result.exit_code == 0, result.output
+        kwargs = mock_submit.call_args.kwargs
+        assert kwargs["partition"] == "normal"
+        assert kwargs["staging_root"] == str(staging)
+        assert kwargs["fast_tmp_root"] == str(fast)
+        assert kwargs["keep_tmpdir"] is True
+        assert kwargs["compiler_module"] == "intel-compilers/2024"
+        assert kwargs["sbatch_overrides"] == {"mem": "8GB"}
+
+    def test_batch_dispatches_one_submit_per_file(
+        self, runner, tmp_path
+    ):
+        exp_dir = tmp_path / "py-slurm-experiment"
+        exp_dir.mkdir()
+        run_codes = ["py-run-01", "py-run-02", "py-run-03"]
+        for rc in run_codes:
+            _make_macro_empty_hdf5(exp_dir, rc)
+        experiment_json = {
+            "name": "py-slurm-experiment",
+            "description": "",
+            "created": "2026-01-01T00:00:00",
+            "lysis_version": "test",
+            "runs": [
+                {"run_code": rc, "row_index": i, "description": "",
+                 "macro_params": None}
+                for i, rc in enumerate(run_codes)
+            ],
+        }
+        (exp_dir / "experiment.json").write_text(json.dumps(experiment_json))
+
+        with patch(
+            "lysis.tools.slurm.submit_python_macro_slurm_job",
+            side_effect=[101, 102, 103],
+        ) as mock_submit:
+            result = runner.invoke(
+                cli,
+                ["run-macro", str(exp_dir), "--backend", "python", "--slurm",
+                 "--allow-dirty", "--allow-commit-mismatch"],
+            )
+        assert result.exit_code == 0, result.output
+        assert mock_submit.call_count == 3
+        for jid in (101, 102, 103):
+            assert str(jid) in result.output

--- a/tests/tools/test_slurm.py
+++ b/tests/tools/test_slurm.py
@@ -18,6 +18,7 @@ import pytest
 from lysis.config.constants import CONST
 from lysis.config.parameters import MacroParameters, MicroParameters
 from lysis.tools.slurm import (
+    _python_macro_spec,
     _snapshot_lysis_src,
     apply_sbatch_overrides,
     generate_macro_array_script,
@@ -27,6 +28,7 @@ from lysis.tools.slurm import (
     submit_macro_slurm_job,
     submit_micro_child_job,
     submit_micro_slurm_job,
+    submit_python_macro_slurm_job,
     wait_for_jobs,
 )
 
@@ -1891,3 +1893,269 @@ class TestSourcePinningInGeneratedScripts:
             pythonpath="/snap/python_src",
         )
         assert 'export PYTHONPATH="/snap/python_src"' in script
+
+
+# ---------------------------------------------------------------------------
+# Python backend (--backend python --slurm)
+# ---------------------------------------------------------------------------
+
+
+class TestPythonMacroSpec:
+    """:func:`_python_macro_spec` is the contract between Python CLI dispatch
+    and the shared array-mode internals."""
+
+    def test_backend_is_python(self):
+        assert _python_macro_spec().backend == "python"
+
+    def test_single_task_array(self):
+        """HDF5 single-writer constraint forces all sims in series → 1 task."""
+        assert _python_macro_spec().num_array_tasks == 1
+
+    def test_runner_class_is_python_macro(self):
+        spec = _python_macro_spec()
+        assert spec.runner_module == "lysis.execution.python_macro"
+        assert spec.runner_class == "PythonMacro"
+
+    def test_no_binary_or_codes(self):
+        """No Fortran executable to pre-stage, no in/out file codes."""
+        spec = _python_macro_spec()
+        assert spec.prestage_executable is False
+        assert spec.in_file_code is None
+        assert spec.out_file_code == ""
+        assert spec.num_children is None
+
+    def test_no_concat_no_nfs_wait(self):
+        """Task writes directly to HDF5 — nothing to concat, nothing to flush."""
+        spec = _python_macro_spec()
+        assert spec.needs_concat_step is False
+        assert spec.nfs_wait_seconds == 0
+
+
+class TestSubmitPythonMacroSlurmJob:
+    """End-to-end script generation for the Python --slurm path.
+
+    All tests monkeypatch ``gs.sbatch`` and the venv-sync side effect so
+    nothing leaves the test tmpdir.  We then inspect the generated array
+    and master scripts to assert the contract.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _patch_env_sync(self):
+        """The venv sync is expensive and irrelevant here."""
+        with patch("lysis.tools.slurm._ensure_env_synced"):
+            yield
+
+    def _staging_dir(self, staging_root):
+        return list(staging_root.iterdir())[0]
+
+    @patch("lysis.tools.slurm.gs.sbatch", return_value=8765)
+    def test_returns_master_job_id(self, mock_sbatch, tmp_path):
+        staging_root = tmp_path / "staging_root"
+        staging_root.mkdir()
+        h5 = tmp_path / "py-run.h5"
+        h5.write_text("")  # placeholder; PythonMacro is never instantiated here
+        job_id = submit_python_macro_slurm_job(
+            h5, staging_root=staging_root,
+        )
+        assert job_id == 8765
+
+    @patch("lysis.tools.slurm.gs.sbatch", return_value=1)
+    def test_no_setup_data_dir_pre_staged(self, mock_sbatch, tmp_path):
+        """Python backend has no setup files — staging dir must not contain
+        a data/{run_code}/ skeleton that the Fortran path pre-stages."""
+        staging_root = tmp_path / "staging_root"
+        staging_root.mkdir()
+        h5 = tmp_path / "py-run.h5"
+        h5.write_text("")
+        submit_python_macro_slurm_job(h5, staging_root=staging_root)
+        staging_dir = self._staging_dir(staging_root)
+        assert not (staging_dir / "data").exists()
+
+    @patch("lysis.tools.slurm.gs.sbatch", return_value=1)
+    def test_array_script_calls_python_macro_execute(
+        self, mock_sbatch, tmp_path,
+    ):
+        staging_root = tmp_path / "staging_root"
+        staging_root.mkdir()
+        h5 = tmp_path / "py-run.h5"
+        h5.write_text("")
+        submit_python_macro_slurm_job(h5, staging_root=staging_root)
+        staging_dir = self._staging_dir(staging_root)
+        array = (staging_dir / "lysis-macro-array__py-run.sh").read_text()
+        assert "from lysis.execution.python_macro import PythonMacro" in array
+        assert f"PythonMacro.from_hdf5('{h5.resolve()}').execute()" in array
+
+    @patch("lysis.tools.slurm.gs.sbatch", return_value=1)
+    def test_array_script_has_array_zero_zero_directive(
+        self, mock_sbatch, tmp_path,
+    ):
+        staging_root = tmp_path / "staging_root"
+        staging_root.mkdir()
+        h5 = tmp_path / "py-run.h5"
+        h5.write_text("")
+        submit_python_macro_slurm_job(h5, staging_root=staging_root)
+        staging_dir = self._staging_dir(staging_root)
+        array = (staging_dir / "lysis-macro-array__py-run.sh").read_text()
+        assert "0-0" in array
+
+    @patch("lysis.tools.slurm.gs.sbatch", return_value=1)
+    def test_array_script_does_not_reference_binary_or_index(
+        self, mock_sbatch, tmp_path,
+    ):
+        """PythonMacro.from_hdf5 takes no binary, no index, no file codes."""
+        staging_root = tmp_path / "staging_root"
+        staging_root.mkdir()
+        h5 = tmp_path / "py-run.h5"
+        h5.write_text("")
+        submit_python_macro_slurm_job(h5, staging_root=staging_root)
+        staging_dir = self._staging_dir(staging_root)
+        array = (staging_dir / "lysis-macro-array__py-run.sh").read_text()
+        assert "SLURM_ARRAY_TASK_ID" not in array
+        assert "exec_in_workdir" not in array
+        assert "out_file_code" not in array
+
+    @patch("lysis.tools.slurm.gs.sbatch", return_value=1)
+    def test_single_tier_no_local_workdir_or_h5_copy(
+        self, mock_sbatch, tmp_path,
+    ):
+        """Without --fast-tmp-root the task writes straight to the original h5."""
+        staging_root = tmp_path / "staging_root"
+        staging_root.mkdir()
+        h5 = tmp_path / "py-run.h5"
+        h5.write_text("")
+        submit_python_macro_slurm_job(h5, staging_root=staging_root)
+        staging_dir = self._staging_dir(staging_root)
+        array = (staging_dir / "lysis-macro-array__py-run.sh").read_text()
+        assert "local_work_dir" not in array
+        assert "local_h5_path" not in array
+        assert "mktemp" not in array
+
+    @patch("lysis.tools.slurm.gs.sbatch", return_value=1)
+    def test_two_tier_copies_h5_to_fast_tmp_and_back(
+        self, mock_sbatch, tmp_path,
+    ):
+        """--fast-tmp-root must cp the .h5 in before running and back after."""
+        staging_root = tmp_path / "staging_root"
+        staging_root.mkdir()
+        h5 = tmp_path / "py-run.h5"
+        h5.write_text("")
+        submit_python_macro_slurm_job(
+            h5, staging_root=staging_root, fast_tmp_root="/nvme/scratch",
+        )
+        staging_dir = self._staging_dir(staging_root)
+        array = (staging_dir / "lysis-macro-array__py-run.sh").read_text()
+        h5_resolved = str(h5.resolve())
+        assert 'mktemp -d -p "/nvme/scratch"' in array
+        assert 'local_h5_path="${local_work_dir}/py-run.h5"' in array
+        # cp out (h5 → fast tmp)
+        assert f'cp "{h5_resolved}" "${{local_h5_path}}"' in array
+        # cp back (fast tmp → h5)
+        assert f'cp "${{local_h5_path}}" "{h5_resolved}"' in array
+        # final cleanup of the local work dir
+        assert 'rm -rf "${local_work_dir}"' in array
+
+    @patch("lysis.tools.slurm.gs.sbatch", return_value=1)
+    def test_two_tier_array_script_uses_local_h5_in_python_call(
+        self, mock_sbatch, tmp_path,
+    ):
+        """The python -c must run PythonMacro against the local h5 copy."""
+        staging_root = tmp_path / "staging_root"
+        staging_root.mkdir()
+        h5 = tmp_path / "py-run.h5"
+        h5.write_text("")
+        submit_python_macro_slurm_job(
+            h5, staging_root=staging_root, fast_tmp_root="/nvme/scratch",
+        )
+        staging_dir = self._staging_dir(staging_root)
+        array = (staging_dir / "lysis-macro-array__py-run.sh").read_text()
+        assert "PythonMacro.from_hdf5('${local_h5_path}').execute()" in array
+
+    @patch("lysis.tools.slurm.gs.sbatch", return_value=1)
+    def test_master_script_does_not_import_results(
+        self, mock_sbatch, tmp_path,
+    ):
+        """Task wrote to HDF5 itself — master must not try to import per-sim
+        outputs (no Fortran-style data_dir / runner construction)."""
+        staging_root = tmp_path / "staging_root"
+        staging_root.mkdir()
+        h5 = tmp_path / "py-run.h5"
+        h5.write_text("")
+        submit_python_macro_slurm_job(h5, staging_root=staging_root)
+        staging_dir = self._staging_dir(staging_root)
+        master = (staging_dir / "lysis-macro-master__py-run.py").read_text()
+        assert "import_results" not in master
+        assert "concatenate_child_outputs" not in master
+        assert "BINARY_NAME" not in master
+        assert "Python task wrote results directly into HDF5" in master
+
+    @patch("lysis.tools.slurm.gs.sbatch", return_value=1)
+    def test_master_script_still_polls_squeue(
+        self, mock_sbatch, tmp_path,
+    ):
+        """Single-task array still needs the squeue poll — the master is
+        the only handle on task completion before staging cleanup."""
+        staging_root = tmp_path / "staging_root"
+        staging_root.mkdir()
+        h5 = tmp_path / "py-run.h5"
+        h5.write_text("")
+        submit_python_macro_slurm_job(h5, staging_root=staging_root)
+        staging_dir = self._staging_dir(staging_root)
+        master = (staging_dir / "lysis-macro-master__py-run.py").read_text()
+        assert "gs.squeue.read()" in master
+        assert "ARRAY_JOB_ID" in master
+
+    @patch("lysis.tools.slurm.gs.sbatch", return_value=1)
+    def test_python_backend_exports_pythonpath_to_snapshot(
+        self, mock_sbatch, tmp_path,
+    ):
+        """Source pinning applies to the Python backend too — same snapshot
+        directory, same PYTHONPATH export, immune to source edits while queued."""
+        staging_root = tmp_path / "staging_root"
+        staging_root.mkdir()
+        h5 = tmp_path / "py-run.h5"
+        h5.write_text("")
+        submit_python_macro_slurm_job(h5, staging_root=staging_root)
+        staging_dir = self._staging_dir(staging_root)
+        array = (staging_dir / "lysis-macro-array__py-run.sh").read_text()
+        master = (staging_dir / "lysis-macro-master__py-run.sh").read_text()
+        expected = f'export PYTHONPATH="{staging_dir}/python_src"'
+        assert expected in array
+        assert expected in master
+        assert (staging_dir / "python_src" / "lysis" / "__init__.py").exists()
+
+    @patch("lysis.tools.slurm.gs.sbatch", return_value=1)
+    def test_partition_and_sbatch_overrides_apply(
+        self, mock_sbatch, tmp_path,
+    ):
+        """--partition and --sbatch must reach both array and master headers."""
+        staging_root = tmp_path / "staging_root"
+        staging_root.mkdir()
+        h5 = tmp_path / "py-run.h5"
+        h5.write_text("")
+        submit_python_macro_slurm_job(
+            h5,
+            staging_root=staging_root,
+            partition="long",
+            sbatch_overrides={"hold": "", "exclusive=user": None},
+        )
+        staging_dir = self._staging_dir(staging_root)
+        array = (staging_dir / "lysis-macro-array__py-run.sh").read_text()
+        master = (staging_dir / "lysis-macro-master__py-run.sh").read_text()
+        for content in (array, master):
+            assert "long" in content
+            assert "#SBATCH --hold" in content
+            assert "--exclusive=user" not in content
+
+    @patch("lysis.tools.slurm.gs.sbatch", return_value=1)
+    def test_python_uses_uv_run_prefix(self, mock_sbatch, tmp_path):
+        """Generated python invocations must go through ``uv run --frozen
+        python`` so the project's .venv is on sys.path."""
+        staging_root = tmp_path / "staging_root"
+        staging_root.mkdir()
+        h5 = tmp_path / "py-run.h5"
+        h5.write_text("")
+        submit_python_macro_slurm_job(h5, staging_root=staging_root)
+        staging_dir = self._staging_dir(staging_root)
+        array = (staging_dir / "lysis-macro-array__py-run.sh").read_text()
+        assert "uv run" in array
+        assert "--frozen" in array


### PR DESCRIPTION
## Summary

- Extend `_SlurmJobSpec` with a `backend` discriminator and branch
  `submit_slurm_job`, `generate_array_script`, `_runner_init_line`, and
  the master-script template on it — the Python backend reuses the
  shared array-mode internals rather than forking them.
- Add `_python_macro_spec()` and `submit_python_macro_slurm_job()`
  wrappers mirroring the Fortran public surface (minus `--executable`,
  `--in-file-code`, `--out-file-code`, `--fortran-commit`,
  `--allow-stale-binary`).
- Wire `lysis run-macro --backend python --slurm` in the CLI: relax the
  python-backend rejection list to accept `--slurm`, `--partition`,
  `--compiler`, `--sbatch`, `--staging-root`, `--fast-tmp-root`, and
  dispatch to the new submit function (one master Slurm job per Run, the
  existing batch loop fans out one job per `.h5` file).
- `--fast-tmp-root` for the Python backend cp's the `.h5` to node-local
  scratch, runs there, cp's it back over the original on success. A
  mid-job crash leaves the original in `MACRO_EMPTY` state for clean
  resubmission. Without `--fast-tmp-root` the job writes directly to the
  original `.h5`.
- HDF5's single-writer constraint forces every simulation for a Run to
  run in series within one job, so the Python path is a single-task
  array (`--array=0-0`) rather than `n_sims` tasks. Source pinning via
  PYTHONPATH snapshot still applies.

Closes #65.

## Test plan

- [x] Added `TestPythonMacroSpec` (5 tests) — `_python_macro_spec()`
      field contract.
- [x] Added `TestSubmitPythonMacroSlurmJob` (13 tests) — generated
      array-script body (single-tier + two-tier `--fast-tmp-root`),
      master-script body (no `import_results`), PYTHONPATH source
      pinning, partition / `--sbatch` propagation, uv-run prefix.
- [x] Added `TestRunMacroPythonSlurmDispatch` to `tests/cli/test_run_macro.py`
      (3 tests) — CLI single-file, option-threading, and batch dispatch.
- [x] Removed obsolete `test_python_with_slurm_errors` (now valid combo).
- [x] Full non-Fortran-binary suite green:
      `uv run --extra test pytest tests/ --ignore=tests/execution/test_fortran_micro.py --ignore=tests/execution/test_fortran_macro.py`
      → 1836 passed, 1 skipped.
- [x] Smoke-printed actual generated bash + master.py for single-tier
      and `--fast-tmp-root` modes; output matches the spec.
- [x] End-to-end on the cluster (deferred to verification on `dev-1.1.0`):
      `lysis run-macro <h5> --backend python --slurm` → master job ID
      prints, HDF5 transitions out of `MACRO_EMPTY`, `macroscale_out`
      populated in series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)