### PR TITLE
Fix `lysis parameters` error on microscale-only files (#22)

### DIFF
--- a/src/lysis/cli/parameters.py
+++ b/src/lysis/cli/parameters.py
@@ -61,15 +61,19 @@ _COMPUTED = {
 }
 
 
-def _get_raw(macro_params, attr_name):
-    """Return the raw value of a parameter (Pint Quantity or scalar), or None."""
+def _get_raw(macro_params, micro_params, attr_name):
+    """Return the raw value of a parameter (Pint Quantity or scalar), or None.
+
+    Either ``macro_params`` or ``micro_params`` may be ``None`` when the
+    corresponding data collection is absent from the file.  Macroscale and
+    computed parameters resolve to ``None`` when no macroscale data is present.
+    """
     if attr_name in _COMPUTED:
-        return _COMPUTED[attr_name](macro_params)
-    if hasattr(macro_params, attr_name):
+        return _COMPUTED[attr_name](macro_params) if macro_params is not None else None
+    if macro_params is not None and hasattr(macro_params, attr_name):
         return getattr(macro_params, attr_name)
-    micro = getattr(macro_params, "micro_params", None)
-    if micro is not None and hasattr(micro, attr_name):
-        return getattr(micro, attr_name)
+    if micro_params is not None and hasattr(micro_params, attr_name):
+        return getattr(micro_params, attr_name)
     return None
 
 
@@ -106,32 +110,86 @@ def _param_header(attr_name, display_units, natural_units):
 
 
 def _load_run_params(data_root, run_code, param_specs, add_names, console):
-    """Load a Run and return a dict of formatted parameter values, or None on error."""
+    """Load a Run and read its formatted parameter values.
+
+    :return: ``(values, has_macro)`` where ``values`` is a
+        ``{attr_name: formatted_str}`` dict (or ``None`` on error) and
+        ``has_macro`` is ``True`` when the file contains a macroscale data
+        collection.
+    :rtype: tuple[dict | None, bool]
+    """
     from lysis.config.run import Run
 
     try:
         run = Run(data_root, run_code)
         run.open_data()
-        run.macro_params = run.data.macro_params
-        macro_params = run.macro_params
+        # Detect which data collections are present before reading parameters:
+        # a microscale-only file has no macroscale parameters (issue #22).
+        macro_params = run.data.macro_params
+        micro_params = run.data.micro_params
     except Exception as e:
         console.print(f"[red]Error loading {run_code}:[/red] {e}")
-        return None
+        return None, False
+
+    has_macro = macro_params is not None
+
+    if macro_params is None and micro_params is None:
+        console.print(f"[yellow]No parameters found for {run_code}[/yellow]")
+        run.data.close()
+        return None, False
 
     try:
         values = {}
         for attr_name, _src, display_units, fmt in param_specs:
-            raw = _get_raw(macro_params, attr_name)
+            raw = _get_raw(macro_params, micro_params, attr_name)
             values[attr_name] = _format_value(raw, display_units, fmt)
         for attr_name in add_names:
-            raw = _get_raw(macro_params, attr_name)
+            raw = _get_raw(macro_params, micro_params, attr_name)
             values[attr_name] = _auto_format(raw)
-        return values
+        return values, has_macro
     except Exception as e:
         console.print(f"[red]Error reading parameters for {run_code}:[/red] {e}")
-        return None
+        return None, has_macro
     finally:
         run.data.close()
+
+
+def _macro_param_names():
+    """Canonical set of macroscale-only parameter attribute names.
+
+    Derived from the dataclass definitions: a parameter defined on
+    :class:`~lysis.config.parameters.MacroParameters` but not on
+    :class:`~lysis.config.parameters.MicroParameters` is macroscale-only.  The
+    nested ``micro_params`` container is excluded.
+
+    :rtype: set[str]
+    """
+    import dataclasses
+
+    from lysis.config.parameters import MacroParameters, MicroParameters
+
+    macro = {f.name for f in dataclasses.fields(MacroParameters)}
+    micro = {f.name for f in dataclasses.fields(MicroParameters)}
+    return (macro - micro) - {"micro_params"}
+
+
+def _drop_macro_specs(param_specs):
+    """Remove macroscale and computed parameter rows from the spec list.
+
+    Used when no run in the table has a macroscale data collection (issue #22),
+    so those rows could never carry data.  The macroscale parameters are
+    identified from the canonical :class:`MacroParameters` dataclass rather than
+    inferred from missing values, so a *microscale* parameter that is
+    unexpectedly absent still renders as ``N/A`` and is never silently dropped.
+
+    :param param_specs: Effective ``(attr_name, source, units, fmt)`` specs.
+    :return: ``param_specs`` filtered to non-macroscale, non-computed rows.
+    """
+    macro_names = _macro_param_names()
+    return [
+        p for p in param_specs
+        if p[0] not in macro_names and p[0] not in _COMPUTED
+    ]
 
 
 @cli.command()
@@ -234,11 +292,11 @@ def parameters(ctx, path, sort_mode, no_progress, add_params, drop_params, markd
 
         if not no_progress:
             with console.status(f"Loading parameters for {run_code}..."):
-                values = _load_run_params(
+                values, has_macro = _load_run_params(
                     data_root, run_code, param_specs, add_names, console
                 )
         else:
-            values = _load_run_params(
+            values, has_macro = _load_run_params(
                 data_root, run_code, param_specs, add_names, console
             )
 
@@ -246,8 +304,10 @@ def parameters(ctx, path, sort_mode, no_progress, add_params, drop_params, markd
             ctx.exit(1)
             return
 
+        # Drop macroscale rows when this file has no macroscale collection.
+        effective_specs = param_specs if has_macro else _drop_macro_specs(param_specs)
         df = parameters_table(
-            {run_code: values}, param_specs, add_names, natural_units, [run_code]
+            {run_code: values}, effective_specs, add_names, natural_units, [run_code]
         )
 
         if markdown_out is not None:
@@ -283,6 +343,7 @@ def parameters(ctx, path, sort_mode, no_progress, add_params, drop_params, markd
             run_codes = sorted(run_codes)
 
         rows = {}
+        any_macro = False
 
         _pctx = (
             Progress(
@@ -303,21 +364,25 @@ def parameters(ctx, path, sort_mode, no_progress, add_params, drop_params, markd
                 else None
             )
             for run_code in run_codes:
-                vals = _load_run_params(
+                vals, has_macro = _load_run_params(
                     path, run_code, param_specs, add_names, console
                 )
                 if prog is not None:
                     prog.advance(_task)
                 if vals is not None:
                     rows[run_code] = vals
+                    any_macro = any_macro or has_macro
 
         if not rows:
             ctx.exit(1)
             return
 
-        # Preserve sort order, skipping any failed runs
+        # Preserve sort order, skipping any failed runs.  Drop macroscale rows
+        # only when no run in the directory has a macroscale collection, so
+        # columns still line up when the set is mixed.
         ordered = [rc for rc in run_codes if rc in rows]
-        df = parameters_table(rows, param_specs, add_names, natural_units, ordered)
+        effective_specs = param_specs if any_macro else _drop_macro_specs(param_specs)
+        df = parameters_table(rows, effective_specs, add_names, natural_units, ordered)
 
         if markdown_out is not None:
             emit_markdown(

--- a/tests/cli/test_parameters.py
+++ b/tests/cli/test_parameters.py
@@ -1,12 +1,13 @@
 """Tests for ``lysis parameters`` CLI command."""
 
+import warnings
 from unittest.mock import patch
 
 import pytest
 from click.testing import CliRunner
 
 from lysis.cli import cli
-from lysis.cli.parameters import _DEFAULT_PARAMS
+from lysis.cli.parameters import _DEFAULT_PARAMS, _load_run_params
 
 
 # ---------------------------------------------------------------------------
@@ -59,7 +60,7 @@ class TestParametersHelp:
 class TestParametersMarkdownSingleFile:
     @patch("lysis.cli.parameters._load_run_params")
     def test_markdown_to_stdout(self, mock_load, runner, mock_params, tmp_path):
-        mock_load.return_value = mock_params
+        mock_load.return_value = (mock_params, True)
         h5 = tmp_path / "run_A.h5"
         h5.touch()
 
@@ -70,7 +71,7 @@ class TestParametersMarkdownSingleFile:
 
     @patch("lysis.cli.parameters._load_run_params")
     def test_markdown_to_stdout_has_sections(self, mock_load, runner, mock_params, tmp_path):
-        mock_load.return_value = mock_params
+        mock_load.return_value = (mock_params, True)
         h5 = tmp_path / "run_A.h5"
         h5.touch()
 
@@ -82,7 +83,7 @@ class TestParametersMarkdownSingleFile:
 
     @patch("lysis.cli.parameters._load_run_params")
     def test_markdown_to_stdout_contains_param(self, mock_load, runner, mock_params, tmp_path):
-        mock_load.return_value = mock_params
+        mock_load.return_value = (mock_params, True)
         h5 = tmp_path / "run_A.h5"
         h5.touch()
 
@@ -93,7 +94,7 @@ class TestParametersMarkdownSingleFile:
 
     @patch("lysis.cli.parameters._load_run_params")
     def test_markdown_to_file(self, mock_load, runner, mock_params, tmp_path):
-        mock_load.return_value = mock_params
+        mock_load.return_value = (mock_params, True)
         h5 = tmp_path / "run_B.h5"
         h5.touch()
         out_file = tmp_path / "params.md"
@@ -107,7 +108,7 @@ class TestParametersMarkdownSingleFile:
 
     @patch("lysis.cli.parameters._load_run_params")
     def test_markdown_file_content(self, mock_load, runner, mock_params, tmp_path):
-        mock_load.return_value = mock_params
+        mock_load.return_value = (mock_params, True)
         h5 = tmp_path / "run_C.h5"
         h5.touch()
         out_file = tmp_path / "params.md"
@@ -121,7 +122,7 @@ class TestParametersMarkdownSingleFile:
 
     @patch("lysis.cli.parameters._load_run_params")
     def test_markdown_file_confirmation_message(self, mock_load, runner, mock_params, tmp_path):
-        mock_load.return_value = mock_params
+        mock_load.return_value = (mock_params, True)
         h5 = tmp_path / "run_D.h5"
         h5.touch()
         out_file = tmp_path / "params.md"
@@ -134,7 +135,7 @@ class TestParametersMarkdownSingleFile:
 
     @patch("lysis.cli.parameters._load_run_params")
     def test_no_markdown_flag_gives_normal_output(self, mock_load, runner, mock_params, tmp_path):
-        mock_load.return_value = mock_params
+        mock_load.return_value = (mock_params, True)
         h5 = tmp_path / "run_E.h5"
         h5.touch()
 
@@ -152,7 +153,7 @@ class TestParametersMarkdownSingleFile:
 class TestParametersMarkdownDirectory:
     @patch("lysis.cli.parameters._load_run_params")
     def test_markdown_to_stdout(self, mock_load, runner, mock_params, tmp_path):
-        mock_load.return_value = mock_params
+        mock_load.return_value = (mock_params, True)
         (tmp_path / "run_1.h5").touch()
         (tmp_path / "run_2.h5").touch()
 
@@ -168,7 +169,7 @@ class TestParametersMarkdownDirectory:
     def test_markdown_to_stdout_run_codes_as_columns(
         self, mock_load, runner, mock_params, tmp_path
     ):
-        mock_load.return_value = mock_params
+        mock_load.return_value = (mock_params, True)
         (tmp_path / "run_X.h5").touch()
         (tmp_path / "run_Y.h5").touch()
 
@@ -182,7 +183,7 @@ class TestParametersMarkdownDirectory:
 
     @patch("lysis.cli.parameters._load_run_params")
     def test_markdown_to_file(self, mock_load, runner, mock_params, tmp_path):
-        mock_load.return_value = mock_params
+        mock_load.return_value = (mock_params, True)
         (tmp_path / "run_1.h5").touch()
         out_file = tmp_path / "params.md"
 
@@ -198,7 +199,7 @@ class TestParametersMarkdownDirectory:
         # Return params without the dropped key
         params = _make_params()
         del params["pore_size"]
-        mock_load.return_value = params
+        mock_load.return_value = (params, True)
         (tmp_path / "run_1.h5").touch()
 
         result = runner.invoke(
@@ -213,7 +214,7 @@ class TestParametersMarkdownDirectory:
     def test_markdown_with_add(self, mock_load, runner, tmp_path):
         params = _make_params(add_names=["protofibril_radius"])
         params["protofibril_radius"] = "0.0024"
-        mock_load.return_value = params
+        mock_load.return_value = (params, True)
         (tmp_path / "run_1.h5").touch()
 
         result = runner.invoke(
@@ -236,7 +237,7 @@ class TestParametersMarkdownDirectory:
     def test_no_markdown_flag_gives_normal_output(
         self, mock_load, runner, mock_params, tmp_path
     ):
-        mock_load.return_value = mock_params
+        mock_load.return_value = (mock_params, True)
         (tmp_path / "run_1.h5").touch()
 
         result = runner.invoke(
@@ -245,3 +246,143 @@ class TestParametersMarkdownDirectory:
 
         assert result.exit_code == 0
         assert "### Macroscale Parameters" not in result.output
+
+
+# ---------------------------------------------------------------------------
+# Microscale-only files (issue #22)
+# ---------------------------------------------------------------------------
+
+
+def _make_micro_only_run(tmp_path, run_code="micro_only", micro_simulations=42):
+    """Create a microscale-only HDF5 file (no macroscale collection)."""
+    from lysis.config.parameters import MicroParameters
+    from lysis.dataio.datastore import DataStore
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        micro = MicroParameters(micro_simulations=micro_simulations)
+    ds = DataStore.create(run_code, str(tmp_path), micro)
+    ds.close()
+    return run_code
+
+
+class TestParametersMicroOnly:
+    """A microscale-only file must not error just because no macro params exist."""
+
+    def test_load_run_params_returns_dict(self, tmp_path):
+        run_code = _make_micro_only_run(tmp_path)
+        from rich.console import Console
+
+        values, has_macro = _load_run_params(
+            str(tmp_path), run_code, _DEFAULT_PARAMS, [], Console()
+        )
+
+        assert values is not None
+
+    def test_has_macro_false_for_micro_only(self, tmp_path):
+        run_code = _make_micro_only_run(tmp_path)
+        from rich.console import Console
+
+        _values, has_macro = _load_run_params(
+            str(tmp_path), run_code, _DEFAULT_PARAMS, [], Console()
+        )
+
+        assert has_macro is False
+
+    def test_micro_param_populated(self, tmp_path):
+        run_code = _make_micro_only_run(tmp_path, micro_simulations=42)
+        from rich.console import Console
+
+        values, has_macro = _load_run_params(
+            str(tmp_path), run_code, _DEFAULT_PARAMS, [], Console()
+        )
+
+        assert values["micro_simulations"] == "42"
+
+    def test_macro_param_is_na(self, tmp_path):
+        run_code = _make_micro_only_run(tmp_path)
+        from rich.console import Console
+
+        values, has_macro = _load_run_params(
+            str(tmp_path), run_code, _DEFAULT_PARAMS, [], Console()
+        )
+
+        # Macro and computed params resolve to N/A, not an exception
+        assert values["pore_size"] == "N/A"
+        assert values["grid_node_distance"] == "N/A"
+
+    def test_cli_single_file_exits_0(self, runner, tmp_path):
+        run_code = _make_micro_only_run(tmp_path)
+        h5 = tmp_path / f"{run_code}.h5"
+
+        result = runner.invoke(cli, ["parameters", str(h5), "--no-progress"])
+
+        assert result.exit_code == 0
+        assert "micro_simulations" in result.output
+
+    def test_cli_directory_exits_0(self, runner, tmp_path):
+        _make_micro_only_run(tmp_path)
+
+        result = runner.invoke(cli, ["parameters", str(tmp_path), "--no-progress"])
+
+        assert result.exit_code == 0
+
+    def test_cli_drops_macro_rows(self, runner, tmp_path):
+        run_code = _make_micro_only_run(tmp_path)
+        h5 = tmp_path / f"{run_code}.h5"
+
+        result = runner.invoke(
+            cli, ["parameters", str(h5), "--markdown", "-"]
+        )
+
+        assert result.exit_code == 0
+        # No macro values exist, so the macro section/rows are dropped entirely.
+        assert "### Macroscale Parameters" not in result.output
+        assert "pore_size" not in result.output
+        assert "grid_node_distance" not in result.output
+        # Microscale rows still render.
+        assert "### Microscale Parameters" in result.output
+        assert "micro_simulations" in result.output
+
+    def test_cli_no_na_rows_remain(self, runner, tmp_path):
+        run_code = _make_micro_only_run(tmp_path)
+        h5 = tmp_path / f"{run_code}.h5"
+
+        result = runner.invoke(cli, ["parameters", str(h5), "--no-progress"])
+
+        assert result.exit_code == 0
+        assert "N/A" not in result.output
+
+
+# ---------------------------------------------------------------------------
+# Macro-spec dropping (canonical source)
+# ---------------------------------------------------------------------------
+
+
+class TestDropMacroSpecs:
+    """``_drop_macro_specs`` keys off the canonical MacroParameters fields."""
+
+    def test_macro_param_names_from_dataclass(self):
+        from lysis.cli.parameters import _macro_param_names
+
+        names = _macro_param_names()
+        # Representative macroscale-only fields
+        assert "pore_size" in names
+        assert "rows" in names
+        assert "macro_simulations" in names
+        # Microscale fields and the nested container are excluded
+        assert "fiber_radius" not in names
+        assert "micro_simulations" not in names
+        assert "micro_params" not in names
+
+    def test_drops_macro_and_computed_keeps_micro(self):
+        from lysis.cli.parameters import _drop_macro_specs
+
+        kept = {p[0] for p in _drop_macro_specs(_DEFAULT_PARAMS)}
+        # Macro and computed rows are gone
+        assert "pore_size" not in kept
+        assert "grid_node_distance" not in kept  # computed
+        # Every microscale row survives, so a missing micro param still shows N/A
+        assert "fiber_radius" in kept
+        assert "micro_simulations" in kept
+        assert "micro_seed" in kept


### PR DESCRIPTION
## Summary

Fixes #22 — `lysis parameters` threw an error when run against a microscale-only file (no macroscale data collection).

The command assumed every file had macroscale parameters: `run.data.macro_params` is `None` for a micro-only file, and the computed-parameter lambdas (e.g. `grid_node_distance`) and the `macro_params.micro_params` lookup then raised on `None`, surfacing as an "Error reading parameters" and a non-zero exit.

## Approach

As the issue suggested, detect which data collections are present *before* reading parameters:

- `_get_raw` now takes both `macro_params` and `micro_params` (either may be `None`); macroscale and computed params resolve to `None` when no macroscale data is present, and microscale params are read directly from `micro_params`.
- `_load_run_params` returns `(values, has_macro)`, where `has_macro` reflects whether the file actually contains a macroscale collection.
- When **no** run in the table has a macroscale collection, the macroscale and computed rows are dropped. The macroscale parameter set is derived **canonically** from the `MacroParameters` dataclass fields (`fields(MacroParameters) − fields(MicroParameters) − {micro_params}`) rather than inferred from missing values — so an unexpectedly-absent *microscale* parameter still renders as `N/A` and is never silently hidden. In a mixed directory (some runs with macro, some without), the macro rows are kept so columns line up.

## Tests

- New `TestParametersMicroOnly`: builds a real microscale-only `DataStore` and checks the load path returns values, reports `has_macro=False`, populates micro params, resolves macro/computed to `N/A`, and that the CLI exits 0 and drops the macro section.
- New `TestDropMacroSpecs`: locks in the canonical classification and that every microscale row survives dropping.
- Existing mock-based tests updated for the new `(values, has_macro)` return.

Full `tests/cli/` + `tests/analysis/test_summary.py` suite: 370 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)