### PR TITLE
Let Slurm masters pass src/fortran stamp to children (#67)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -46,6 +46,17 @@ Changed
   setup. The compiled ``lib/kiss.so`` is no longer tracked in git -- build it
   with ``make`` (or ``make shared``).
 
+Fixed
+-----
+
+- ``lysis run-micro`` / ``run-macro`` (especially under ``--slurm``) no longer
+  abort with a spurious ``StaleBinaryError`` when the staging directory lives
+  outside the source repository. The Slurm master now resolves the
+  ``src/fortran/`` git stamp once on the submit host and bakes it into the
+  generated child/array task scripts, so the compute-node preflight check
+  compares the binary against that stamp directly instead of trying to run
+  ``git`` from a directory that is no longer inside a checkout. (#67)
+
 Removed
 -------
 

--- a/src/lysis/execution/fortran.py
+++ b/src/lysis/execution/fortran.py
@@ -119,6 +119,18 @@ class FortranRunner(SimulationRunner):
     #: :func:`~lysis.tools.provenance.gather_binary_provenance` path is
     #: used (queries ``<binary> --version``).
     historical_binary_attrs: "dict | None" = None
+    #: Optional pre-computed ``(commit, dirty)`` tuple for the
+    #: ``src/fortran/`` source tree, forwarded to
+    #: :func:`~lysis.tools.provenance.verify_binary_matches_source`.
+    #: Used by Slurm masters that have copied ``src/`` out to a staging
+    #: directory: the master resolves the stamp once via
+    #: :func:`~lysis.tools.provenance.gather_fortran_source_provenance`
+    #: while still inside the repo, then hands it to each child runner so
+    #: the child does not need to invoke git from outside the checkout.
+    #: ``None`` (the default) preserves the in-process git lookup, which
+    #: is the right behaviour when the runner is constructed inside the
+    #: repository (e.g. the local non-slurm path).
+    source_stamp: "tuple[str, str] | None" = None
 
     # ------------------------------------------------------------------
     # Abstract hooks (implemented by subclasses)
@@ -288,6 +300,7 @@ class FortranRunner(SimulationRunner):
             self._binary_check_info = verify_binary_matches_source(
                 self.executable,
                 allow_stale=allow_stale,
+                source_stamp=self.source_stamp,
             )
         return self._binary_check_info
 

--- a/src/lysis/execution/fortran_macro.py
+++ b/src/lysis/execution/fortran_macro.py
@@ -137,6 +137,7 @@ class FortranMacro(FortranRunner):
         allow_stale_binary: bool = False,
         skip_binary_verification: bool = False,
         historical_binary_attrs: "dict | None" = None,
+        source_stamp: "tuple[str, str] | None" = None,
     ) -> "FortranMacro":
         """Construct a :class:`FortranMacro` from an existing HDF5 run file.
 
@@ -173,6 +174,14 @@ class FortranMacro(FortranRunner):
             stamped into the HDF5 file in place of the default
             ``<binary> --version`` query.  Defaults to ``None``.
         :type historical_binary_attrs: dict, optional
+        :param source_stamp: Optional pre-computed ``(commit, dirty)``
+            tuple for ``src/fortran/``, forwarded to
+            :func:`~lysis.tools.provenance.verify_binary_matches_source`.
+            Used by Slurm masters that resolve the stamp once before
+            copying ``src/`` out to a staging dir, so the child does not
+            need to invoke git from outside the checkout.  Defaults to
+            ``None`` (in-process git lookup).
+        :type source_stamp: tuple[str, str] or None
         :return: Fully configured :class:`FortranMacro` instance.
         :rtype: FortranMacro
         :raises ValueError: If microscale datasets are empty (microscale not yet
@@ -216,6 +225,7 @@ class FortranMacro(FortranRunner):
             allow_stale_binary=allow_stale_binary,
             skip_binary_verification=skip_binary_verification,
             historical_binary_attrs=historical_binary_attrs,
+            source_stamp=source_stamp,
         )
 
     # ------------------------------------------------------------------

--- a/src/lysis/execution/fortran_micro.py
+++ b/src/lysis/execution/fortran_micro.py
@@ -129,6 +129,7 @@ class FortranMicro(FortranRunner):
         allow_stale_binary: bool = False,
         skip_binary_verification: bool = False,
         historical_binary_attrs: "dict | None" = None,
+        source_stamp: "tuple[str, str] | None" = None,
     ) -> "FortranMicro":
         """Construct a :class:`FortranMicro` from an existing HDF5 run file.
 
@@ -169,6 +170,14 @@ class FortranMicro(FortranRunner):
             stamped into the HDF5 file in place of the default
             ``<binary> --version`` query.  Defaults to ``None``.
         :type historical_binary_attrs: dict, optional
+        :param source_stamp: Optional pre-computed ``(commit, dirty)``
+            tuple for ``src/fortran/``, forwarded to
+            :func:`~lysis.tools.provenance.verify_binary_matches_source`.
+            Used by Slurm masters that resolve the stamp once before
+            copying ``src/`` out to a staging dir, so the child does not
+            need to invoke git from outside the checkout.  Defaults to
+            ``None`` (in-process git lookup).
+        :type source_stamp: tuple[str, str] or None
         :return: Fully configured :class:`FortranMicro` instance.
         :rtype: FortranMicro
         :raises RuntimeError: If the HDF5 file's directory is not found.
@@ -205,6 +214,7 @@ class FortranMicro(FortranRunner):
             allow_stale_binary=allow_stale_binary,
             skip_binary_verification=skip_binary_verification,
             historical_binary_attrs=historical_binary_attrs,
+            source_stamp=source_stamp,
         )
 
     # ------------------------------------------------------------------

