### PR TITLE
Rename --compiler to --modules on run-macro/run-micro (#64)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -40,6 +40,12 @@ Unreleased
 Changed
 -------
 
+- The ``--compiler`` option on ``lysis run-micro`` / ``run-macro`` has been
+  renamed to ``--modules``. Its value is passed verbatim to ``module load``,
+  so you can now request several LMod modules at once as a quoted,
+  space-separated list (e.g. ``--modules "intel-compilers/2023 hdf5"``).
+  This is a hard break: ``--compiler`` is no longer recognised. (#64)
+
 - The ``Makefile`` now builds the KISS RNG shared library (``lib/kiss.so``) as
   part of the default ``make`` target and creates the ``bin/`` and ``lib/``
   output directories on demand, so a fresh checkout builds with no manual

--- a/docs/source/usage/historical_fortran.rst
+++ b/docs/source/usage/historical_fortran.rst
@@ -23,7 +23,7 @@ Basic usage
     lysis run-macro data/my-experiment/ \
         --executable macro_diffuse_into_and_along__internal \
         --fortran-commit 60d200f \
-        --slurm --compiler intel-compilers/2024
+        --slurm --modules intel-compilers/2024
 
 When ``--fortran-commit`` is set:
 
@@ -72,16 +72,24 @@ Lifecycle
   returns.  Parallel ``lysis run-macro`` invocations on different folders
   never collide — each gets a distinct ``mkdtemp``.
 
-Compiler module
----------------
+LMod modules
+------------
 
-The ``--compiler`` flag (default ``intel-compilers/2023``) tells generated
-Slurm scripts which LMod module to ``module load`` before invoking the
-Fortran binary.  With ``--fortran-commit --slurm`` the build step is *also*
-wrapped in ``module purge && module load <compiler>`` so the binary links
-against the exact toolchain the Slurm preamble will load at runtime.
+The ``--modules`` flag (default ``intel-compilers/2023``) tells generated
+Slurm scripts which LMod modules to ``module load`` before invoking the
+Fortran binary.  The value is forwarded verbatim to ``module load``, which
+itself accepts a space-separated list, so you can request several modules
+at once — be sure to quote the list so the shell keeps it as one argument::
 
-Local mode (no ``--slurm``) ignores ``--compiler``: the binary is built and
+    --modules "intel-compilers/2024 SciPy-bundle/2023.07"
+
+Include a Fortran compiler module so the binary finds its runtime; add any
+other modules the job needs.  With ``--fortran-commit --slurm`` the build
+step is *also* wrapped in ``module purge && module load <modules>`` so the
+binary links against the exact toolchain the Slurm preamble will load at
+runtime.
+
+Local mode (no ``--slurm``) ignores ``--modules``: the binary is built and
 executed in the same environment the CLI was launched from, so anything you
 loaded with ``module load`` before running ``lysis`` governs both steps.
 
@@ -96,7 +104,13 @@ Examples::
     lysis run-macro data/run01.h5 \
         --executable macro_diffuse_into_and_along__internal \
         --fortran-commit 60d200f \
-        --slurm --compiler intel-compilers/2024
+        --slurm --modules intel-compilers/2024
+
+    # Slurm — load several modules at once (quote the list).
+    lysis run-macro data/run01.h5 \
+        --executable macro_diffuse_into_and_along__internal \
+        --fortran-commit 60d200f \
+        --slurm --modules "intel-compilers/2024 SciPy-bundle/2023.07"
 
 Limitations and caveats
 -----------------------

--- a/src/lysis/cli/run_macro.py
+++ b/src/lysis/cli/run_macro.py
@@ -35,7 +35,7 @@ from lysis.cli._provenance import (
     enforce_init_commit_match,
     enforce_lysis_clean,
 )
-from lysis.tools.slurm import DEFAULT_COMPILER_MODULE, parse_sbatch_tokens
+from lysis.tools.slurm import DEFAULT_MODULES, parse_sbatch_tokens
 
 
 @cli.command(name="run-macro")
@@ -111,17 +111,19 @@ from lysis.tools.slurm import DEFAULT_COMPILER_MODULE, parse_sbatch_tokens
     help="Input file code suffix for macroscale_in files.",
 )
 @click.option(
-    "--compiler",
-    "compiler",
-    default=DEFAULT_COMPILER_MODULE,
+    "--modules",
+    "modules",
+    default=DEFAULT_MODULES,
     show_default=True,
-    metavar="MODULE",
+    metavar="MODULES",
     help=(
-        "LMod module spec providing the Fortran compiler runtime, loaded "
-        "by each generated Slurm script (e.g. ``intel-compilers/2024``).  "
-        "With --slurm, also wraps the historical-build ``make`` invocation "
-        "of --fortran-commit so the binary links against the same toolchain "
-        "the Slurm preamble will load.  Only meaningful with --slurm."
+        "Space-separated list of LMod module specs to ``module load`` in "
+        "each generated Slurm script (e.g. ``\"intel-compilers/2024 "
+        "SciPy-bundle/2023.07\"``).  Include a Fortran compiler module so "
+        "the simulation binary finds its runtime.  With --slurm, the same "
+        "list also wraps the historical-build ``make`` invocation of "
+        "--fortran-commit so the binary links against the matching "
+        "toolchain.  Only meaningful with --slurm."
     ),
 )
 @click.option(
@@ -172,7 +174,7 @@ from lysis.tools.slurm import DEFAULT_COMPILER_MODULE, parse_sbatch_tokens
 @allow_commit_mismatch_option
 @click.pass_context
 def run_macro(ctx, target_path, executable, use_slurm, partition, staging_root,
-              fast_tmp_root, keep_tmpdir, out_file_code, in_file_code, compiler,
+              fast_tmp_root, keep_tmpdir, out_file_code, in_file_code, modules,
               fortran_commit, sbatch_tokens, allow_stale_binary, allow_dirty,
               allow_commit_mismatch):
     """Execute the Fortran macroscale simulation for a Run or Experiment.
@@ -227,8 +229,8 @@ def run_macro(ctx, target_path, executable, use_slurm, partition, staging_root,
 
     # --fortran-commit: build the historical binary once up front, share its
     # path across every run in this invocation, tear down at the end.  Only
-    # load the compiler module around the build when Slurm jobs (which load
-    # the same module via the preamble) will be executing the binary.
+    # load the modules around the build when Slurm jobs (which load the same
+    # modules via the preamble) will be executing the binary.
     with contextlib.ExitStack() as stack:
         if fortran_commit is not None:
             from lysis.execution.historical_build import (
@@ -240,7 +242,7 @@ def run_macro(ctx, target_path, executable, use_slurm, partition, staging_root,
                     build_historical_binary(
                         fortran_commit,
                         executable,
-                        compiler_module=compiler if use_slurm else None,
+                        modules=modules if use_slurm else None,
                         keep_dir=keep_tmpdir,
                     )
                 )
@@ -277,7 +279,7 @@ def run_macro(ctx, target_path, executable, use_slurm, partition, staging_root,
                         keep_tmpdir=keep_tmpdir,
                         in_code=in_file_code,
                         out_code=out_file_code,
-                        compiler_module=compiler,
+                        modules=modules,
                         sbatch_overrides=sbatch_overrides,
                         historical_binary_attrs=historical_provenance,
                     )

--- a/src/lysis/cli/run_micro.py
+++ b/src/lysis/cli/run_micro.py
@@ -34,7 +34,7 @@ from lysis.cli._provenance import (
     enforce_init_commit_match,
     enforce_lysis_clean,
 )
-from lysis.tools.slurm import DEFAULT_COMPILER_MODULE, parse_sbatch_tokens
+from lysis.tools.slurm import DEFAULT_MODULES, parse_sbatch_tokens
 
 
 @cli.command(name="run-micro")
@@ -115,17 +115,19 @@ from lysis.tools.slurm import DEFAULT_COMPILER_MODULE, parse_sbatch_tokens
     ),
 )
 @click.option(
-    "--compiler",
-    "compiler",
-    default=DEFAULT_COMPILER_MODULE,
+    "--modules",
+    "modules",
+    default=DEFAULT_MODULES,
     show_default=True,
-    metavar="MODULE",
+    metavar="MODULES",
     help=(
-        "LMod module spec providing the Fortran compiler runtime, loaded "
-        "by each generated Slurm script (e.g. ``intel-compilers/2024``).  "
-        "With --slurm, also wraps the historical-build ``make`` invocation "
-        "of --fortran-commit so the binary links against the same toolchain "
-        "the Slurm preamble will load.  Only meaningful with --slurm."
+        "Space-separated list of LMod module specs to ``module load`` in "
+        "each generated Slurm script (e.g. ``\"intel-compilers/2024 "
+        "SciPy-bundle/2023.07\"``).  Include a Fortran compiler module so "
+        "the simulation binary finds its runtime.  With --slurm, the same "
+        "list also wraps the historical-build ``make`` invocation of "
+        "--fortran-commit so the binary links against the matching "
+        "toolchain.  Only meaningful with --slurm."
     ),
 )
 @click.option(
@@ -176,7 +178,7 @@ from lysis.tools.slurm import DEFAULT_COMPILER_MODULE, parse_sbatch_tokens
 @allow_commit_mismatch_option
 @click.pass_context
 def run_micro(ctx, target_path, executable, use_slurm, partition, staging_root,
-              fast_tmp_root, keep_tmpdir, file_code, num_children, compiler,
+              fast_tmp_root, keep_tmpdir, file_code, num_children, modules,
               fortran_commit, sbatch_tokens, allow_stale_binary, allow_dirty,
               allow_commit_mismatch):
     """Execute the Fortran microscale simulation for a Run or Experiment.
@@ -230,8 +232,8 @@ def run_micro(ctx, target_path, executable, use_slurm, partition, staging_root,
 
     # --fortran-commit: build the historical binary once up front, share its
     # path across every run in this invocation, tear down at the end.  Only
-    # load the compiler module around the build when Slurm jobs (which load
-    # the same module via the preamble) will be executing the binary.
+    # load the modules around the build when Slurm jobs (which load the same
+    # modules via the preamble) will be executing the binary.
     with contextlib.ExitStack() as stack:
         if fortran_commit is not None:
             from lysis.execution.historical_build import (
@@ -243,7 +245,7 @@ def run_micro(ctx, target_path, executable, use_slurm, partition, staging_root,
                     build_historical_binary(
                         fortran_commit,
                         executable,
-                        compiler_module=compiler if use_slurm else None,
+                        modules=modules if use_slurm else None,
                         keep_dir=keep_tmpdir,
                     )
                 )
@@ -282,7 +284,7 @@ def run_micro(ctx, target_path, executable, use_slurm, partition, staging_root,
                         keep_tmpdir=keep_tmpdir,
                         out_code=file_code,
                         num_children=nc_arg,
-                        compiler_module=compiler,
+                        modules=modules,
                         sbatch_overrides=sbatch_overrides,
                         historical_binary_attrs=historical_provenance,
                     )

--- a/src/lysis/execution/historical_build.py
+++ b/src/lysis/execution/historical_build.py
@@ -9,8 +9,8 @@ Backs the ``--fortran-commit <ref>`` flag on ``lysis run-micro`` and
    that SHA into a fresh temp directory (no worktree state, no
    collision with parallel CLI invocations).
 3. Run ``make`` inside the temp directory, capturing stdout/stderr to
-   ``.build_log``.  When a *compiler_module* is supplied, the build is
-   wrapped in ``bash -c 'module purge && module load <module> && …'``
+   ``.build_log``.  When *modules* is supplied, the build is
+   wrapped in ``bash -c 'module purge && module load <modules> && …'``
    so the binary links against the same toolchain that Slurm jobs will
    load at runtime.
 4. Compute a synthesised provenance dict via
@@ -130,18 +130,19 @@ def _archive_into(sha: str, repo_root: Path, build_dir: Path) -> None:
         )
 
 
-def _make_argv(build_dir: Path, compiler_module: Optional[str]) -> list[str]:
+def _make_argv(build_dir: Path, modules: Optional[str]) -> list[str]:
     """Build the argv that runs ``make`` in *build_dir*, optionally module-wrapped.
 
-    When *compiler_module* is given, the build is invoked inside a
-    short bash script that loads the requested LMod module first.
+    When *modules* is given, the build is invoked inside a
+    short bash script that ``module load``s the requested
+    (space-separated) LMod modules first.
     """
-    if compiler_module is None:
+    if modules is None:
         return ["make", "-C", str(build_dir)]
     script = (
         "[ -z \"${LMOD_CMD:-}\" ] && [ -f /etc/profile.d/lmod.sh ] "
         "&& source /etc/profile.d/lmod.sh; "
-        f"module purge && module load {compiler_module} && "
+        f"module purge && module load {modules} && "
         f'make -C "{build_dir}"'
     )
     return ["bash", "-c", script]
@@ -165,14 +166,14 @@ def build_historical_binary(
     ref: str,
     executable_name: str,
     *,
-    compiler_module: Optional[str] = None,
+    modules: Optional[str] = None,
     keep_dir: bool = False,
     repo_root: Optional[Path] = None,
 ) -> Iterator[tuple[Path, dict]]:
     """Build Fortran binaries at *ref* and yield ``(binary_path, provenance_dict)``.
 
     On context entry: resolves *ref*, extracts source via ``git archive``,
-    runs ``make`` (optionally inside ``module load <compiler_module>``),
+    runs ``make`` (optionally inside ``module load <modules>``),
     and computes a synthesised provenance dict.
 
     On context exit: removes the build directory unless ``keep_dir=True``.
@@ -185,12 +186,14 @@ def build_historical_binary(
         build; the full path returned in the yielded tuple is
         ``<build_dir>/bin/<basename>``.
     :type executable_name: str
-    :param compiler_module: LMod module spec (e.g.
-        ``"intel-compilers/2023"``) to load around ``make`` and the
-        compiler-version probe.  ``None`` (default) uses the current
-        environment; appropriate for local-mode runs where the same
-        environment will execute the binary.
-    :type compiler_module: str or None
+    :param modules: Space-separated list of LMod module specs (e.g.
+        ``"intel-compilers/2023"`` or
+        ``"intel-compilers/2024 SciPy-bundle/2023.07"``) to load around
+        ``make`` and the compiler-version probe.  Include a Fortran
+        compiler module so the build succeeds.  ``None`` (default) uses
+        the current environment; appropriate for local-mode runs where the
+        same environment will execute the binary.
+    :type modules: str or None
     :param keep_dir: Preserve the build directory after the context
         exits.  Useful for debugging.  Defaults to ``False``.
     :type keep_dir: bool, optional
@@ -227,7 +230,7 @@ def build_historical_binary(
         build_log = build_dir / ".build_log"
         with build_log.open("w") as fh:
             result = subprocess.run(
-                _make_argv(build_dir, compiler_module),
+                _make_argv(build_dir, modules),
                 stdout=fh,
                 stderr=subprocess.STDOUT,
                 check=False,
@@ -251,7 +254,7 @@ def build_historical_binary(
             binary_path,
             resolved_sha=resolved_sha,
             build_log=build_log,
-            compiler_module=compiler_module,
+            modules=modules,
         )
         yield binary_path, provenance
     except BaseException:

--- a/src/lysis/tools/provenance/binary.py
+++ b/src/lysis/tools/provenance/binary.py
@@ -398,23 +398,25 @@ def _probe_iso_fortran_env_compiler_version(
         return first[0].strip() or None
 
 
-def _module_wrapper_argv(compiler_module: Optional[str]) -> Optional[list[str]]:
-    """Build the bash-wrapper argv used to load an LMod module around a subprocess.
+def _module_wrapper_argv(modules: Optional[str]) -> Optional[list[str]]:
+    """Build the bash-wrapper argv used to load LMod modules around a subprocess.
 
-    :param compiler_module: LMod module spec, e.g. ``"intel-compilers/2023"``,
-        or ``None`` to skip wrapping.
-    :type compiler_module: str or None
+    :param modules: Space-separated list of LMod module specs, e.g.
+        ``"intel-compilers/2023"`` or
+        ``"intel-compilers/2024 SciPy-bundle/2023.07"``, forwarded verbatim
+        to ``module load``; or ``None`` to skip wrapping.
+    :type modules: str or None
     :return: argv list with ``"exec \"$@\""`` as the bash body so the
         wrapped command's exit status is preserved verbatim, or ``None``
-        when *compiler_module* is ``None``.
+        when *modules* is ``None``.
     :rtype: list[str] or None
     """
-    if compiler_module is None:
+    if modules is None:
         return None
     script = (
         "[ -z \"${LMOD_CMD:-}\" ] && [ -f /etc/profile.d/lmod.sh ] "
         "&& source /etc/profile.d/lmod.sh; "
-        f"module purge && module load {compiler_module} && exec \"$@\""
+        f"module purge && module load {modules} && exec \"$@\""
     )
     return ["bash", "-c", script, "--"]
 
@@ -424,7 +426,7 @@ def gather_historical_binary_provenance(
     *,
     resolved_sha: str,
     build_log: "Path | None" = None,
-    compiler_module: Optional[str] = None,
+    modules: Optional[str] = None,
 ) -> dict:
     """Build a binary-provenance dict for a binary rebuilt from an older commit.
 
@@ -459,11 +461,11 @@ def gather_historical_binary_provenance(
         and the result is ``"unknown"`` for *binary_compiler* in the
         synthesis path.
     :type build_log: pathlib.Path or None
-    :param compiler_module: LMod module spec to load around the stub
-        compile/run pair (e.g. ``"intel-compilers/2023"``).  Should match
-        the module that wrapped ``make``.  ``None`` (default) runs the
-        probe in the current environment.
-    :type compiler_module: str or None
+    :param modules: Space-separated list of LMod module specs to load
+        around the stub compile/run pair (e.g. ``"intel-compilers/2023"``).
+        Should match the modules that wrapped ``make``.  ``None`` (default)
+        runs the probe in the current environment.
+    :type modules: str or None
     :return: Dict keyed by :data:`CONST.BINARY_COMMIT_ATTR`,
         :data:`CONST.BINARY_DIRTY_ATTR`, :data:`CONST.BINARY_COMPILER_ATTR`,
         :data:`CONST.BINARY_SOURCE_ATTR`.  All values are strings;
@@ -485,7 +487,7 @@ def gather_historical_binary_provenance(
     else:
         probed = _probe_iso_fortran_env_compiler_version(
             compiler_name,
-            module_wrapper=_module_wrapper_argv(compiler_module),
+            module_wrapper=_module_wrapper_argv(modules),
         )
     return {
         CONST.BINARY_COMMIT_ATTR: resolved_sha,

--- a/src/lysis/tools/slurm.py
+++ b/src/lysis/tools/slurm.py
@@ -709,8 +709,9 @@ def generate_array_script(
     :param slurm_log_dir: Directory for Slurm ``.out`` logs.  Defaults to
         ``hdf5_path.parent / ".slurm"``.
     :type slurm_log_dir: Path or str, optional
-    :param modules: Space-separated list of LMod module specs (include a
-        Fortran compiler module so the binary finds its runtime), baked into each generated task script.  Defaults to
+    :param modules: Space-separated list of LMod module specs to load in
+        each generated task script (include a Fortran compiler module so
+        the binary finds its runtime).  Defaults to
         :data:`DEFAULT_MODULES`.
     :type modules: str, optional
     :param sbatch_overrides: User overrides for the per-task ``#SBATCH``

--- a/src/lysis/tools/slurm.py
+++ b/src/lysis/tools/slurm.py
@@ -92,16 +92,17 @@ def _require_gs():
 #
 # Generated scripts no longer depend on per-user dotfiles (``~/.bashrc`` /
 # ``~/lysis.sh``).  Instead, every script emits a self-contained preamble
-# that loads the Intel compiler runtime via LMod and invokes Python through
-# the project's ``uv``-managed environment.  The submitting user's repo
-# root is baked in at script-generation time from ``lysis.__file__``.
+# that loads the requested LMod modules and invokes Python through the
+# project's ``uv``-managed environment.  The submitting user's repo root is
+# baked in at script-generation time from ``lysis.__file__``.
 
-#: Default LMod module providing the Fortran binary's runtime libraries.
-#: Assumed to be available on the cluster's LMod stack for all users.
-#: Callers can override per-job via the ``compiler_module`` keyword argument
-#: on the public submit/generate functions (exposed as ``--compiler`` on the
-#: ``lysis run-micro`` and ``lysis run-macro`` CLI commands).
-DEFAULT_COMPILER_MODULE: str = "intel-compilers/2023"
+#: Default space-separated list of LMod modules providing the Fortran
+#: binary's runtime libraries.  Assumed to be available on the cluster's
+#: LMod stack for all users.  Callers can override per-job via the
+#: ``modules`` keyword argument on the public submit/generate functions
+#: (exposed as ``--modules`` on the ``lysis run-micro`` and
+#: ``lysis run-macro`` CLI commands).
+DEFAULT_MODULES: str = "intel-compilers/2023"
 
 
 def _repo_root() -> Path:
@@ -119,16 +120,17 @@ def _repo_root() -> Path:
 
 def _env_preamble(
     repo_root: Path,
-    compiler_module: str,
+    modules: str,
     *,
     pythonpath: "Path | str | None" = None,
 ) -> str:
     """Return the bash preamble that prepares a generated script's environment.
 
-    Loads the requested Fortran compiler runtime via LMod (required by the
-    Fortran binary) and puts ``~/.local/bin`` on PATH so ``uv`` is
-    discoverable on compute nodes.  Defensive against non-login shells by
-    sourcing ``lmod.sh`` when the ``module`` function isn't already defined.
+    Loads the requested LMod modules (which should include the Fortran
+    compiler runtime required by the Fortran binary) and puts
+    ``~/.local/bin`` on PATH so ``uv`` is discoverable on compute nodes.
+    Defensive against non-login shells by sourcing ``lmod.sh`` when the
+    ``module`` function isn't already defined.
 
     When *pythonpath* is supplied, an ``export PYTHONPATH=...`` line is
     appended.  ``uv run`` inherits environment variables from the calling
@@ -140,10 +142,12 @@ def _env_preamble(
         unused inside the preamble itself; included for future extensions
         like ``cd`` into the repo).
     :type repo_root: Path
-    :param compiler_module: LMod module spec to load (e.g.
-        ``"intel-compilers/2023"`` or ``"intel-compilers/2024"``).  See
-        :data:`DEFAULT_COMPILER_MODULE` for the project default.
-    :type compiler_module: str
+    :param modules: Space-separated list of LMod module specs to load (e.g.
+        ``"intel-compilers/2023"`` or
+        ``"intel-compilers/2024 SciPy-bundle/2023.07"``).  Forwarded
+        verbatim to ``module load``.  See :data:`DEFAULT_MODULES` for the
+        project default.
+    :type modules: str
     :param pythonpath: When set, exported as ``PYTHONPATH`` so generated
         scripts import ``lysis`` from that path rather than the live
         editable install (see :func:`_snapshot_lysis_src`).  ``None``
@@ -156,7 +160,7 @@ def _env_preamble(
         "# Lysis environment setup (user-independent)",
         "[ -z \"${LMOD_CMD:-}\" ] && [ -f /etc/profile.d/lmod.sh ] "
         "&& source /etc/profile.d/lmod.sh",
-        f"module purge && module load {compiler_module}",
+        f"module purge && module load {modules}",
         'export PATH="$HOME/.local/bin:$PATH"',
     ]
     if pythonpath is not None:
@@ -661,7 +665,7 @@ def generate_array_script(
     partition: Optional[str] = None,
     fast_tmp_root: Optional[str] = None,
     slurm_log_dir: Optional["Path | str"] = None,
-    compiler_module: str = DEFAULT_COMPILER_MODULE,
+    modules: str = DEFAULT_MODULES,
     sbatch_overrides: Optional[Mapping[str, Optional[str]]] = None,
     historical_binary_attrs: Optional[dict] = None,
     pythonpath: "Path | str | None" = None,
@@ -705,10 +709,10 @@ def generate_array_script(
     :param slurm_log_dir: Directory for Slurm ``.out`` logs.  Defaults to
         ``hdf5_path.parent / ".slurm"``.
     :type slurm_log_dir: Path or str, optional
-    :param compiler_module: LMod module spec for the Fortran compiler
-        runtime, baked into each generated task script.  Defaults to
-        :data:`DEFAULT_COMPILER_MODULE`.
-    :type compiler_module: str, optional
+    :param modules: Space-separated list of LMod module specs (include a
+        Fortran compiler module so the binary finds its runtime), baked into each generated task script.  Defaults to
+        :data:`DEFAULT_MODULES`.
+    :type modules: str, optional
     :param sbatch_overrides: User overrides for the per-task ``#SBATCH``
         header, in the shape returned by :func:`parse_sbatch_tokens`.
         A ``None`` value removes the matching default; any other value
@@ -753,7 +757,7 @@ def generate_array_script(
 
     repo_root = _repo_root()
     env_preamble = _env_preamble(
-        repo_root, compiler_module, pythonpath=pythonpath
+        repo_root, modules, pythonpath=pythonpath
     )
     py = _uv_python_prefix(repo_root)
 
@@ -854,7 +858,7 @@ def submit_slurm_job(
     partition: Optional[str] = None,
     fast_tmp_root: Optional[str] = None,
     keep_tmpdir: bool = False,
-    compiler_module: str = DEFAULT_COMPILER_MODULE,
+    modules: str = DEFAULT_MODULES,
     sbatch_overrides: Optional[Mapping[str, Optional[str]]] = None,
     historical_binary_attrs: Optional[dict] = None,
 ) -> int:
@@ -880,10 +884,10 @@ def submit_slurm_job(
     :type fast_tmp_root: str, optional
     :param keep_tmpdir: Preserve staging dir after the master job.
     :type keep_tmpdir: bool, optional
-    :param compiler_module: LMod module spec for the Fortran compiler
-        runtime, baked into both the master and array task scripts.
-        Defaults to :data:`DEFAULT_COMPILER_MODULE`.
-    :type compiler_module: str, optional
+    :param modules: Space-separated list of LMod module specs (include a
+        Fortran compiler module so the binary finds its runtime), baked into both the master and array task scripts.
+        Defaults to :data:`DEFAULT_MODULES`.
+    :type modules: str, optional
     :param sbatch_overrides: User overrides for the ``#SBATCH`` header,
         applied to BOTH the master job and each array task (shape returned
         by :func:`parse_sbatch_tokens`).  Defaults to ``None``.
@@ -967,7 +971,7 @@ def submit_slurm_job(
         spec, staging_dir, run_code, hdf5_path, executable,
         partition=partition, fast_tmp_root=fast_tmp_root,
         slurm_log_dir=slurm_log_dir,
-        compiler_module=compiler_module,
+        modules=modules,
         sbatch_overrides=sbatch_overrides,
         historical_binary_attrs=historical_binary_attrs,
         pythonpath=pythonpath,
@@ -1005,7 +1009,7 @@ def submit_slurm_job(
 
     master_sh_content = gs.scripts.plain(
         [
-            _env_preamble(repo_root, compiler_module, pythonpath=pythonpath),
+            _env_preamble(repo_root, modules, pythonpath=pythonpath),
             f'{_uv_python_prefix(repo_root)} "{master_py_path}"',
         ],
         **sbatch_opts,
@@ -1032,7 +1036,7 @@ def generate_micro_child_script(
     partition: Optional[str] = None,
     fast_tmp_root: Optional[str] = None,
     slurm_log_dir: Optional["Path | str"] = None,
-    compiler_module: str = DEFAULT_COMPILER_MODULE,
+    modules: str = DEFAULT_MODULES,
     sbatch_overrides: Optional[Mapping[str, Optional[str]]] = None,
     historical_binary_attrs: Optional[dict] = None,
     pythonpath: "Path | str | None" = None,
@@ -1073,10 +1077,10 @@ def generate_micro_child_script(
     :param slurm_log_dir: Directory for Slurm ``.out`` logs.  Defaults to
         ``hdf5_path.parent / ".slurm"``.
     :type slurm_log_dir: Path or str, optional
-    :param compiler_module: LMod module spec for the Fortran compiler
-        runtime, baked into the generated script.  Defaults to
-        :data:`DEFAULT_COMPILER_MODULE`.
-    :type compiler_module: str, optional
+    :param modules: Space-separated list of LMod module specs (include a
+        Fortran compiler module so the binary finds its runtime), baked into the generated script.  Defaults to
+        :data:`DEFAULT_MODULES`.
+    :type modules: str, optional
     :param sbatch_overrides: User overrides for the child's ``#SBATCH``
         header (shape returned by :func:`parse_sbatch_tokens`).  Defaults
         to ``None``.
@@ -1118,7 +1122,7 @@ def generate_micro_child_script(
 
     repo_root = _repo_root()
     env_preamble = _env_preamble(
-        repo_root, compiler_module, pythonpath=pythonpath
+        repo_root, modules, pythonpath=pythonpath
     )
     py = _uv_python_prefix(repo_root)
 
@@ -1283,7 +1287,7 @@ def generate_micro_array_script(
     partition: Optional[str] = None,
     fast_tmp_root: Optional[str] = None,
     slurm_log_dir: Optional["Path | str"] = None,
-    compiler_module: str = DEFAULT_COMPILER_MODULE,
+    modules: str = DEFAULT_MODULES,
     sbatch_overrides: Optional[Mapping[str, Optional[str]]] = None,
     historical_binary_attrs: Optional[dict] = None,
 ) -> str:
@@ -1314,7 +1318,7 @@ def generate_micro_array_script(
         spec, staging_dir, run_code, hdf5_path, executable,
         partition=partition, fast_tmp_root=fast_tmp_root,
         slurm_log_dir=slurm_log_dir,
-        compiler_module=compiler_module,
+        modules=modules,
         sbatch_overrides=sbatch_overrides,
         historical_binary_attrs=historical_binary_attrs,
     )
@@ -1330,7 +1334,7 @@ def submit_micro_slurm_job(
     keep_tmpdir: bool = False,
     out_code: str = "",
     num_children: Optional[int] = None,
-    compiler_module: str = DEFAULT_COMPILER_MODULE,
+    modules: str = DEFAULT_MODULES,
     sbatch_overrides: Optional[Mapping[str, Optional[str]]] = None,
     historical_binary_attrs: Optional[dict] = None,
 ) -> int:
@@ -1384,11 +1388,11 @@ def submit_micro_slurm_job(
         across that many tasks.  ``None`` (default) selects the legacy
         single-child path.
     :type num_children: int, optional
-    :param compiler_module: LMod module spec for the Fortran compiler
-        runtime, baked into every generated script (master, array tasks,
+    :param modules: Space-separated list of LMod module specs (include a
+        Fortran compiler module so the binary finds its runtime), baked into every generated script (master, array tasks,
         and the legacy single child).  Defaults to
-        :data:`DEFAULT_COMPILER_MODULE`.
-    :type compiler_module: str, optional
+        :data:`DEFAULT_MODULES`.
+    :type modules: str, optional
     :param sbatch_overrides: User overrides for the ``#SBATCH`` header,
         applied to BOTH the master and child/array task scripts (shape
         returned by :func:`parse_sbatch_tokens`).  Defaults to ``None``.
@@ -1443,7 +1447,7 @@ def submit_micro_slurm_job(
             spec, hdf5_path, executable, staging_root_dir,
             partition=partition, fast_tmp_root=fast_tmp_root,
             keep_tmpdir=keep_tmpdir,
-            compiler_module=compiler_module,
+            modules=modules,
             sbatch_overrides=sbatch_overrides,
             historical_binary_attrs=historical_binary_attrs,
         )
@@ -1502,7 +1506,7 @@ def submit_micro_slurm_job(
         staging_dir, run_code, hdf5_path, executable, out_code,
         partition=partition, fast_tmp_root=fast_tmp_root,
         slurm_log_dir=slurm_log_dir,
-        compiler_module=compiler_module,
+        modules=modules,
         sbatch_overrides=sbatch_overrides,
         historical_binary_attrs=historical_binary_attrs,
         pythonpath=pythonpath,
@@ -1540,7 +1544,7 @@ def submit_micro_slurm_job(
 
     master_sh_content = gs.scripts.plain(
         [
-            _env_preamble(repo_root, compiler_module, pythonpath=pythonpath),
+            _env_preamble(repo_root, modules, pythonpath=pythonpath),
             f'{_uv_python_prefix(repo_root)} "{master_py_path}"',
         ],
         **sbatch_opts,
@@ -1585,7 +1589,7 @@ def generate_macro_array_script(
     partition: Optional[str] = None,
     fast_tmp_root: Optional[str] = None,
     slurm_log_dir: Optional["Path | str"] = None,
-    compiler_module: str = DEFAULT_COMPILER_MODULE,
+    modules: str = DEFAULT_MODULES,
     sbatch_overrides: Optional[Mapping[str, Optional[str]]] = None,
     historical_binary_attrs: Optional[dict] = None,
 ) -> str:
@@ -1614,7 +1618,7 @@ def generate_macro_array_script(
         spec, staging_dir, run_code, hdf5_path, executable,
         partition=partition, fast_tmp_root=fast_tmp_root,
         slurm_log_dir=slurm_log_dir,
-        compiler_module=compiler_module,
+        modules=modules,
         sbatch_overrides=sbatch_overrides,
         historical_binary_attrs=historical_binary_attrs,
     )
@@ -1630,7 +1634,7 @@ def submit_macro_slurm_job(
     keep_tmpdir: bool = False,
     in_code: str = "",
     out_code: str = "",
-    compiler_module: str = DEFAULT_COMPILER_MODULE,
+    modules: str = DEFAULT_MODULES,
     sbatch_overrides: Optional[Mapping[str, Optional[str]]] = None,
     historical_binary_attrs: Optional[dict] = None,
 ) -> int:
@@ -1676,10 +1680,10 @@ def submit_macro_slurm_job(
     :param out_code: Output file code suffix for the Fortran binary,
         defaults to ``""``.
     :type out_code: str, optional
-    :param compiler_module: LMod module spec for the Fortran compiler
-        runtime, baked into the generated master and array task scripts.
-        Defaults to :data:`DEFAULT_COMPILER_MODULE`.
-    :type compiler_module: str, optional
+    :param modules: Space-separated list of LMod module specs (include a
+        Fortran compiler module so the binary finds its runtime), baked into the generated master and array task scripts.
+        Defaults to :data:`DEFAULT_MODULES`.
+    :type modules: str, optional
     :param sbatch_overrides: User overrides for the ``#SBATCH`` header,
         applied to BOTH the master and array task scripts (shape returned
         by :func:`parse_sbatch_tokens`).  Defaults to ``None``.
@@ -1720,7 +1724,7 @@ def submit_macro_slurm_job(
         spec, hdf5_path, executable, staging_root_dir,
         partition=partition, fast_tmp_root=fast_tmp_root,
         keep_tmpdir=keep_tmpdir,
-        compiler_module=compiler_module,
+        modules=modules,
         sbatch_overrides=sbatch_overrides,
         historical_binary_attrs=historical_binary_attrs,
     )

--- a/tests/cli/test_run_macro.py
+++ b/tests/cli/test_run_macro.py
@@ -347,9 +347,9 @@ class TestRunMacroSlurm:
         assert call_kwargs.get("out_code") == "_out"
 
     @patch("lysis.tools.slurm.submit_macro_slurm_job", return_value=1)
-    def test_compiler_default_is_forwarded(self, mock_submit, runner, macro_hdf5):
-        """Without --compiler, the default module spec must be forwarded."""
-        from lysis.tools.slurm import DEFAULT_COMPILER_MODULE
+    def test_modules_default_is_forwarded(self, mock_submit, runner, macro_hdf5):
+        """Without --modules, the default module spec must be forwarded."""
+        from lysis.tools.slurm import DEFAULT_MODULES
         result = runner.invoke(
             cli,
             [
@@ -360,25 +360,25 @@ class TestRunMacroSlurm:
         )
         assert result.exit_code == 0, result.output
         assert (
-            mock_submit.call_args.kwargs.get("compiler_module")
-            == DEFAULT_COMPILER_MODULE
+            mock_submit.call_args.kwargs.get("modules")
+            == DEFAULT_MODULES
         )
 
     @patch("lysis.tools.slurm.submit_macro_slurm_job", return_value=1)
-    def test_compiler_override_is_forwarded(self, mock_submit, runner, macro_hdf5):
-        """--compiler=foo/2024 must reach submit_macro_slurm_job."""
+    def test_modules_override_is_forwarded(self, mock_submit, runner, macro_hdf5):
+        """--modules=foo/2024 must reach submit_macro_slurm_job."""
         result = runner.invoke(
             cli,
             [
                 "run-macro", str(macro_hdf5),
                 "--executable", "/bin/macro.exe",
                 "--slurm",
-                "--compiler", "intel-compilers/2024",
+                "--modules", "intel-compilers/2024",
             ],
         )
         assert result.exit_code == 0, result.output
         assert (
-            mock_submit.call_args.kwargs.get("compiler_module")
+            mock_submit.call_args.kwargs.get("modules")
             == "intel-compilers/2024"
         )
 
@@ -558,8 +558,8 @@ class TestRunMacroFortranCommit:
 
         @contextmanager
         def fake_cm(*args, **kwargs):
-            # Local mode: compiler_module should be None.
-            assert kwargs.get("compiler_module") is None
+            # Local mode: modules should be None.
+            assert kwargs.get("modules") is None
             yield fake_binary, prov
 
         mock_build.side_effect = fake_cm
@@ -598,7 +598,7 @@ class TestRunMacroFortranCommit:
 
         @contextmanager
         def fake_cm(*args, **kwargs):
-            assert kwargs.get("compiler_module") == "intel-compilers/2024"
+            assert kwargs.get("modules") == "intel-compilers/2024"
             yield fake_binary, prov
 
         mock_build.side_effect = fake_cm
@@ -609,7 +609,7 @@ class TestRunMacroFortranCommit:
                 "--executable", "macro_diffuse_into_and_along__internal",
                 "--fortran-commit", "HEAD",
                 "--slurm",
-                "--compiler", "intel-compilers/2024",
+                "--modules", "intel-compilers/2024",
             ],
         )
         assert result.exit_code == 0, result.output

--- a/tests/cli/test_run_micro.py
+++ b/tests/cli/test_run_micro.py
@@ -315,9 +315,9 @@ class TestRunMicroSlurm:
         assert mock_submit.call_args.kwargs.get("num_children") is None
 
     @patch("lysis.tools.slurm.submit_micro_slurm_job", return_value=1)
-    def test_compiler_default_is_forwarded(self, mock_submit, runner, micro_hdf5):
-        """Without --compiler, the default module spec must be forwarded."""
-        from lysis.tools.slurm import DEFAULT_COMPILER_MODULE
+    def test_modules_default_is_forwarded(self, mock_submit, runner, micro_hdf5):
+        """Without --modules, the default module spec must be forwarded."""
+        from lysis.tools.slurm import DEFAULT_MODULES
         result = runner.invoke(
             cli,
             [
@@ -328,25 +328,25 @@ class TestRunMicroSlurm:
         )
         assert result.exit_code == 0, result.output
         assert (
-            mock_submit.call_args.kwargs.get("compiler_module")
-            == DEFAULT_COMPILER_MODULE
+            mock_submit.call_args.kwargs.get("modules")
+            == DEFAULT_MODULES
         )
 
     @patch("lysis.tools.slurm.submit_micro_slurm_job", return_value=1)
-    def test_compiler_override_is_forwarded(self, mock_submit, runner, micro_hdf5):
-        """--compiler=foo/2024 must reach submit_micro_slurm_job."""
+    def test_modules_override_is_forwarded(self, mock_submit, runner, micro_hdf5):
+        """--modules=foo/2024 must reach submit_micro_slurm_job."""
         result = runner.invoke(
             cli,
             [
                 "run-micro", str(micro_hdf5),
                 "--executable", "/bin/micro.exe",
                 "--slurm",
-                "--compiler", "intel-compilers/2024",
+                "--modules", "intel-compilers/2024",
             ],
         )
         assert result.exit_code == 0, result.output
         assert (
-            mock_submit.call_args.kwargs.get("compiler_module")
+            mock_submit.call_args.kwargs.get("modules")
             == "intel-compilers/2024"
         )
 
@@ -786,8 +786,8 @@ class TestRunMicroFortranCommit:
 
         @contextmanager
         def fake_cm(*args, **kwargs):
-            # In slurm mode we should pass compiler_module=<the --compiler value>.
-            assert kwargs.get("compiler_module") == "intel-compilers/2024"
+            # In slurm mode we should pass modules=<the --modules value>.
+            assert kwargs.get("modules") == "intel-compilers/2024"
             yield fake_binary, prov
 
         mock_build.side_effect = fake_cm
@@ -798,7 +798,7 @@ class TestRunMicroFortranCommit:
                 "--executable", "micro_rates",
                 "--fortran-commit", "HEAD",
                 "--slurm",
-                "--compiler", "intel-compilers/2024",
+                "--modules", "intel-compilers/2024",
             ],
         )
         assert result.exit_code == 0, result.output

--- a/tests/tools/test_slurm.py
+++ b/tests/tools/test_slurm.py
@@ -230,26 +230,38 @@ class TestGenerateMicroChildScript:
         assert "lysis.execution.fortran_micro" in script
         assert "codeutil" not in script
 
-    def test_default_compiler_module_in_preamble(self, tmp_path):
-        """Without compiler_module, the default LMod spec is loaded."""
-        from lysis.tools.slurm import DEFAULT_COMPILER_MODULE
+    def test_default_modules_in_preamble(self, tmp_path):
+        """Without modules, the default LMod spec is loaded."""
+        from lysis.tools.slurm import DEFAULT_MODULES
         staging = tmp_path / "staging"
         script = generate_micro_child_script(
             staging, "run-01", tmp_path / "run-01.h5",
             "/bin/micro.exe", "",
         )
-        assert f"module load {DEFAULT_COMPILER_MODULE}" in script
+        assert f"module load {DEFAULT_MODULES}" in script
 
-    def test_custom_compiler_module_in_preamble(self, tmp_path):
-        """compiler_module override must appear in the module-load line."""
+    def test_custom_modules_in_preamble(self, tmp_path):
+        """modules override must appear in the module-load line."""
         staging = tmp_path / "staging"
         script = generate_micro_child_script(
             staging, "run-01", tmp_path / "run-01.h5",
             "/bin/micro.exe", "",
-            compiler_module="intel-compilers/2024.2.0",
+            modules="intel-compilers/2024.2.0",
         )
         assert "module load intel-compilers/2024.2.0" in script
         assert "module load intel-compilers/2023" not in script
+
+    def test_space_separated_modules_in_preamble(self, tmp_path):
+        """A space-separated module list is forwarded verbatim to module load."""
+        staging = tmp_path / "staging"
+        script = generate_micro_child_script(
+            staging, "run-01", tmp_path / "run-01.h5",
+            "/bin/micro.exe", "",
+            modules="intel-compilers/2024 SciPy-bundle/2023.07",
+        )
+        assert (
+            "module load intel-compilers/2024 SciPy-bundle/2023.07" in script
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #64.

## Summary

Renames the `--compiler` flag on `lysis run-macro` and `lysis run-micro` to `--modules`. The flag value is interpolated verbatim into `module load <value>` in every generated Slurm preamble, the historical-build `make` wrapper, and the `iso_fortran_env` compiler-version probe — and LMod's `module load` already accepts a space-separated list. The old name hid that capability behind a misleading label.

**Rename only, no behaviour change.** Passing `--modules "intel-compilers/2024 SciPy-bundle/2023.07"` loads both modules in the generated preamble.

## Changes

- **CLI** (`run_macro.py`, `run_micro.py`): `--compiler` → `--modules` (Click param `compiler` → `modules`); help text now describes a quoted space-separated module list.
- **`tools/slurm.py`**: `DEFAULT_COMPILER_MODULE` → `DEFAULT_MODULES`; `compiler_module` kwarg → `modules` on every function; comment + all `:param modules:` docstrings reworded for list semantics.
- **`execution/historical_build.py`** and **`tools/provenance/binary.py`**: same `compiler_module` → `modules` rename + docstring updates.
- **Tests**: renamed `--compiler`/`compiler_module`/`DEFAULT_COMPILER_MODULE` references and the two `test_compiler_*` functions; added `test_space_separated_modules_in_preamble` verifying a list reaches `module load` verbatim.
- **Docs** (`historical_fortran.rst`): "Compiler module" → "LMod modules"; documents loading several modules at once (with a quoting note).

## Hard break

Matching the #36 / #63 precedent, `--compiler` is no longer recognised — no Click deprecation alias.

## Acceptance criteria

- [x] `--modules "intel-compilers/2024"` and `--modules "intel-compilers/2024 SciPy-bundle/2023.07"` both work; the latter loads both modules in the preamble.
- [x] `run-micro` same.
- [x] `--compiler` no longer recognised (`Error: No such option: --compiler`).
- [x] No remaining `compiler_module` / `DEFAULT_COMPILER_MODULE` references in `src/lysis/` or `tests/`.
- [x] `--help` and `historical_fortran.rst` describe the space-separated-list capability explicitly.
- [x] Full suite passes.

## Testing

Rebuilt the Fortran binaries (`intel-compilers/2023`, `make` + `make shared`) and ran the full suite: **1930 passed, 16 skipped, 0 failures/errors** (63 benign provenance warnings, consistent with baseline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)