### PR TITLE
Fix ReadTheDocs build and add docs build check to CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,3 +52,4 @@ jobs:
 
         - name: Build docs (warnings treated as errors, like RTD fail_on_warning)
           run: uv run --no-project python -m sphinx -T -W --keep-going -b html -d _build/doctrees docs/source _build/html
+          

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,3 +29,26 @@ jobs:
 
         - name: Run pytest
           run: uv run pytest -m "not real_data and not fortran_binary" -q
+
+  docs:
+    # Mirror the ReadTheDocs build so requirements drift is caught in PR review.
+    # Install ONLY from docs/requirements.txt (not `uv sync`) so a dependency the
+    # docs build needs but docs/requirements.txt omits surfaces here too.
+    runs-on: ubuntu-latest
+
+    steps:
+        - name: Checkout code
+          uses: actions/checkout@v4
+
+        - name: Install uv
+          uses: astral-sh/setup-uv@v5
+
+        - name: Set up Python
+          # Match the python version pinned in .readthedocs.yaml.
+          run: uv python install 3.11
+
+        - name: Install docs requirements
+          run: uv venv && uv pip install -r docs/requirements.txt
+
+        - name: Build docs (warnings treated as errors, like RTD fail_on_warning)
+          run: uv run --no-project python -m sphinx -T -W --keep-going -b html -d _build/doctrees docs/source _build/html

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -11,6 +11,8 @@ sphinxcontrib-jquery>=4.0
 numpy>=1.20
 h5py>=3.0
 pint>=0.20
+scipy>=1.10  # lysis.analysis.compare imports scipy.stats.ks_2samp
+sympy>=1.12  # lysis.config.param_resolver imports sympy
 
 # Progress bars and visualization
 tqdm>=4.60


### PR DESCRIPTION
## Summary
The ReadTheDocs build was failing. This fixes it and adds a CI check so the same class of breakage is caught in PR review instead of only after merge.

## Root cause
RTD builds with `fail_on_warning: true`. Autodoc imports `lysis.cli`, whose import chain reaches:

```
lysis.cli → lysis.analysis.compare → from scipy.stats import ks_2samp
```

`scipy` is a core package dependency (`scipy>=1.10` in `pyproject.toml`) but was **missing from `docs/requirements.txt`**. In the RTD environment the import raised `ModuleNotFoundError: No module named 'scipy'`, producing 3 autodoc warnings → build failed.

## Changes
1. **`docs/requirements.txt`** — add `scipy>=1.10` (the fix) and `sympy>=1.12` (same latent gap: a core dep imported by `lysis.config.param_resolver`; not currently reached by autodoc, added so a future automodule won't reintroduce the break).
2. **`.github/workflows/tests.yml`** — add a `docs` job mirroring the RTD build.
   - Installs **only** from `docs/requirements.txt` (not `uv sync`), so a dep the docs build needs but the requirements file omits surfaces here too. A `uv sync` would install the full package deps and mask the gap.
   - Builds with `sphinx -T -W --keep-going`, matching RTD's `fail_on_warning`.
   - Python pinned to 3.11 to match `.readthedocs.yaml`.

## Verification
Reproduced RTD's exact invocation in a clean venv built from `docs/requirements.txt`:
- With the fix: `build succeeded`, **zero warnings**.
- With scipy removed: exits non-zero — `build finished with problems, 3 warnings (with warnings treated as errors)` — confirming the new CI check has teeth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)