--- a/src/lysis/tools/provenance/binary.py
+++ b/src/lysis/tools/provenance/binary.py
@@ -201,6 +201,7 @@ def verify_binary_matches_source(
     executable: "Path | str",
     *,
     allow_stale: Optional[bool] = None,
+    source_stamp: "Optional[tuple[str, str]]" = None,
 ) -> dict:
     """Compare the binary's embedded stamp to the current source tree.
 
@@ -208,6 +209,16 @@ def verify_binary_matches_source(
     :param allow_stale: Explicit override.  ``None`` (the default) consults
         :func:`allow_stale_from_env`; ``True`` downgrades a mismatch to a
         warning; ``False`` always raises on mismatch.
+    :param source_stamp: Optional pre-computed ``(commit, dirty)`` tuple
+        to compare the binary against, in place of the default
+        :func:`gather_fortran_source_provenance` lookup.  Allows a caller
+        that has already resolved the source stamp (e.g. a Slurm master
+        that has copied ``src/`` out to a staging directory outside the
+        repository) to skip the in-process ``git`` query that would
+        otherwise fail because the binary's directory is no longer inside
+        a checkout.  ``None`` (the default) preserves the in-process git
+        lookup.
+    :type source_stamp: tuple[str, str] or None
     :return: Empty dict on match.  On overridden mismatch, a dict
         containing ``"banner"`` (text to prepend to the Fortran stdout
         log file) and :data:`CONST.STALE_BINARY_OVERRIDE_ATTR` for
@@ -226,7 +237,10 @@ def verify_binary_matches_source(
     binary_commit, binary_dirty, _binary_compiler = query_binary_version(
         executable
     )
-    source_commit, source_dirty = gather_fortran_source_provenance()
+    if source_stamp is not None:
+        source_commit, source_dirty = source_stamp
+    else:
+        source_commit, source_dirty = gather_fortran_source_provenance()
 
     matches = (
         binary_commit == source_commit

--- a/src/lysis/tools/slurm.py
+++ b/src/lysis/tools/slurm.py
@@ -598,6 +598,7 @@ def _runner_init_line(
     binary_path: str,
     *,
     skip_binary_verification: bool = False,
+    source_stamp: Optional[tuple] = None,
 ) -> str:
     """Build the ``from_hdf5(...)`` call used inside the array task ``python -c``.
 
