### PR TITLE
Fix broken Read the Docs build (#53)

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -24,7 +24,7 @@ build:
 # Build documentation in the "doc" directory with Sphinx
 sphinx:
   configuration: docs/source/conf.py
-  fail_on_warning: false
+  fail_on_warning: true
 
 # Optionally declare the Python requirements required to build your docs
 python:

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -16,6 +16,9 @@ pint>=0.20
 tqdm>=4.60
 matplotlib>=3.3
 
+# Data frames (used by lysis.tools.display and lysis.analysis)
+pandas>=1.3
+
 # CLI dependencies
 click>=8.0
 rich>=12.0

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -8,6 +8,7 @@ This documentation includes both usage guides and API reference.
    :maxdepth: 2
    :caption: Usage Guide
 
+   usage/system_onboarding
    usage/ontology
    usage/fiber_size_conventions
    usage/data_specification

--- a/docs/source/lysis.dataio.rst
+++ b/docs/source/lysis.dataio.rst
@@ -1,11 +1,11 @@
 lysis.dataio package
-==================
+====================
 
 Submodules
 ----------
 
 lysis.dataio.dataconvert module
------------------------------
+-------------------------------
 
 .. automodule:: lysis.dataio.dataconvert
    :members:
@@ -13,7 +13,7 @@ lysis.dataio.dataconvert module
    :undoc-members:
 
 lysis.dataio.dataspec module
---------------------------
+----------------------------
 
 .. automodule:: lysis.dataio.dataspec
    :members:
@@ -21,7 +21,7 @@ lysis.dataio.dataspec module
    :undoc-members:
 
 lysis.dataio.datastore module
----------------------------
+-----------------------------
 
 .. automodule:: lysis.dataio.datastore
    :members:
@@ -29,7 +29,7 @@ lysis.dataio.datastore module
    :undoc-members:
 
 lysis.dataio.fileops module
--------------------------
+---------------------------
 
 .. automodule:: lysis.dataio.fileops
    :members:

--- a/docs/source/lysis.execution.rst
+++ b/docs/source/lysis.execution.rst
@@ -1,13 +1,45 @@
 lysis.execution package
-=======================
+========================
 
 Submodules
 ----------
 
-lysis.execution.codeutil module
+lysis.execution.base module
+---------------------------
+
+.. automodule:: lysis.execution.base
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+lysis.execution.fortran module
 -------------------------------
 
-.. automodule:: lysis.execution.codeutil
+.. automodule:: lysis.execution.fortran
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+lysis.execution.fortran_macro module
+-------------------------------------
+
+.. automodule:: lysis.execution.fortran_macro
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+lysis.execution.fortran_micro module
+-------------------------------------
+
+.. automodule:: lysis.execution.fortran_micro
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+lysis.execution.historical_build module
+----------------------------------------
+
+.. automodule:: lysis.execution.historical_build
    :members:
    :show-inheritance:
    :undoc-members:

--- a/docs/source/usage/data_specification.rst
+++ b/docs/source/usage/data_specification.rst
@@ -738,6 +738,7 @@ Parameters
   (``micro{file_code}.txt``) instead of ``params.json``.
 - All parameters are stored as plain ``numpy.float64`` values
   instead of ``pint.Quantity`` objects with units.
+
 ``Nsave.dat``
   The number of snapshots recorded in the simulation.
 
@@ -759,7 +760,7 @@ v1.90.0
 Identical to v1.95.0 with the following exception in macroscale output:
 
 Macroscale Output
-++++++++++++++++
++++++++++++++++++
 
 - ``f_deg_list.dat`` **does not exist** in v1.90.0.
 - ``f_deg_time.dat`` replaces it with a binary snapshot array recording the

--- a/docs/source/usage/historical_fortran.rst
+++ b/docs/source/usage/historical_fortran.rst
@@ -1,6 +1,6 @@
-==========================================
+===========================================
 Running a Historical Fortran Implementation
-==========================================
+===========================================
 
 Both ``lysis run-micro`` and ``lysis run-macro`` accept a
 ``--fortran-commit <ref>`` flag that builds the Fortran binaries from an

--- a/docs/source/usage/ontology.rst
+++ b/docs/source/usage/ontology.rst
@@ -3,73 +3,75 @@ Ontology
 ========================
 
 *This document defines the terms used in this project (code, data, etc.).
-It is important because different words have different meanings to different people in different 
+It is important because different words have different meanings to different people in different
 situations. Here we try to use each word in only one place so that meanings are unambiguous.*
 
-Run
-    A collection of Simulations that share the same Scenario and Mechanism(s).
+.. glossary::
 
-    *Because of this definition, it is important to say that we 'execute code' or 'execute a 
-    program', not 'run code' or 'run a program'.*
+   Run
+       A collection of Simulations that share the same Scenario and Mechanism(s).
 
-Experiment
-    A collection of Runs with a range of Scenarios and/or Mechanisms
-    that are compared and contrasted to elucidate cause and effect relationships.
+       *Because of this definition, it is important to say that we 'execute code' or 'execute a
+       program', not 'run code' or 'run a program'.*
 
-Scenario
-    A set of numeric parameters, to be used in a run. These are usually derived from physical, 
-    measurable characteristics. 
-    
-    E.g., 
+   Experiment
+       A collection of Runs with a range of Scenarios and/or Mechanisms
+       that are compared and contrasted to elucidate cause and effect relationships.
 
-    * The number of tPA molecules in the container
-    * The number of rows in the fibrin grid
+   Scenario
+       A set of numeric parameters, to be used in a run. These are usually derived from physical,
+       measurable characteristics.
 
-Mechanism
-    A set of rules governing how the model will execute. These are usually represented by different 
-    code logic. 
-    
-    E.g.,
+       E.g.,
 
-    * The presence of red blood cells in the fibrin grid
-    * The 'into-and-along' unbinding hypothesis
+       * The number of tPA molecules in the container
+       * The number of rows in the fibrin grid
 
-Simulation
-    A single execution of the fibrinolysis model. 
-    This can either just be the microscale model, or it can be both,
-    but the macroscale model cannot be run without input from the microscale model first.
-    A simulation must have an associated Scenario, 
-    and an associated Mechanism for each model being executed.
+   Mechanism
+       A set of rules governing how the model will execute. These are usually represented by
+       different code logic.
 
-Edge grid
-    The rectilinear grid that dictates location in the Macroscale model. 
-    This grid is made up of nodes and edges between them.
-    Fibers may exist along edges in the grid.
-    Locations are based on the edges between adjacent nodes, however nodes and edges are numbered 
-    differently. There are different co-ordinate systems used for this grid in Fortran and Python.
-    See the documentation accompanying the Python EdgeGrid class for more information.
+       E.g.,
 
-Edge grid row
-    Nodes, edges, and locations in the edge grid are all arranged in rows, numbered from bottom to 
-    top.
+       * The presence of red blood cells in the fibrin grid
+       * The 'into-and-along' unbinding hypothesis
 
-Edge grid column
-    Nodes in the edge grid are arranged in columns, numbered from left to right.
+   Simulation
+       A single execution of the fibrinolysis model.
+       This can either just be the microscale model, or it can be both,
+       but the macroscale model cannot be run without input from the microscale model first.
+       A simulation must have an associated Scenario,
+       and an associated Mechanism for each model being executed.
 
-Edge grid rank
-    Fibers and edges in a given edge grid row are numbered by rank from left to right.
-    Note that a location's rank does NOT correspond with its adjoining node's column.
+   Edge grid
+       The rectilinear grid that dictates location in the Macroscale model.
+       This grid is made up of nodes and edges between them.
+       Fibers may exist along edges in the grid.
+       Locations are based on the edges between adjacent nodes, however nodes and edges are numbered
+       differently. There are different co-ordinate systems used for this grid in Fortran and Python.
+       See the documentation accompanying the Python EdgeGrid class for more information.
 
-Dataset
-    A single table of data. One Run will produce many different datasets.
-    (This usage of the term is for consistency with the H5Py library which being used to store data 
-    for this project.)
+   Edge grid row
+       Nodes, edges, and locations in the edge grid are all arranged in rows, numbered from bottom to
+       top.
 
-Data Collection
-    A group of datasets resulting from a single simulation. Currently, the three data collections 
-    are:
+   Edge grid column
+       Nodes in the edge grid are arranged in columns, numbered from left to right.
 
-    :Microscale Out: The datasets output by the microscale model
-    :Macroscale In: Those datasets, derived from the microscale output, that the macroscale model
-                    needs as input.
-    :Macroscale Out: The datasets output by the macroscale model.
+   Edge grid rank
+       Fibers and edges in a given edge grid row are numbered by rank from left to right.
+       Note that a location's rank does NOT correspond with its adjoining node's column.
+
+   Dataset
+       A single table of data. One Run will produce many different datasets.
+       (This usage of the term is for consistency with the H5Py library which being used to store data
+       for this project.)
+
+   Data Collection
+       A group of datasets resulting from a single simulation. Currently, the three data collections
+       are:
+
+       :Microscale Out: The datasets output by the microscale model
+       :Macroscale In: Those datasets, derived from the microscale output, that the macroscale model
+                       needs as input.
+       :Macroscale Out: The datasets output by the macroscale model.

--- a/src/lysis/config/parameters.py
+++ b/src/lysis/config/parameters.py
@@ -47,7 +47,7 @@ Parameters with physical units use Pint Quantity objects, which provide:
 - Dimensional analysis
 - Human-readable representation
 
-The ureg (UnitRegistry) and Q_ (Quantity constructor) are imported from
+The ``ureg`` (UnitRegistry) and ``Q_`` (Quantity constructor) are imported from
 the constants module.
 
 Usage Example
@@ -896,31 +896,31 @@ class MacroParameters(Parameters):
     """The number of fibrin-free rows at the top of the grid.
 
     This represents the depth of the fibrin-free region where tPA molecules
-    enter the simulation domain. 
-    
+    enter the simulation domain.
+
     For example, if empty_rows = 28, then rows 0-27 contain no fibers, and
     row 28 is the first row with fibers.
 
     Note: In the Fortran code, there was no variable for 'The number of empty rows'.
-    Instead, the variable `Ffree` gave the 1-indexed location of the first non-empty row.
-    In 0-indexing, the number of empty rows is the same as the index of the first 
+    Instead, the variable ``Ffree`` gave the 1-indexed location of the first non-empty
+    row. In 0-indexing, the number of empty rows is the same as the index of the first
     non-empty row, but in 1-indexing, this is not the case.
-    Thus, `empty_rows` and `Ffree` are not exactly translatable, but
-    `empty_rows = Ffree - 1`
+    Thus, ``empty_rows`` and ``Ffree`` are not exactly translatable, but
+    ``empty_rows = Ffree - 1``
 
-    Here is a graphical (rotated) example with four fiber-free rows and 
-    five rows of fibrin. 
+    Here is a graphical (rotated) example with four fiber-free rows and
+    five rows of fibrin.
     In Python, this would give: rows = 9, fiber_rows = 6, and empty_rows = 3.
-    In Fortran, the equivalent would be: F = 9, Fhat = 6, and Ffree = 4
-    
-                      empty_rows
-                       ^^^^^^^
-    Python indexing:   0  1  2  3  4  5  6  7  8
-                       .  .  .  |  |  |  |  |  |
-    Fortran indexing:  1  2  3  4  5  6  7  8  9
-                                ^
-                              Ffree
-                                
+    In Fortran, the equivalent would be: F = 9, Fhat = 6, and Ffree = 4::
+
+                          empty_rows
+                           ^^^^^^^
+        Python indexing:   0  1  2  3  4  5  6  7  8
+                           .  .  .  |  |  |  |  |  |
+        Fortran indexing:  1  2  3  4  5  6  7  8  9
+                                    ^
+                                  Ffree
+
     :Units: None
     :Fortran: Ffree-1"""
 

--- a/src/lysis/dataio/dataspec.py
+++ b/src/lysis/dataio/dataspec.py
@@ -1053,6 +1053,7 @@ def parse_shape(
     grid dimensions.
 
     Shape elements can be:
+
     - **Integers**: Passed through unchanged (e.g., 100, -1)
     - **Strings**: Parameter references in "dict_key.param_name" format
       (e.g., "macro_params.total_molecules")

--- a/src/lysis/geometry/edge_grid.py
+++ b/src/lysis/geometry/edge_grid.py
@@ -559,10 +559,11 @@ class EdgeGrid(object):
         :type b: Tuple[int, int]
         :param metric: The metric being used to calculate the distance, defaults to "euclidian".
             Options are:
-                - "euclidian": :math:`\sqrt{(x_1-x_2)^2+(y_1-y_2)^2+(z_1-z_2)^2}`
-                - "manhattan": :math:`\lvert x_1-x_2\rvert+\lvert y_1-y_2\rvert+\lvert z_1-z_2\rvert`
-                - "taxicab": :math:`\lvert x_1-x_2\rvert+\lvert y_1-y_2\rvert+\lvert z_1-z_2\rvert`
-                - "2d_euclidian": :math:`\sqrt{(x_1-x_2)^2+(y_1-y_2)^2}`
+
+            - "euclidian": :math:`\sqrt{(x_1-x_2)^2+(y_1-y_2)^2+(z_1-z_2)^2}`
+            - "manhattan": :math:`\lvert x_1-x_2\rvert+\lvert y_1-y_2\rvert+\lvert z_1-z_2\rvert`
+            - "taxicab": :math:`\lvert x_1-x_2\rvert+\lvert y_1-y_2\rvert+\lvert z_1-z_2\rvert`
+            - "2d_euclidian": :math:`\sqrt{(x_1-x_2)^2+(y_1-y_2)^2}`
         :type metric: str, optional
         :raises AttributeError: If the metric passed is not among those implemented.
         :return: A Pint Quantity object containing the distance between the centers of the two edges.

--- a/src/lysis/np_macroscale.py
+++ b/src/lysis/np_macroscale.py
@@ -639,6 +639,7 @@ class MacroscaleSim:
         generated binding time.
 
         This method:
+
         - Updates bound status to False for affected molecules
         - Clears the unbound_by_degradation flag
         - For forced unbinds (MICRO_UNBOUND): sets waiting time and
@@ -795,16 +796,20 @@ class MacroscaleSim:
 
         If 100*r is an integer i, we simply return unbinding_time[i].
 
-        If 100*r is not an integer, then f(r) lies in the interval:
+        If 100*r is not an integer, then f(r) lies in the interval::
+
             (f(floor(100*r)), f(ceil(100*r)))
 
-        We define a linear function g(x) such that:
+        We define a linear function g(x) such that::
+
             g(floor(100*r)) = f(floor(100*r))
             g(ceil(100*r)) = f(ceil(100*r))
+
         and use g(r) to approximate f(r).
 
         Equivalently, if i is an integer such that 100i < 100r < 100(i+1) and
-        λ is defined such that 100i + λ = 100r, then:
+        λ is defined such that 100i + λ = 100r, then::
+
             f(r) ≈ (1-λ)*f(i/100) + λ*f((i+1)/100)
 
         :param unbinding_time_bin: Array of values in [0, 100] representing which bin

--- a/src/lysis/tools/kiss.py
+++ b/src/lysis/tools/kiss.py
@@ -54,12 +54,13 @@ class KissRandomGenerator:
     The interface mimics numpy.random.Generator to allow drop-in replacement
     in code that needs to exactly replicate the Fortran KISS sequence.
 
+    The ``mscw`` and ``kiss32`` C functions are documented as methods below
+    (their stubs are overwritten by the C library during ``__init__``).
+
     Attributes:
         state_type: ctypes array type for the 4-element generator state
         urcw1: C function for generating single U(0,1) random numbers
         vurcw1: C function for generating arrays of U(0,1) random numbers
-        mscw: C function for generating time-based seeds
-        kiss32: C function for generating 32-bit unsigned integers
 
     Note:
         The underlying C library (kiss.so) must be compiled and available in

--- a/src/lysis/tools/slurm.py
+++ b/src/lysis/tools/slurm.py
@@ -58,7 +58,32 @@ from pathlib import Path
 from string import Template
 from typing import Dict, List, Mapping, Optional
 
-import GooseSLURM as gs
+# ``GooseSLURM`` is an optional HPC dependency, only needed when actually
+# submitting or polling Slurm jobs.  Guard the import the same way the rest of
+# the package guards optional deps (cf. ``cupy`` in ``lysis/__init__.py`` and
+# ``matplotlib`` in ``lysis/tools/__init__.py``) so that ``import lysis``
+# succeeds in environments without it — e.g. the docs build.  The submission
+# helpers below check :func:`_require_gs` before using ``gs``.
+try:
+    import GooseSLURM as gs
+except ImportError:  # pragma: no cover - exercised only off-cluster
+    gs = None
+
+
+def _require_gs():
+    """Return the :mod:`GooseSLURM` module, or raise a clear error if absent.
+
+    :return: The imported ``GooseSLURM`` module.
+    :rtype: module
+    :raises ImportError: If ``GooseSLURM`` is not installed.
+    """
+    if gs is None:  # pragma: no cover - exercised only off-cluster
+        raise ImportError(
+            "GooseSLURM is required for Slurm job submission/polling but is "
+            "not installed. Install it (HPC environments only) to use the "
+            "lysis.tools.slurm submission helpers."
+        )
+    return gs
 
 
 # ---------------------------------------------------------------------------
@@ -871,7 +896,9 @@ def submit_slurm_job(
     :type historical_binary_attrs: dict, optional
     :return: Master Slurm job ID.
     :rtype: int
+    :raises ImportError: If ``GooseSLURM`` is not installed.
     """
+    _require_gs()
     run_code = hdf5_path.stem
 
     # Sync the project venv against uv.lock before any Slurm tasks fire,
@@ -1189,6 +1216,7 @@ def submit_micro_child_job(script_text: str, script_path: "Path | str") -> int:
     :raises subprocess.CalledProcessError: If ``sbatch`` fails.
     :raises ValueError: If ``sbatch`` output cannot be parsed for a job ID.
     """
+    _require_gs()
     script_path = Path(script_path)
     script_path.write_text(script_text)
     script_path.chmod(0o755)
@@ -1208,6 +1236,7 @@ def wait_for_jobs(job_ids: List[int], poll_interval: int = 30) -> None:
     :raises RuntimeError: If any job appears in squeue with state
         ``FAILED`` or ``CANCELLED``.
     """
+    _require_gs()
     remaining = list(job_ids)
     while remaining:
         time.sleep(poll_interval)
@@ -1375,6 +1404,7 @@ def submit_micro_slurm_job(
     :raises ValueError: If ``num_children`` is set and is either less than
         1 or greater than ``micro_simulations``.
     """
+    _require_gs()
     from lysis.execution.fortran_micro import FortranMicro  # noqa: PLC0415
 
     hdf5_path = Path(hdf5_path).resolve()
@@ -1663,6 +1693,7 @@ def submit_macro_slurm_job(
     :raises subprocess.CalledProcessError: If ``sbatch`` fails.
     :raises ValueError: If the HDF5 file does not contain ``macro_params``.
     """
+    _require_gs()
     from lysis.execution.fortran_macro import FortranMacro  # noqa: PLC0415
 
     hdf5_path = Path(hdf5_path).resolve()

--- a/src/lysis/tools/slurm.py
+++ b/src/lysis/tools/slurm.py
@@ -739,7 +739,9 @@ def generate_array_script(
     :type source_stamp: tuple[str, str] or None
     :return: Slurm array job bash script text.
     :rtype: str
+    :raises ImportError: If ``GooseSLURM`` is not installed.
     """
+    _require_gs()
     staging_dir = Path(staging_dir)
     hdf5_path = Path(hdf5_path)
     executable = Path(executable)
@@ -1103,7 +1105,9 @@ def generate_micro_child_script(
     :type source_stamp: tuple[str, str] or None
     :return: Slurm bash script text.
     :rtype: str
+    :raises ImportError: If ``GooseSLURM`` is not installed.
     """
+    _require_gs()
     staging_dir = Path(staging_dir)
     hdf5_path = Path(hdf5_path)
     executable = Path(executable)


### PR DESCRIPTION
Fixes #53.

## Primary fix (build-breaking `ConfigError`)

The RTD build died with a Sphinx `ConfigError` because `docs/source/conf.py` imports the `lysis` package to read version metadata, and that import chain hit an **unguarded** `import GooseSLURM` in `src/lysis/tools/slurm.py`. `autodoc_mock_imports` doesn't apply while `conf.py` itself is evaluated, so the mock never kicked in. This also broke `import lysis` in **any** environment without the optional HPC dependency.

- Guard the `GooseSLURM` import the same way the package already guards `cupy`/`matplotlib` (`gs = None` on `ImportError`).
- Add a `_require_gs()` helper called at the public submission entry points (`submit_slurm_job`, `submit_micro_child_job`, `wait_for_jobs`, `submit_micro_slurm_job`, `submit_macro_slurm_job`) so off-cluster calls raise a clear `ImportError` instead of `AttributeError: 'NoneType'`.
- Call sites keep using the module-level `gs`, so the existing tests that patch `lysis.tools.slurm.gs.sbatch` still pass (158/158).

## Secondary defects (clean build)

- `docs/requirements.txt`: add `pandas` (autodoc needs it for `lysis.cli`/`display`/`summary`).
- `lysis.execution.rst`: replace the removed `codeutil` reference with the real submodules (`base`, `fortran`, `fortran_macro`, `fortran_micro`, `historical_build`).
- Fix docutils errors in docstrings (`np_macroscale`, `config/parameters`, `dataio/dataspec`, `geometry/edge_grid`), including the `Q_` hyperlink-target false positive and an ASCII diagram that needed a literal block.
- Fix malformed RST titles (`lysis.dataio`, `data_specification`, `historical_fortran`).
- Add `docs/source/_static/`, add `system_onboarding` to the toctree, convert `ontology.rst` to a `.. glossary::` (resolves the `:term:`Run`` reference), and remove the duplicate `mscw`/`kiss32` object descriptions in `kiss.py`.

Defect 3 (`cp_macroscale.py`) was moot — that file was already archived out of the package.

## `fail_on_warning`

The build now produces **0 warnings**, so `.readthedocs.yaml` flips `fail_on_warning` to `true` to catch future regressions.

## Verification

- `import lysis` succeeds with `GooseSLURM` blocked (simulating the docs/non-HPC env).
- `python -m sphinx -T -W -b html docs/source <out>` exits **0**.
- `pytest tests/tools/test_slurm.py` -> 158 passed; all 1945 tests collect cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)