@@ -605,7 +606,10 @@ def _runner_init_line(
     *skip_binary_verification* is True the call emits
     ``skip_binary_verification=True`` so the historical-build workflow's
     binary↔source mismatch does not crash ``_verify_binary_version`` at
-    task start.
+    task start.  When *source_stamp* is provided it is baked into the
+    call as ``source_stamp=(commit, dirty)`` so the array task does not
+    have to invoke git from the staging directory (which is outside the
+    source repository on most HPC layouts).
     """
     args = [f"'{hdf5_path}'", f"'{binary_path}'"]
     if spec.in_file_code is not None:
@@ -616,6 +620,9 @@ def _runner_init_line(
         args.append(f"num_children={spec.num_children}")
     if skip_binary_verification:
         args.append("skip_binary_verification=True")
+    if source_stamp is not None and not skip_binary_verification:
+        commit, dirty = source_stamp
+        args.append(f"source_stamp=('{commit}', '{dirty}')")
     return f"{spec.runner_class}.from_hdf5({', '.join(args)})"
 
 
@@ -633,6 +640,7 @@ def generate_array_script(
     sbatch_overrides: Optional[Mapping[str, Optional[str]]] = None,
     historical_binary_attrs: Optional[dict] = None,
     pythonpath: "Path | str | None" = None,
+    source_stamp: Optional[tuple] = None,
 ) -> str:
     """Generate a Slurm array job bash script for an array-mode dispatch.
 
@@ -695,6 +703,15 @@ def generate_array_script(
         that path rather than the live editable install.  ``None``
         (default) leaves ``PYTHONPATH`` untouched.
     :type pythonpath: Path or str, optional
+    :param source_stamp: Pre-resolved ``(commit, dirty)`` for
+        ``src/fortran/``.  Baked into the array task's ``from_hdf5``
+        call so the binary↔source check on the compute node compares
+        against the master's stamp instead of running ``git`` from the
+        staging dir (which is outside the repo and would fail).
+        Ignored when ``historical_binary_attrs`` is set (the staleness
+        check is bypassed in that workflow).  ``None`` (default)
+        preserves the in-process git lookup.
+    :type source_stamp: tuple[str, str] or None
     :return: Slurm array job bash script text.
     :rtype: str
     """
@@ -736,6 +753,7 @@ def generate_array_script(
         init = _runner_init_line(
             spec, hdf5_path, f"{staging_dir}/{binary_name}",
             skip_binary_verification=skip_binary_verification,
+            source_stamp=source_stamp,
         )
         execute = f"""\
 # Execute {spec.scale}scale Fortran binary via lysis
@@ -777,6 +795,7 @@ cp "{staging_dir}/{binary_name}" "${{local_work_dir}}/" """
         init = _runner_init_line(
             spec, hdf5_path, f"${{local_work_dir}}/{binary_name}",
             skip_binary_verification=skip_binary_verification,
+            source_stamp=source_stamp,
         )
         execute = f"""\
 # Execute {spec.scale}scale Fortran binary into local fast storage
@@ -899,6 +918,19 @@ def submit_slurm_job(
     # job is queued or running.
     pythonpath = _snapshot_lysis_src(repo_root, staging_dir)
 
+    # Resolve src/fortran/ stamp once on the submit host (still inside the
+    # repo) and bake it into the array script so compute-node tasks compare
+    # the binary against this stamp instead of running git in the staging
+    # dir (which is outside the checkout — the lookup would fail there and
+    # raise StaleBinaryError).  Skipped under --fortran-commit, where the
+    # binary↔source mismatch is intentional and the check is bypassed.
+    source_stamp: Optional[tuple] = None
+    if historical_binary_attrs is None:
+        from lysis.tools.provenance import (  # noqa: PLC0415
+            gather_fortran_source_provenance,
+        )
+        source_stamp = gather_fortran_source_provenance()
+
     # ------------------------------------------------------------------
     # Write array job script
     # ------------------------------------------------------------------
@@ -910,6 +942,7 @@ def submit_slurm_job(
         sbatch_overrides=sbatch_overrides,
         historical_binary_attrs=historical_binary_attrs,
         pythonpath=pythonpath,
+        source_stamp=source_stamp,
     )
     array_path = staging_dir / f"lysis-{spec.scale}-array__{run_code}.sh"
     array_path.write_text(array_script)
@@ -974,6 +1007,7 @@ def generate_micro_child_script(
     sbatch_overrides: Optional[Mapping[str, Optional[str]]] = None,
     historical_binary_attrs: Optional[dict] = None,
     pythonpath: "Path | str | None" = None,
+    source_stamp: Optional[tuple] = None,
 ) -> str:
     """Generate a Slurm bash script for a single child microscale Fortran job.
 
@@ -1032,6 +1066,14 @@ def generate_micro_child_script(
         that path rather than the live editable install.  ``None``
         (default) leaves ``PYTHONPATH`` untouched.
     :type pythonpath: Path or str, optional
+    :param source_stamp: Pre-resolved ``(commit, dirty)`` for
+        ``src/fortran/``.  Baked into the child's ``from_hdf5`` call so
+        the binary↔source check on the compute node compares against the
+        master's stamp instead of running ``git`` from the staging dir
+        (which is outside the repo and would fail).  Ignored when
+        ``historical_binary_attrs`` is set.  ``None`` (default)
+        preserves the in-process git lookup.
+    :type source_stamp: tuple[str, str] or None
     :return: Slurm bash script text.
     :rtype: str
     """
@@ -1067,6 +1109,11 @@ def generate_micro_child_script(
         if historical_binary_attrs is not None
         else ""
     )
+    if source_stamp is not None and historical_binary_attrs is None:
+        commit, dirty = source_stamp
+        source_stamp_kwarg = f", source_stamp=('{commit}', '{dirty}')"
+    else:
+        source_stamp_kwarg = ""
 
     if fast_tmp_root is None:
         # ------------------------------------------------------------------
@@ -1087,7 +1134,7 @@ mkdir -p "${{staging_datadir}}" """
 {py} -c "
 from pathlib import Path
 from lysis.execution.fortran_micro import FortranMicro
-fm = FortranMicro.from_hdf5('{hdf5_path}', '{staging_dir}/{binary_name}', out_file_code='{out_code}'{skip_verify_kwarg})
+fm = FortranMicro.from_hdf5('{hdf5_path}', '{staging_dir}/{binary_name}', out_file_code='{out_code}'{skip_verify_kwarg}{source_stamp_kwarg})
 fm.exec_in_workdir(Path('{staging_dir}'))
 " """
 
@@ -1115,7 +1162,7 @@ cp "{staging_dir}/{binary_name}" "${{local_work_dir}}/" """
 {py} -c "
 from pathlib import Path
 from lysis.execution.fortran_micro import FortranMicro
-fm = FortranMicro.from_hdf5('{hdf5_path}', '${{local_work_dir}}/{binary_name}', out_file_code='{out_code}'{skip_verify_kwarg})
+fm = FortranMicro.from_hdf5('{hdf5_path}', '${{local_work_dir}}/{binary_name}', out_file_code='{out_code}'{skip_verify_kwarg}{source_stamp_kwarg})
 fm.exec_in_workdir(Path('${{local_work_dir}}'))
 " """
 
@@ -1404,6 +1451,16 @@ def submit_micro_slurm_job(
     # via PYTHONPATH, immune to source edits made while the job runs.
     pythonpath = _snapshot_lysis_src(repo_root, staging_dir)
 
+    # Resolve the src/fortran/ stamp once before the child runs from
+    # outside the repo (see submit_slurm_job for the analogous comment in
+    # the array path).
+    source_stamp: Optional[tuple] = None
+    if historical_binary_attrs is None:
+        from lysis.tools.provenance import (  # noqa: PLC0415
+            gather_fortran_source_provenance,
+        )
+        source_stamp = gather_fortran_source_provenance()
+
     # ------------------------------------------------------------------
     # Write child script
     # ------------------------------------------------------------------
@@ -1415,6 +1472,7 @@ def submit_micro_slurm_job(
         sbatch_overrides=sbatch_overrides,
         historical_binary_attrs=historical_binary_attrs,
         pythonpath=pythonpath,
+        source_stamp=source_stamp,
     )
     child_path = staging_dir / f"lysis-micro-child__{run_code}.sh"
     child_path.write_text(child_script)

--- a/tests/execution/test_fortran.py
+++ b/tests/execution/test_fortran.py
@@ -362,3 +362,59 @@ class TestSkipBinaryVerification:
         assert called == []
         # No banner attrs either.
         assert runner._binary_hdf5_attrs == {}
+
+
+# ---------------------------------------------------------------------------
+# source_stamp (Slurm-master copy-out path)
+# ---------------------------------------------------------------------------
+
+
+class TestSourceStampPlumbing:
+    """A runner constructed with a ``source_stamp`` must hand it to
+    ``verify_binary_matches_source`` so the binary check on a compute
+    node does not need to invoke git from outside the source repo.
+    """
+
+    def test_runner_forwards_source_stamp(self, monkeypatch, tmp_path):
+        import lysis.tools.provenance as prov_pkg
+        captured = {}
+
+        def fake_verify(exe, **kw):
+            captured["exe"] = exe
+            captured["kw"] = kw
+            return {}
+
+        monkeypatch.setattr(
+            prov_pkg, "verify_binary_matches_source", fake_verify,
+        )
+        r = Run(str(tmp_path))
+        r.initialize_micro_param()
+        cls = _make_stub_class()
+        runner = cls(
+            run=r,
+            executable="/bin/stub.exe",
+            source_stamp=("abc123", "clean"),
+        )
+        runner._verify_binary_version()
+        assert captured["exe"] == "/bin/stub.exe"
+        assert captured["kw"]["source_stamp"] == ("abc123", "clean")
+
+    def test_runner_default_source_stamp_is_none(
+        self, monkeypatch, tmp_path,
+    ):
+        import lysis.tools.provenance as prov_pkg
+        captured = {}
+
+        def fake_verify(exe, **kw):
+            captured["kw"] = kw
+            return {}
+
+        monkeypatch.setattr(
+            prov_pkg, "verify_binary_matches_source", fake_verify,
+        )
+        r = Run(str(tmp_path))
+        r.initialize_micro_param()
+        cls = _make_stub_class()
+        runner = cls(run=r, executable="/bin/stub.exe")
+        runner._verify_binary_version()
+        assert captured["kw"]["source_stamp"] is None

--- a/tests/tools/test_provenance_binary.py
+++ b/tests/tools/test_provenance_binary.py
@@ -307,6 +307,92 @@ def test_verify_explicit_false_overrides_env(monkeypatch):
 
 
 # ----------------------------------------------------------------------
+# verify_binary_matches_source — source_stamp override
+# ----------------------------------------------------------------------
+
+def _sentinel_source_provenance():
+    raise AssertionError(
+        "gather_fortran_source_provenance must not be called when "
+        "source_stamp is provided"
+    )
+
+
+def test_verify_source_stamp_match_skips_git_lookup(monkeypatch):
+    # When source_stamp matches the binary, we accept without calling git.
+    monkeypatch.setattr(
+        binary_mod, "query_binary_version",
+        lambda exe, **kw: ("abc123", "clean", "Intel"),
+    )
+    monkeypatch.setattr(
+        binary_mod, "gather_fortran_source_provenance",
+        _sentinel_source_provenance,
+    )
+    result = verify_binary_matches_source(
+        "/fake/bin",
+        allow_stale=False,
+        source_stamp=("abc123", "clean"),
+    )
+    assert result == {}
+
+
+def test_verify_source_stamp_mismatch_raises(monkeypatch):
+    monkeypatch.setattr(
+        binary_mod, "query_binary_version",
+        lambda exe, **kw: ("abc123", "clean", "Intel"),
+    )
+    monkeypatch.setattr(
+        binary_mod, "gather_fortran_source_provenance",
+        _sentinel_source_provenance,
+    )
+    with pytest.raises(StaleBinaryError) as excinfo:
+        verify_binary_matches_source(
+            "/fake/bin",
+            allow_stale=False,
+            source_stamp=("def456", "clean"),
+        )
+    assert "abc123" in str(excinfo.value)
+    assert "def456" in str(excinfo.value)
+
+
+def test_verify_source_stamp_none_falls_back_to_git_lookup(monkeypatch):
+    # The fallback path (source_stamp=None) must still call
+    # gather_fortran_source_provenance.
+    calls = {"n": 0}
+
+    def fake_source():
+        calls["n"] += 1
+        return ("abc123", "clean")
+
+    monkeypatch.setattr(
+        binary_mod, "query_binary_version",
+        lambda exe, **kw: ("abc123", "clean", "Intel"),
+    )
+    monkeypatch.setattr(
+        binary_mod, "gather_fortran_source_provenance", fake_source,
+    )
+    assert verify_binary_matches_source(
+        "/fake/bin", allow_stale=False, source_stamp=None,
+    ) == {}
+    assert calls["n"] == 1
+
+
+def test_verify_source_stamp_dirty_match(monkeypatch):
+    monkeypatch.setattr(
+        binary_mod, "query_binary_version",
+        lambda exe, **kw: ("abc123", "dirty", "Intel"),
+    )
+    monkeypatch.setattr(
+        binary_mod, "gather_fortran_source_provenance",
+        _sentinel_source_provenance,
+    )
+    assert verify_binary_matches_source(
+        "/fake/bin",
+        allow_stale=False,
+        source_stamp=("abc123", "dirty"),
+    ) == {}
+
+
+# ----------------------------------------------------------------------
 # gather_historical_binary_provenance
 # ----------------------------------------------------------------------
 

--- a/tests/tools/test_slurm.py
+++ b/tests/tools/test_slurm.py
@@ -1663,6 +1663,98 @@ class TestHistoricalBinaryAttrsInChildAndArrayScripts:
 
 
 # ---------------------------------------------------------------------------
+# TestSourceStampInGeneratedScripts
+# ---------------------------------------------------------------------------
+
+
+class TestSourceStampInGeneratedScripts:
+    """The master Slurm job resolves the ``src/fortran/`` stamp on the
+    submit host (where the repo is) and bakes it into the generated child
+    and array task scripts as a ``source_stamp=(commit, dirty)`` kwarg to
+    ``FortranMicro.from_hdf5`` / ``FortranMacro.from_hdf5``.  The compute
+    node then compares the binary against that stamp directly instead of
+    running ``git`` from the staging directory (which is outside the
+    checkout and would fail).
+    """
+
+    _STAMP = ("abc123def456", "clean")
+
+    # -- generate_micro_child_script (legacy single-child path) ------------
+
+    def test_legacy_single_tier_bakes_source_stamp(self, tmp_path):
+        script = generate_micro_child_script(
+            tmp_path / "stage", "run-01", tmp_path / "run-01.h5",
+            "/bin/micro.exe", "",
+            source_stamp=self._STAMP,
+        )
+        assert "source_stamp=('abc123def456', 'clean')" in script
+
+    def test_legacy_two_tier_bakes_source_stamp(self, tmp_path):
+        script = generate_micro_child_script(
+            tmp_path / "stage", "run-01", tmp_path / "run-01.h5",
+            "/bin/micro.exe", "",
+            fast_tmp_root="/nvme/scratch",
+            source_stamp=self._STAMP,
+        )
+        assert "source_stamp=('abc123def456', 'clean')" in script
+
+    def test_legacy_no_source_stamp_when_unset(self, tmp_path):
+        script = generate_micro_child_script(
+            tmp_path / "stage", "run-01", tmp_path / "run-01.h5",
+            "/bin/micro.exe", "",
+        )
+        assert "source_stamp=" not in script
+
+    def test_legacy_source_stamp_suppressed_under_historical(self, tmp_path):
+        """Under --fortran-commit the staleness check is bypassed, so any
+        passed source_stamp must not be baked into the script (it would be
+        dead code at best, confusing at worst)."""
+        script = generate_micro_child_script(
+            tmp_path / "stage", "run-01", tmp_path / "run-01.h5",
+            "/bin/micro.exe", "",
+            historical_binary_attrs={"binary_commit": "h" * 40},
+            source_stamp=self._STAMP,
+        )
+        assert "source_stamp=" not in script
+        assert "skip_binary_verification=True" in script
+
+    # -- generate_micro_array_script (array micro path) --------------------
+
+    def test_micro_array_single_tier_bakes_source_stamp(self, tmp_path):
+        from lysis.tools.slurm import generate_array_script, _micro_spec
+        spec = _micro_spec(4, "")
+        script = generate_array_script(
+            spec, tmp_path / "stage", "run-01", tmp_path / "run-01.h5",
+            "/bin/micro.exe",
+            source_stamp=self._STAMP,
+        )
+        assert "source_stamp=('abc123def456', 'clean')" in script
+
+    def test_micro_array_two_tier_bakes_source_stamp(self, tmp_path):
+        from lysis.tools.slurm import generate_array_script, _micro_spec
+        spec = _micro_spec(4, "")
+        script = generate_array_script(
+            spec, tmp_path / "stage", "run-01", tmp_path / "run-01.h5",
+            "/bin/micro.exe",
+            fast_tmp_root="/nvme/scratch",
+            source_stamp=self._STAMP,
+        )
+        assert "source_stamp=('abc123def456', 'clean')" in script
+
+    def test_array_source_stamp_suppressed_under_historical(self, tmp_path):
+        from lysis.tools.slurm import generate_array_script, _micro_spec
+        spec = _micro_spec(4, "")
+        script = generate_array_script(
+            spec, tmp_path / "stage", "run-01", tmp_path / "run-01.h5",
+            "/bin/micro.exe",
+            historical_binary_attrs={"binary_commit": "h" * 40},
+            source_stamp=self._STAMP,
+        )
+        assert "source_stamp=" not in script
+        assert "skip_binary_verification=True" in script
+
+
+# ---------------------------------------------------------------------------
 # TestSubmitWithHistoricalBinaryAttrsEndToEnd
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Fixes #67: `lysis run-micro` / `run-macro` (under `--slurm`) aborted with a spurious `StaleBinaryError` when the staging directory lived outside the source repository, because the child task tried to run `git` from a copy of `src/lysis/` that had no `.git` parent.
- Adds an optional `source_stamp=(commit, dirty)` kwarg through `verify_binary_matches_source`, `FortranRunner`, `FortranMicro/Macro.from_hdf5`, and the Slurm script generators. The master resolves the stamp once on the submit host (still inside the repo) and bakes it into the generated child/array `from_hdf5(...)` call.
- Local non-slurm path is unchanged: `source_stamp=None` falls back to the existing in-process git lookup. Historical-build path (`--fortran-commit`) is also unchanged: it still emits `skip_binary_verification=True` and suppresses the new kwarg.

## Test plan
- [x] `uv run --extra test pytest tests/tools/test_provenance_binary.py tests/execution/test_fortran.py tests/tools/test_slurm.py` — 237 passed, 1 skipped
- [x] Full suite excluding Fortran-binary-execution tests — 1815 passed, 1 skipped
- [x] End-to-end sanity check on the cluster: `lysis run-micro --slurm --staging-root /scratch …` no longer errors with `StaleBinaryError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)