### PR TITLE
Clean up HDF5 provenance attributes: pipeline_*, backend_*, 3-state dirty (#61)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -50,9 +50,10 @@ Changed
   (``"fortran"`` / ``"python"``) self-identifies the engine, and the redundant
   ``binary_source = "historical:<sha>"`` marker is replaced by a boolean
   ``backend_historical`` (the SHA already lives in ``backend_commit``). This is
-  a hard break for the v2.0.0 on-disk format; existing files can be migrated in
-  place with ``scripts/migrate_provenance_attrs.py`` (dry-run by default, with
-  per-dataset checksum verification). (#61)
+  a hard break for the v2.0.0 on-disk format; existing files were migrated in
+  place with ``archive/scripts/migrate_provenance_attrs.py`` (a completed
+  one-off, kept as a template; dry-run by default, with per-dataset checksum
+  verification). (#61)
 - Renamed the macroscale simulation module ``lysis.np_macroscale`` to
   ``lysis.macroscale``. The ``np_`` prefix distinguished it from a since-removed
   CuPy/GPU sibling and no longer means anything. ``MacroscaleSim`` is still

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -40,6 +40,19 @@ Unreleased
 Changed
 -------
 
+- Cleaned up the HDF5 provenance attribute schema stamped onto the
+  ``micro_data`` / ``macro_data`` groups. The ``execution_*`` family is renamed
+  to ``pipeline_*`` (it records the lysis Python pipeline, not the simulation
+  engine) and the ``binary_*`` family to ``backend_*`` (so it can describe a
+  future Python backend). All ``*_dirty`` fields are now the 3-state string
+  ``"clean"`` / ``"dirty"`` / ``"unknown"`` (``execution_dirty`` was previously
+  a bool that hid the ``"unknown"`` case). A new ``backend_type`` attribute
+  (``"fortran"`` / ``"python"``) self-identifies the engine, and the redundant
+  ``binary_source = "historical:<sha>"`` marker is replaced by a boolean
+  ``backend_historical`` (the SHA already lives in ``backend_commit``). This is
+  a hard break for the v2.0.0 on-disk format; existing files can be migrated in
+  place with ``scripts/migrate_provenance_attrs.py`` (dry-run by default, with
+  per-dataset checksum verification). (#61)
 - Renamed the macroscale simulation module ``lysis.np_macroscale`` to
   ``lysis.macroscale``. The ``np_`` prefix distinguished it from a since-removed
   CuPy/GPU sibling and no longer means anything. ``MacroscaleSim`` is still

--- a/archive/README.rst
+++ b/archive/README.rst
@@ -180,3 +180,47 @@ Dead package module (formerly ``src/lysis/molecule.py``):
 Note: the usage guides ``docs/source/usage/fortran_microscale.rst`` and
 ``fortran_macroscale.rst`` still walk through the archived shell scripts and
 ``micro_to_macro.py``; they should be updated to the CLI workflow.
+
+One-off data migrations (``scripts/``)
+--------------------------------------
+
+Completed, single-use scripts that performed an in-place rewrite of existing
+HDF5 data files. They are **not** part of the CLI and have already run to
+completion against every affected file; they are preserved only as worked
+**templates** for future migrations of the same shape (open each file, edit
+only attributes, verify per-dataset checksums, back up, log).
+
+**Safety valve.** Each script defines a single module-level line near the top::
+
+    _SAFETY_VALVE = True
+
+While that line is present the script refuses to write --- ``--apply`` is forced
+to a dry-run (and the SHA-backfill script refuses to run at all). This prevents
+anyone from re-running a finished migration by accident. To reuse one as a
+template, copy it out and **delete that one line** to re-enable ``--apply``.
+
+The reusable pure transform that the migration driver depends on lives in the
+package (``lysis.tools.provenance.migrate.migrate_provenance_group``), not here,
+so it stays unit-tested (``tests/tools/test_provenance_migrate.py``).
+
+Files:
+
+- ``migrate_provenance_attrs.py`` --- issue #61 provenance-attribute migration
+  (``execution_* -> pipeline_*``, ``binary_* -> backend_*``, 3-state
+  ``*_dirty``, ``backend_type``, ``backend_historical``). Dry-run by default;
+  classifies every ``*.h5`` (will-migrate / already-migrated / not-v2.0.0 /
+  not-mine / not-writable / read-error), backs each file up (``--backup-dir``),
+  edits only the provenance attrs, then reopens the file and verifies every
+  dataset's SHA-256 plus all untouched attributes are unchanged --- halting on
+  the first mismatch and naming the file. Parallel via ``-j``;
+  ``--include-other-owners`` opts in to group-writable files owned by others.
+  Typical invocation as a template (after removing the safety valve)::
+
+      python migrate_provenance_attrs.py <root> --apply \
+          --backup-dir ~/prov_backup -j 8 --report /tmp/migration.txt
+
+- ``backfill_provenance_sha.py`` --- companion that reconstructs the per-file
+  ``<flattened>.sha256.txt`` audit sidecars for files migrated before that
+  logging existed, by checksumming each backup (pre-edit) against the live file
+  (post-edit) and flagging any data difference. Reuses the sibling script's
+  manifest/checksum helpers.

--- a/archive/scripts/backfill_provenance_sha.py
+++ b/archive/scripts/backfill_provenance_sha.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python
+"""Backfill per-file SHA-256 sidecars for already-migrated HDF5 files (issue #61).
+
+Companion one-off to ``migrate_provenance_attrs.py``.  The earliest migration
+runs predated the per-file ``.sha256.txt`` sidecar, so this script reconstructs
+that audit trail after the fact: for every backup the migration made, it
+checksums the backup copy (== pre-edit) and the live file (== post-edit), writes
+the sidecar next to the backup, and flags any dataset whose checksum differs
+between the two (a post-hoc proof that the migration changed only attributes,
+never data — expected: zero mismatches).
+
+ARCHIVED: like its sibling this is a completed one-off, kept as a template.
+See ``archive/README.rst``.  The SAFETY VALVE below blocks it from running
+until the marked line is removed.
+"""
+import concurrent.futures as cf
+import glob
+import importlib.util
+import os
+import sys
+
+# ===========================================================================
+# SAFETY VALVE  (archived one-off — issue #61)
+# ---------------------------------------------------------------------------
+# This script already ran once.  While the line below is present it refuses to
+# do anything (it writes .sha256.txt sidecars, so it is gated like its sibling).
+# DELETE the single line below to actually run it when reusing as a template.
+_SAFETY_VALVE = True
+# ===========================================================================
+
+# Reuse the migration script's checksum/manifest helpers from the sibling file.
+_SIBLING = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                        "migrate_provenance_attrs.py")
+_spec = importlib.util.spec_from_file_location("_migrate_sibling", _SIBLING)
+m = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(m)
+
+# (root, backup_dir) pairs to reconcile.  Adjust to match the actual backup
+# locations used by the original migration run.
+PAIRS = [
+    (os.path.expanduser("~/git/UCO-OpResearch/lysis/data"),
+     os.path.expanduser("~/prov_backup_local")),
+    ("/shared/lysis-group", os.path.expanduser("~/prov_backup_shared")),
+]
+
+
+def worker(bdir, bf, live):
+    backup_path = os.path.join(bdir, bf)
+    pre = m._build_manifest(backup_path)        # backup == pre-edit
+    if live is None:
+        return ("ORPHAN", bf, [])
+    post = m._build_manifest(live)              # live == post-edit
+    m._write_sha_log(bdir, live, pre, post)     # sidecar name == bf + .sha256.txt
+    diffs = [n for n, sig in pre["datasets"].items()
+             if post["datasets"].get(n) != sig]
+    if set(pre["datasets"]) != set(post["datasets"]):
+        diffs.append("<dataset-set-changed>")
+    return ("OK" if not diffs else "MISMATCH", bf, diffs)
+
+
+def main():
+    if globals().get("_SAFETY_VALVE", False):
+        print(
+            "SAFETY VALVE ENGAGED: this is an archived one-off; refusing to run.\n"
+            "Delete the `_SAFETY_VALVE = True` line near the top to enable it "
+            "(see archive/README.rst).",
+            flush=True,
+        )
+        return 0
+
+    tasks = []
+    for root, bdir in PAIRS:
+        if not os.path.isdir(bdir):
+            continue
+        livemap = {m._backup_basename(p): p
+                   for p in glob.iglob(os.path.join(root, "**", "*.h5"), recursive=True)}
+        for bf in os.listdir(bdir):
+            if bf.endswith(".sha256.txt"):
+                continue
+            if os.path.exists(os.path.join(bdir, bf + ".sha256.txt")):
+                continue  # already has a sidecar
+            tasks.append((bdir, bf, livemap.get(bf)))
+
+    print(f"backfilling {len(tasks)} sidecar(s) across {PAIRS}", flush=True)
+    ok = orphan = 0
+    mismatches = []
+    with cf.ProcessPoolExecutor(max_workers=8) as ex:
+        futs = {ex.submit(worker, *t): t[1] for t in tasks}
+        done = 0
+        for fut in cf.as_completed(futs):
+            status, bf, diffs = fut.result()
+            done += 1
+            if status == "OK":
+                ok += 1
+            elif status == "ORPHAN":
+                orphan += 1
+                print(f"  ORPHAN (no live file): {bf}", flush=True)
+            else:
+                mismatches.append((bf, diffs))
+                print(f"  !!! MISMATCH {bf}: {diffs}", flush=True)
+            if done % 100 == 0:
+                print(f"  ...{done}/{len(tasks)}", flush=True)
+
+    print(f"\nDONE. sidecars OK={ok}  orphan={orphan}  mismatched={len(mismatches)}", flush=True)
+    if mismatches:
+        print("MISMATCHES (data differs between backup and live — investigate!):", flush=True)
+        for bf, diffs in mismatches:
+            print(f"  {bf}: {diffs}", flush=True)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/archive/scripts/migrate_provenance_attrs.py
+++ b/archive/scripts/migrate_provenance_attrs.py
@@ -62,6 +62,20 @@ SCALE_GROUPS = ("micro_data", "macro_data")
 EXPECTED_VERSION = "v2.0.0"
 _HASH_ROWS = 4096  # rows of the leading axis read per chunk when checksumming
 
+# ===========================================================================
+# SAFETY VALVE  (archived one-off migration — issue #61)
+# ---------------------------------------------------------------------------
+# This script already performed its single, completed migration.  It lives in
+# archive/ only as a worked template for future in-place HDF5 attribute
+# migrations.  To stop anyone re-running it by accident, the line below pins it
+# to dry-run: ``--apply`` is silently downgraded to a dry-run while it is present.
+#
+# To actually run a migration (i.e. when adapting this as a template), DELETE
+# the single line below.  Removing it makes the guard default to off, so
+# ``--apply`` works normally again.
+_SAFETY_VALVE = True
+# ===========================================================================
+
 
 # --------------------------------------------------------------------------- #
 # Helpers
@@ -347,6 +361,18 @@ def main(argv=None):
         "(not threads) give real speed-up. Has no effect on a dry-run.",
     )
     args = parser.parse_args(argv)
+
+    # SAFETY VALVE: while the `_SAFETY_VALVE` line near the top of this file is
+    # present, refuse to write — force dry-run.  Delete that line to enable --apply.
+    if globals().get("_SAFETY_VALVE", False) and args.apply:
+        print(
+            "SAFETY VALVE ENGAGED: this is an archived one-off migration; "
+            "refusing --apply and running in DRY-RUN mode instead.\n"
+            "To enable --apply, delete the `_SAFETY_VALVE = True` line near the "
+            "top of this script (see archive/README.rst).",
+            flush=True,
+        )
+        args.apply = False
 
     roots = args.roots if args.roots else DEFAULT_ROOTS
     if args.apply and args.backup_dir is None and not args.no_backup:

--- a/docs/source/usage/data_specification.rst
+++ b/docs/source/usage/data_specification.rst
@@ -30,6 +30,46 @@ Group Structure
 ``log_files``
   Contains log files for all executions of code
 
+Provenance attributes
+--------------------
+
+Each per-scale params group (``micro_data`` / ``macro_data``) carries
+provenance attributes recording *when*, *where*, and *with what code* the
+data was produced.  Three families are stamped, plus the root
+``dataspec_version`` attribute.  All three ``*_dirty`` fields use the same
+3-state string — ``"clean"``, ``"dirty"``, or ``"unknown"`` (git unavailable
+or repo root not found) — so the unknown case is never collapsed into clean.
+
+``init_*`` — the ``src/lysis/`` Python layer at **init** time (stamped by
+``init-experiment`` / ``init-macroscale``):
+
+  ``init_version``, ``init_dirty``, ``init_timestamp``, ``init_hostname``
+
+``pipeline_*`` — the ``src/lysis/`` Python **pipeline** that orchestrated
+init/import at HDF5-import time (stamped by ``run-micro`` / ``run-macro``).
+This is the wrapper that ran the simulation, *not* the engine that executed
+it:
+
+  ``pipeline_version``, ``pipeline_dirty``, ``pipeline_timestamp``,
+  ``pipeline_hostname``
+
+``backend_*`` — the simulation **engine** that actually produced the output.
+For Fortran runs these come from the binary's ``--version`` output:
+
+  ``backend_type``
+    ``"fortran"`` (or ``"python"`` for the future Python backend).
+  ``backend_commit``, ``backend_dirty``, ``backend_compiler``
+    The ``src/fortran/`` commit, dirty bit, and compiler string the binary
+    was built from/with.
+  ``backend_historical``
+    ``True`` only when the binary was rebuilt from an older commit via
+    ``run-{micro,macro} --fortran-commit <ref>``; absent otherwise.  The SHA
+    itself is in ``backend_commit``.
+  ``stale_backend_override``
+    ``True`` only when a binary↔source staleness mismatch was explicitly
+    overridden (``--allow-stale-binary`` / ``LYSIS_ALLOW_STALE_BINARY=1``);
+    absent otherwise.
+
 Microscale datasets
 ++++++++++++++++++++++++++++++++
 

--- a/docs/source/usage/data_specification.rst
+++ b/docs/source/usage/data_specification.rst
@@ -31,7 +31,7 @@ Group Structure
   Contains log files for all executions of code
 
 Provenance attributes
---------------------
+---------------------
 
 Each per-scale params group (``micro_data`` / ``macro_data``) carries
 provenance attributes recording *when*, *where*, and *with what code* the

--- a/scripts/migrate_provenance_attrs.py
+++ b/scripts/migrate_provenance_attrs.py
@@ -1,0 +1,368 @@
+#!/usr/bin/env python
+"""One-time, guard-railed migration of v2.0.0 HDF5 provenance attributes (#61).
+
+Renames/retypes the provenance attributes on the ``micro_data`` / ``macro_data``
+groups of existing v2.0.0 HDF5 files (see
+:mod:`lysis.tools.provenance.migrate` for the exact mapping).  ``init_*`` attrs
+and *all* datasets are left untouched.
+
+Guardrails
+----------
+* **Dry-run by default.**  Nothing is written unless ``--apply`` is passed.
+* **Idempotent.**  Files with no old attrs are classified ``already-migrated``
+  and skipped; re-running after a successful pass is a no-op.
+* **Scope-limited.**  Only ``dataspec_version == "v2.0.0"`` files that carry old
+  provenance attrs *and* are writable by the current user are migrated.  Files
+  owned by other users (not writable) are reported, never touched.
+* **Per-file integrity verification.**  Before editing, a manifest is built of
+  every root/group attribute *and a SHA-256 checksum of every dataset's bytes*.
+  After the attr edits the file is closed, reopened read-only, and every dataset
+  is re-checksummed.  If ANY dataset checksum, any unrelated attribute, or
+  ``dataspec_version`` changed, the script **halts immediately**, prints the
+  offending file, and exits non-zero — so you know exactly which file to restore
+  from backup.  (Datasets are never accessed for writing; this is belt-and-braces.)
+* **Backups.**  ``--backup-dir`` copies each file before editing.  Required under
+  ``--apply`` unless ``--no-backup`` is given explicitly.
+
+Usage
+-----
+    # Dry-run (default) over the standard roots, write a report:
+    python scripts/migrate_provenance_attrs.py --report /tmp/prov_migration.txt
+
+    # Apply, backing up every edited file first:
+    python scripts/migrate_provenance_attrs.py --apply --backup-dir ~/prov_backup
+
+    # Restrict to one root:
+    python scripts/migrate_provenance_attrs.py ~/git/UCO-OpResearch/lysis/data --apply ...
+"""
+
+import argparse
+import hashlib
+import os
+import pwd
+import shutil
+import sys
+from datetime import datetime, timezone
+
+import h5py
+import numpy as np
+
+# Import the shared pure transform from the installed package.
+from lysis.tools.provenance.migrate import migrate_provenance_group, OLD_KEYS
+
+DEFAULT_ROOTS = [
+    os.path.expanduser("~/git/UCO-OpResearch/lysis/data"),
+    "/shared/lysis-group",
+]
+SCALE_GROUPS = ("micro_data", "macro_data")
+EXPECTED_VERSION = "v2.0.0"
+_HASH_ROWS = 4096  # rows of the leading axis read per chunk when checksumming
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+def _decode(value):
+    """Normalise an HDF5 attr value for stable comparison (decode bytes, unwrap np)."""
+    if isinstance(value, bytes):
+        return value.decode("utf-8", "replace")
+    if isinstance(value, np.generic):
+        return value.item()
+    if isinstance(value, np.ndarray):
+        return tuple(_decode(v) for v in value.tolist())
+    return value
+
+
+def _norm_attrs(attrs) -> dict:
+    """Return a plain, comparison-stable dict from an h5py AttributeManager/dict."""
+    return {k: _decode(v) for k, v in dict(attrs).items()}
+
+
+def _hash_object_array(h, arr):
+    """Stably fold an object/vlen array (e.g. h5py vlen strings) into *h*.
+
+    ``ndarray.tobytes()`` on an ``object`` array hashes Python *pointers*
+    (non-deterministic across reads), so iterate and feed each element's
+    own bytes with a length-prefixed separator instead.
+    """
+    for item in arr.ravel():
+        data = item if isinstance(item, bytes) else str(item).encode("utf-8")
+        h.update(len(data).to_bytes(8, "little"))
+        h.update(data)
+
+
+def _dataset_checksum(ds) -> str:
+    """SHA-256 of a dataset's contents, read in bounded chunks.
+
+    Numeric/array datasets hash their raw bytes; object (vlen-string)
+    datasets hash element-by-element so the digest is stable across reads.
+    """
+    h = hashlib.sha256()
+    h.update(repr((ds.shape, str(ds.dtype))).encode())  # bind shape+dtype into the digest
+    is_object = ds.dtype == object
+    if ds.shape == ():  # scalar dataset
+        if is_object:
+            _hash_object_array(h, np.asarray(ds[()], dtype=object))
+        else:
+            h.update(np.asarray(ds[()]).tobytes())
+        return h.hexdigest()
+    if 0 in ds.shape:  # empty dataset — nothing to read
+        return h.hexdigest()
+    n = ds.shape[0]
+    for i in range(0, n, _HASH_ROWS):
+        chunk = ds[i : i + _HASH_ROWS]
+        if is_object:
+            _hash_object_array(h, np.asarray(chunk, dtype=object))
+        else:
+            h.update(np.ascontiguousarray(chunk).tobytes())
+    return h.hexdigest()
+
+
+def _build_manifest(path) -> dict:
+    """Read-only manifest: root attrs, per-scale-group attrs, all dataset checksums."""
+    manifest = {"root_attrs": {}, "group_attrs": {}, "datasets": {}}
+    with h5py.File(path, "r") as f:
+        manifest["root_attrs"] = _norm_attrs(f.attrs)
+        for g in SCALE_GROUPS:
+            if g in f:
+                manifest["group_attrs"][g] = _norm_attrs(f[g].attrs)
+
+        def _visit(name, obj):
+            if isinstance(obj, h5py.Dataset):
+                manifest["datasets"][name] = (
+                    obj.shape,
+                    str(obj.dtype),
+                    _dataset_checksum(obj),
+                )
+
+        f.visititems(_visit)
+    return manifest
+
+
+def _file_owner(path) -> str:
+    try:
+        return pwd.getpwuid(os.stat(path).st_uid).pw_name
+    except (KeyError, OSError):
+        return "?"
+
+
+def _iter_h5(roots):
+    for root in roots:
+        for dirpath, _dirs, files in os.walk(root):
+            for name in files:
+                if name.endswith(".h5"):
+                    yield os.path.join(dirpath, name)
+
+
+# --------------------------------------------------------------------------- #
+# Classification
+# --------------------------------------------------------------------------- #
+def classify(path) -> str:
+    """Return one of the migration categories for *path* (read-only)."""
+    try:
+        with h5py.File(path, "r") as f:
+            ver = _decode(f.attrs.get("dataspec_version"))
+            if ver != EXPECTED_VERSION:
+                return "not-v2.0.0"
+            has_old = any(
+                g in f and (OLD_KEYS & f[g].attrs.keys()) for g in SCALE_GROUPS
+            )
+    except Exception:  # noqa: BLE001 — any read failure is a category, not a crash
+        return "read-error"
+    if not has_old:
+        return "already-migrated"
+    if not os.access(path, os.W_OK):
+        return "not-writable"
+    return "will-migrate"
+
+
+# --------------------------------------------------------------------------- #
+# Migration + verification
+# --------------------------------------------------------------------------- #
+class IntegrityError(RuntimeError):
+    """Raised when post-migration verification detects an unexpected change."""
+
+
+def _expected_group_attrs(pre_attrs, sets, deletes) -> dict:
+    expected = {k: v for k, v in pre_attrs.items() if k not in deletes}
+    expected.update({k: _decode(v) for k, v in sets.items()})
+    return expected
+
+
+def migrate_file(path, *, backup_dir=None):
+    """Migrate one file in place with full pre/post integrity verification.
+
+    :raises IntegrityError: if any dataset checksum, unrelated attribute, or the
+        dataspec_version differs after the edit.  The file's edits are NOT rolled
+        back — recover from the backup and investigate.
+    :return: A dict describing the per-group attribute changes applied.
+    """
+    pre = _build_manifest(path)
+
+    if backup_dir is not None:
+        os.makedirs(backup_dir, exist_ok=True)
+        # Flatten the path into the backup name to avoid collisions across roots.
+        flat = path.lstrip(os.sep).replace(os.sep, "__")
+        shutil.copy2(path, os.path.join(backup_dir, flat))
+
+    # Compute the planned changes per group and the expected post-state.
+    plan = {}
+    expected_group_attrs = {}
+    for g, pre_attrs in pre["group_attrs"].items():
+        sets, deletes = migrate_provenance_group(dict(pre_attrs))
+        if sets or deletes:
+            plan[g] = (sets, deletes)
+            expected_group_attrs[g] = _expected_group_attrs(pre_attrs, sets, deletes)
+
+    if not plan:  # nothing to do (shouldn't happen for a will-migrate file)
+        return {}
+
+    # Apply: attrs only — datasets are never opened for writing.
+    with h5py.File(path, "a") as f:
+        for g, (sets, deletes) in plan.items():
+            group = f[g]
+            for k, v in sets.items():
+                group.attrs[k] = v
+            for k in deletes:
+                if k in group.attrs:
+                    del group.attrs[k]
+
+    # Verify: reopen read-only, rebuild manifest, compare exhaustively.
+    post = _build_manifest(path)
+
+    problems = []
+    if post["root_attrs"] != pre["root_attrs"]:
+        problems.append(f"root attrs changed: {pre['root_attrs']} -> {post['root_attrs']}")
+    if set(post["datasets"]) != set(pre["datasets"]):
+        problems.append("dataset set changed (added/removed datasets)")
+    for name, sig in pre["datasets"].items():
+        if post["datasets"].get(name) != sig:
+            problems.append(f"dataset changed: {name}")
+    for g, expected in expected_group_attrs.items():
+        got = post["group_attrs"].get(g, {})
+        if got != expected:
+            problems.append(
+                f"group '{g}' attrs mismatch:\n    expected={expected}\n    got     ={got}"
+            )
+    # Groups we did not plan to touch must be byte-for-byte identical.
+    for g, pre_attrs in pre["group_attrs"].items():
+        if g not in expected_group_attrs and post["group_attrs"].get(g) != pre_attrs:
+            problems.append(f"untouched group '{g}' attrs changed unexpectedly")
+
+    if problems:
+        raise IntegrityError(
+            f"Integrity check FAILED for:\n  {path}\n" + "\n".join(f"  - {p}" for p in problems)
+        )
+
+    return {g: plan[g] for g in plan}
+
+
+# --------------------------------------------------------------------------- #
+# CLI
+# --------------------------------------------------------------------------- #
+def _format_plan(plan) -> str:
+    lines = []
+    for g, (sets, deletes) in plan.items():
+        added = ", ".join(f"+{k}={v!r}" for k, v in sorted(sets.items()))
+        removed = ", ".join(f"-{k}" for k in sorted(deletes))
+        lines.append(f"      {g}: {added} | {removed}")
+    return "\n".join(lines)
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    parser.add_argument(
+        "roots", nargs="*", default=None,
+        help=f"Directories to scan (default: {DEFAULT_ROOTS}).",
+    )
+    parser.add_argument("--apply", action="store_true", help="Write changes (default: dry-run).")
+    parser.add_argument("--backup-dir", default=None, help="Copy each file here before editing.")
+    parser.add_argument(
+        "--no-backup", action="store_true",
+        help="Proceed under --apply without a backup dir (NOT recommended).",
+    )
+    parser.add_argument("--report", default=None, help="Write the full report to this path too.")
+    args = parser.parse_args(argv)
+
+    roots = args.roots if args.roots else DEFAULT_ROOTS
+    if args.apply and args.backup_dir is None and not args.no_backup:
+        parser.error(
+            "--apply requires --backup-dir (or pass --no-backup to override). "
+            "Backups are the recovery path if integrity verification fails."
+        )
+
+    buckets = {
+        "will-migrate": [], "already-migrated": [], "not-v2.0.0": [],
+        "not-writable": [], "read-error": [],
+    }
+    for path in _iter_h5(roots):
+        buckets[classify(path)].append(path)
+
+    out = []
+
+    def emit(line=""):
+        out.append(line)
+        print(line)
+
+    stamp = datetime.now(timezone.utc).isoformat(timespec="seconds")
+    emit(f"# Provenance attr migration — {'APPLY' if args.apply else 'DRY-RUN'} — {stamp}")
+    emit(f"# roots: {roots}")
+    emit("")
+    for cat, files in buckets.items():
+        emit(f"{cat}: {len(files)}")
+    emit("")
+
+    if buckets["not-writable"]:
+        emit("## not-writable (owned by another user — reported, NOT touched):")
+        for p in sorted(buckets["not-writable"]):
+            emit(f"  [{_file_owner(p)}] {p}")
+        emit("")
+
+    migrated, failed = 0, None
+    emit("## will-migrate:")
+    for path in sorted(buckets["will-migrate"]):
+        if not args.apply:
+            # Show the planned diff without writing.
+            try:
+                manifest = _build_manifest(path)
+            except Exception as e:  # noqa: BLE001
+                emit(f"  READ-ERROR {path}: {e}")
+                continue
+            plan = {}
+            for g, pre_attrs in manifest["group_attrs"].items():
+                sets, deletes = migrate_provenance_group(dict(pre_attrs))
+                if sets or deletes:
+                    plan[g] = (sets, deletes)
+            emit(f"  WOULD MIGRATE {path}")
+            emit(_format_plan(plan))
+        else:
+            try:
+                plan = migrate_file(path, backup_dir=args.backup_dir)
+            except IntegrityError as e:
+                emit("")
+                emit("!!! HALTING — integrity verification failed !!!")
+                emit(str(e))
+                failed = path
+                break
+            migrated += 1
+            emit(f"  MIGRATED {path}")
+            emit(_format_plan(plan))
+
+    emit("")
+    if failed:
+        emit(f"ABORTED at {failed} after {migrated} successful file(s). Restore it from backup.")
+    elif args.apply:
+        emit(f"DONE. Migrated {migrated} file(s).")
+    else:
+        emit(f"DRY-RUN complete. {len(buckets['will-migrate'])} file(s) would be migrated.")
+
+    if args.report:
+        with open(args.report, "w") as fh:
+            fh.write("\n".join(out) + "\n")
+        print(f"\n(report written to {args.report})")
+
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/migrate_provenance_attrs.py
+++ b/scripts/migrate_provenance_attrs.py
@@ -171,8 +171,15 @@ def classify(path) -> str:
         return "read-error"
     if not has_old:
         return "already-migrated"
-    if not os.access(path, os.W_OK):
-        return "not-writable"
+    # Only ever modify files the current user OWNS — never another user's data,
+    # even when the shared group makes them writable (the owner runs the tool on
+    # their own files).  Also skip anything not writable for any other reason.
+    try:
+        st = os.stat(path)
+    except OSError:
+        return "read-error"
+    if st.st_uid != os.getuid() or not os.access(path, os.W_OK):
+        return "not-mine"
     return "will-migrate"
 
 
@@ -282,6 +289,13 @@ def main(argv=None):
         help="Proceed under --apply without a backup dir (NOT recommended).",
     )
     parser.add_argument("--report", default=None, help="Write the full report to this path too.")
+    parser.add_argument(
+        "--jobs", "-j", type=int, default=1,
+        help="Parallel worker processes for --apply (default 1). Each worker "
+        "migrates whole files independently — safe because no two workers ever "
+        "touch the same file. SHA-256 verification is CPU-bound, so processes "
+        "(not threads) give real speed-up. Has no effect on a dry-run.",
+    )
     args = parser.parse_args(argv)
 
     roots = args.roots if args.roots else DEFAULT_ROOTS
@@ -293,7 +307,7 @@ def main(argv=None):
 
     buckets = {
         "will-migrate": [], "already-migrated": [], "not-v2.0.0": [],
-        "not-writable": [], "read-error": [],
+        "not-mine": [], "read-error": [],
     }
     for path in _iter_h5(roots):
         buckets[classify(path)].append(path)
@@ -302,7 +316,7 @@ def main(argv=None):
 
     def emit(line=""):
         out.append(line)
-        print(line)
+        print(line, flush=True)  # flush so `| tee` follows progress live
 
     stamp = datetime.now(timezone.utc).isoformat(timespec="seconds")
     emit(f"# Provenance attr migration — {'APPLY' if args.apply else 'DRY-RUN'} — {stamp}")
@@ -312,41 +326,81 @@ def main(argv=None):
         emit(f"{cat}: {len(files)}")
     emit("")
 
-    if buckets["not-writable"]:
-        emit("## not-writable (owned by another user — reported, NOT touched):")
-        for p in sorted(buckets["not-writable"]):
+    if buckets["not-mine"]:
+        emit("## not-mine (owned by another user or not writable — reported, NOT touched):")
+        for p in sorted(buckets["not-mine"]):
             emit(f"  [{_file_owner(p)}] {p}")
         emit("")
 
     migrated, failed = 0, None
+    will = sorted(buckets["will-migrate"])
     emit("## will-migrate:")
-    for path in sorted(buckets["will-migrate"]):
-        if not args.apply:
-            # Show the planned diff without writing.
+
+    if not args.apply:
+        # Dry-run: show the planned diff without writing — read group attrs
+        # only (no dataset checksums; those are an --apply-time integrity check).
+        for path in will:
             try:
-                manifest = _build_manifest(path)
+                with h5py.File(path, "r") as f:
+                    group_attrs = {
+                        g: _norm_attrs(f[g].attrs) for g in SCALE_GROUPS if g in f
+                    }
             except Exception as e:  # noqa: BLE001
                 emit(f"  READ-ERROR {path}: {e}")
                 continue
             plan = {}
-            for g, pre_attrs in manifest["group_attrs"].items():
+            for g, pre_attrs in group_attrs.items():
                 sets, deletes = migrate_provenance_group(dict(pre_attrs))
                 if sets or deletes:
                     plan[g] = (sets, deletes)
             emit(f"  WOULD MIGRATE {path}")
             emit(_format_plan(plan))
-        else:
+
+    elif max(1, args.jobs) == 1:
+        # Serial apply.
+        for i, path in enumerate(will, 1):
             try:
                 plan = migrate_file(path, backup_dir=args.backup_dir)
-            except IntegrityError as e:
+            except Exception as e:  # noqa: BLE001 — halt on ANY failure
                 emit("")
-                emit("!!! HALTING — integrity verification failed !!!")
+                emit("!!! HALTING — verification failed !!!")
                 emit(str(e))
                 failed = path
                 break
             migrated += 1
-            emit(f"  MIGRATED {path}")
+            emit(f"  MIGRATED [{i}/{len(will)}] {path}")
             emit(_format_plan(plan))
+
+    else:
+        # Parallel apply: one whole file per worker process.  No two workers
+        # touch the same file, so there is no HDF5 race.  Halt on the first
+        # failure — stop scheduling new work and name the offending file.
+        import concurrent.futures as _cf  # noqa: PLC0415
+
+        jobs = max(1, args.jobs)
+        emit(f"  (running {len(will)} file(s) across {jobs} worker processes)")
+        ex = _cf.ProcessPoolExecutor(max_workers=jobs)
+        futs = {
+            ex.submit(migrate_file, p, backup_dir=args.backup_dir): p for p in will
+        }
+        try:
+            for fut in _cf.as_completed(futs):
+                path = futs[fut]
+                try:
+                    plan = fut.result()
+                except Exception as e:  # noqa: BLE001 — halt on ANY failure
+                    emit("")
+                    emit("!!! HALTING — verification failed !!!")
+                    emit(str(e))
+                    failed = path
+                    break
+                migrated += 1
+                emit(f"  MIGRATED [{migrated}/{len(will)}] {path}")
+                emit(_format_plan(plan))
+        finally:
+            # cancel_futures stops not-yet-started tasks; in-flight files (≤ jobs)
+            # finish on their own.  Either way no new file is begun after a halt.
+            ex.shutdown(wait=True, cancel_futures=bool(failed))
 
     emit("")
     if failed:

--- a/scripts/migrate_provenance_attrs.py
+++ b/scripts/migrate_provenance_attrs.py
@@ -12,8 +12,10 @@ Guardrails
 * **Idempotent.**  Files with no old attrs are classified ``already-migrated``
   and skipped; re-running after a successful pass is a no-op.
 * **Scope-limited.**  Only ``dataspec_version == "v2.0.0"`` files that carry old
-  provenance attrs *and* are writable by the current user are migrated.  Files
-  owned by other users (not writable) are reported, never touched.
+  provenance attrs *and* are writable are migrated.  By default a file must be
+  OWNED by the current user; pass ``--include-other-owners`` to also migrate
+  files merely made writable via group permissions (use only when the owner has
+  agreed).  Everything skipped for ownership/permission reasons is reported.
 * **Per-file integrity verification.**  Before editing, a manifest is built of
   every root/group attribute *and a SHA-256 checksum of every dataset's bytes*.
   After the attr edits the file is closed, reopened read-only, and every dataset
@@ -21,16 +23,18 @@ Guardrails
   ``dataspec_version`` changed, the script **halts immediately**, prints the
   offending file, and exits non-zero — so you know exactly which file to restore
   from backup.  (Datasets are never accessed for writing; this is belt-and-braces.)
-* **Backups.**  ``--backup-dir`` copies each file before editing.  Required under
-  ``--apply`` unless ``--no-backup`` is given explicitly.
+* **Backups + SHA log.**  ``--backup-dir`` copies each file before editing and
+  writes a ``<flattened>.sha256.txt`` sidecar listing every dataset's pre- and
+  post-edit checksum.  A backup dir is required under ``--apply`` unless
+  ``--no-backup`` is given explicitly.
 
 Usage
 -----
     # Dry-run (default) over the standard roots, write a report:
     python scripts/migrate_provenance_attrs.py --report /tmp/prov_migration.txt
 
-    # Apply, backing up every edited file first:
-    python scripts/migrate_provenance_attrs.py --apply --backup-dir ~/prov_backup
+    # Apply, backing up every edited file first, 8 workers:
+    python scripts/migrate_provenance_attrs.py --apply --backup-dir ~/prov_backup -j 8
 
     # Restrict to one root:
     python scripts/migrate_provenance_attrs.py ~/git/UCO-OpResearch/lysis/data --apply ...
@@ -154,10 +158,46 @@ def _iter_h5(roots):
                     yield os.path.join(dirpath, name)
 
 
+def _backup_basename(path) -> str:
+    """Flattened backup name for *path* (collision-free across roots)."""
+    return path.lstrip(os.sep).replace(os.sep, "__")
+
+
+def _write_sha_log(backup_dir, path, pre, post) -> str:
+    """Write a per-file SHA-256 audit log next to the backup.
+
+    Two sections — every dataset's pre-edit checksum, then every dataset's
+    post-edit checksum — so the lists line up for a quick diff without having
+    to interleave per line.  Written *before* the integrity check raises, so
+    the record survives even on a verification failure.
+
+    :return: The path of the written ``.sha256.txt`` file.
+    """
+    log_path = os.path.join(backup_dir, _backup_basename(path) + ".sha256.txt")
+    names = sorted(set(pre["datasets"]) | set(post["datasets"]))
+
+    def _sha(manifest, name):
+        entry = manifest["datasets"].get(name)
+        return entry[2] if entry else "MISSING"
+
+    lines = [
+        f"# file: {path}",
+        f"# datasets: {len(names)}    (column: dataset_name  sha256)",
+        "",
+        "[pre-edit]",
+    ]
+    lines += [f"{name}  {_sha(pre, name)}" for name in names]
+    lines += ["", "[post-edit]"]
+    lines += [f"{name}  {_sha(post, name)}" for name in names]
+    with open(log_path, "w") as fh:
+        fh.write("\n".join(lines) + "\n")
+    return log_path
+
+
 # --------------------------------------------------------------------------- #
 # Classification
 # --------------------------------------------------------------------------- #
-def classify(path) -> str:
+def classify(path, *, include_other_owners=False) -> str:
     """Return one of the migration categories for *path* (read-only)."""
     try:
         with h5py.File(path, "r") as f:
@@ -171,14 +211,16 @@ def classify(path) -> str:
         return "read-error"
     if not has_old:
         return "already-migrated"
-    # Only ever modify files the current user OWNS — never another user's data,
-    # even when the shared group makes them writable (the owner runs the tool on
-    # their own files).  Also skip anything not writable for any other reason.
     try:
         st = os.stat(path)
     except OSError:
         return "read-error"
-    if st.st_uid != os.getuid() or not os.access(path, os.W_OK):
+    if not os.access(path, os.W_OK):
+        return "not-writable"
+    # By default only ever modify files the current user OWNS — never another
+    # user's data, even when the shared group makes them writable.  The owner
+    # opts in to group-writable files via --include-other-owners.
+    if st.st_uid != os.getuid() and not include_other_owners:
         return "not-mine"
     return "will-migrate"
 
@@ -208,9 +250,7 @@ def migrate_file(path, *, backup_dir=None):
 
     if backup_dir is not None:
         os.makedirs(backup_dir, exist_ok=True)
-        # Flatten the path into the backup name to avoid collisions across roots.
-        flat = path.lstrip(os.sep).replace(os.sep, "__")
-        shutil.copy2(path, os.path.join(backup_dir, flat))
+        shutil.copy2(path, os.path.join(backup_dir, _backup_basename(path)))
 
     # Compute the planned changes per group and the expected post-state.
     plan = {}
@@ -236,6 +276,11 @@ def migrate_file(path, *, backup_dir=None):
 
     # Verify: reopen read-only, rebuild manifest, compare exhaustively.
     post = _build_manifest(path)
+
+    # Persist the pre/post SHA audit log next to the backup BEFORE the integrity
+    # check below can raise, so the record survives a verification failure.
+    if backup_dir is not None:
+        _write_sha_log(backup_dir, path, pre, post)
 
     problems = []
     if post["root_attrs"] != pre["root_attrs"]:
@@ -288,6 +333,11 @@ def main(argv=None):
         "--no-backup", action="store_true",
         help="Proceed under --apply without a backup dir (NOT recommended).",
     )
+    parser.add_argument(
+        "--include-other-owners", action="store_true",
+        help="Also migrate files owned by another user but writable to you "
+        "(e.g. group-writable shared files). Use only with the owner's consent.",
+    )
     parser.add_argument("--report", default=None, help="Write the full report to this path too.")
     parser.add_argument(
         "--jobs", "-j", type=int, default=1,
@@ -307,10 +357,10 @@ def main(argv=None):
 
     buckets = {
         "will-migrate": [], "already-migrated": [], "not-v2.0.0": [],
-        "not-mine": [], "read-error": [],
+        "not-mine": [], "not-writable": [], "read-error": [],
     }
     for path in _iter_h5(roots):
-        buckets[classify(path)].append(path)
+        buckets[classify(path, include_other_owners=args.include_other_owners)].append(path)
 
     out = []
 
@@ -321,16 +371,19 @@ def main(argv=None):
     stamp = datetime.now(timezone.utc).isoformat(timespec="seconds")
     emit(f"# Provenance attr migration — {'APPLY' if args.apply else 'DRY-RUN'} — {stamp}")
     emit(f"# roots: {roots}")
+    if args.include_other_owners:
+        emit("# include-other-owners: ON (migrating group-writable files you do not own)")
     emit("")
     for cat, files in buckets.items():
         emit(f"{cat}: {len(files)}")
     emit("")
 
-    if buckets["not-mine"]:
-        emit("## not-mine (owned by another user or not writable — reported, NOT touched):")
-        for p in sorted(buckets["not-mine"]):
-            emit(f"  [{_file_owner(p)}] {p}")
-        emit("")
+    for cat in ("not-mine", "not-writable"):
+        if buckets[cat]:
+            emit(f"## {cat} (reported, NOT touched):")
+            for p in sorted(buckets[cat]):
+                emit(f"  [{_file_owner(p)}] {p}")
+            emit("")
 
     migrated, failed = 0, None
     will = sorted(buckets["will-migrate"])
@@ -408,7 +461,7 @@ def main(argv=None):
     elif args.apply:
         emit(f"DONE. Migrated {migrated} file(s).")
     else:
-        emit(f"DRY-RUN complete. {len(buckets['will-migrate'])} file(s) would be migrated.")
+        emit(f"DRY-RUN complete. {len(will)} file(s) would be migrated.")
 
     if args.report:
         with open(args.report, "w") as fh:

--- a/src/lysis/cli/__init__.py
+++ b/src/lysis/cli/__init__.py
@@ -58,7 +58,7 @@ def cli(ctx, verbose):
             highlight=False,
         )
         # Suppress the redundant inline warnings.warn() inside subsequent
-        # gather_execution_provenance() / gather_init_provenance() calls
+        # gather_pipeline_provenance() / gather_init_provenance() calls
         # in this process.  Non-CLI callers (notebooks, scripts) never
         # call this, so they still receive the warning naturally.
         mark_dirty_warning_emitted()

--- a/src/lysis/cli/run_macro.py
+++ b/src/lysis/cli/run_macro.py
@@ -138,9 +138,10 @@ from lysis.tools.slurm import DEFAULT_MODULES, parse_sbatch_tokens
         "binary name (with or without a leading 'bin/') to pick from the "
         "historical build's bin/ directory; the binary↔src/fortran "
         "staleness check is bypassed because the mismatch is intentional.  "
-        "Synthesised provenance (resolved SHA, ``iso_fortran_env`` compiler "
-        "string, ``binary_source = 'historical:<sha>'``) is stamped into "
-        "the HDF5 file in place of the binary's own --version output."
+        "Synthesised provenance (resolved SHA in ``backend_commit``, "
+        "``iso_fortran_env`` compiler string, and ``backend_historical = "
+        "True``) is stamped into the HDF5 file in place of the binary's "
+        "own --version output."
     ),
 )
 @click.option(
@@ -249,7 +250,7 @@ def run_macro(ctx, target_path, executable, use_slurm, partition, staging_root,
             except HistoricalBuildError as e:
                 raise click.ClickException(str(e))
             executable = str(resolved_exe)
-            sha = historical_provenance.get("binary_commit", "?")
+            sha = historical_provenance.get("backend_commit", "?")
             console.print(
                 f"[yellow]Using Fortran built from {sha[:7]} "
                 f"(--fortran-commit {fortran_commit}); "
@@ -281,7 +282,7 @@ def run_macro(ctx, target_path, executable, use_slurm, partition, staging_root,
                         out_code=out_file_code,
                         modules=modules,
                         sbatch_overrides=sbatch_overrides,
-                        historical_binary_attrs=historical_provenance,
+                        historical_backend_attrs=historical_provenance,
                     )
                 except ValueError as e:
                     raise click.ClickException(str(e))
@@ -312,7 +313,7 @@ def run_macro(ctx, target_path, executable, use_slurm, partition, staging_root,
                         skip_binary_verification=(
                             historical_provenance is not None
                         ),
-                        historical_binary_attrs=historical_provenance,
+                        historical_backend_attrs=historical_provenance,
                     )
                 except ValueError as e:
                     raise click.ClickException(str(e))

--- a/src/lysis/cli/run_micro.py
+++ b/src/lysis/cli/run_micro.py
@@ -142,9 +142,10 @@ from lysis.tools.slurm import DEFAULT_MODULES, parse_sbatch_tokens
         "binary name (with or without a leading 'bin/') to pick from the "
         "historical build's bin/ directory; the binary↔src/fortran "
         "staleness check is bypassed because the mismatch is intentional.  "
-        "Synthesised provenance (resolved SHA, ``iso_fortran_env`` compiler "
-        "string, ``binary_source = 'historical:<sha>'``) is stamped into "
-        "the HDF5 file in place of the binary's own --version output."
+        "Synthesised provenance (resolved SHA in ``backend_commit``, "
+        "``iso_fortran_env`` compiler string, and ``backend_historical = "
+        "True``) is stamped into the HDF5 file in place of the binary's "
+        "own --version output."
     ),
 )
 @click.option(
@@ -252,7 +253,7 @@ def run_micro(ctx, target_path, executable, use_slurm, partition, staging_root,
             except HistoricalBuildError as e:
                 raise click.ClickException(str(e))
             executable = str(resolved_exe)
-            sha = historical_provenance.get("binary_commit", "?")
+            sha = historical_provenance.get("backend_commit", "?")
             console.print(
                 f"[yellow]Using Fortran built from {sha[:7]} "
                 f"(--fortran-commit {fortran_commit}); "
@@ -286,7 +287,7 @@ def run_micro(ctx, target_path, executable, use_slurm, partition, staging_root,
                         num_children=nc_arg,
                         modules=modules,
                         sbatch_overrides=sbatch_overrides,
-                        historical_binary_attrs=historical_provenance,
+                        historical_backend_attrs=historical_provenance,
                     )
                 except ValueError as e:
                     raise click.ClickException(str(e))
@@ -316,7 +317,7 @@ def run_micro(ctx, target_path, executable, use_slurm, partition, staging_root,
                         skip_binary_verification=(
                             historical_provenance is not None
                         ),
-                        historical_binary_attrs=historical_provenance,
+                        historical_backend_attrs=historical_provenance,
                     )
                 except ValueError as e:
                     raise click.ClickException(str(e))

--- a/src/lysis/config/constants.py
+++ b/src/lysis/config/constants.py
@@ -68,33 +68,44 @@ class Const:
         self.DATASPEC_VERSION_ATTR = "dataspec_version"
         self.CONVERTED_FROM_ATTR = "converted_from"
         self.RENAMED_FROM_ATTR = "renamed_from"
-        # Init-time provenance (stamped by init-experiment / init-macroscale)
+        # Init-time provenance (stamped by init-experiment / init-macroscale).
+        # Records the ``src/lysis/`` Python layer at init time.  ``init_dirty``
+        # is the 3-state string ``"clean"`` / ``"dirty"`` / ``"unknown"``.
         self.INIT_VERSION_ATTR = "init_version"
         self.INIT_DIRTY_ATTR = "init_dirty"
         self.INIT_TIMESTAMP_ATTR = "init_timestamp"
         self.INIT_HOSTNAME_ATTR = "init_hostname"
-        # Execution-time provenance (stamped by run-micro / run-macro)
-        self.EXECUTION_VERSION_ATTR = "execution_version"
-        self.EXECUTION_DIRTY_ATTR = "execution_dirty"
-        self.EXECUTION_TIMESTAMP_ATTR = "execution_timestamp"
-        self.EXECUTION_HOSTNAME_ATTR = "execution_hostname"
-        # Self-reported provenance from the Fortran binary's --version output.
-        # ``binary_commit`` / ``binary_dirty`` / ``binary_compiler`` are
-        # stamped unconditionally by ``run-*`` commands.
-        # ``stale_binary_override`` is set only when the binary's stamp
+        # Pipeline-time provenance (stamped by run-micro / run-macro at HDF5
+        # import).  Records the ``src/lysis/`` Python pipeline that orchestrated
+        # init/import -- NOT the engine that executes the simulation (that is
+        # the backend, below).  ``pipeline_dirty`` is the 3-state string
+        # ``"clean"`` / ``"dirty"`` / ``"unknown"``.
+        self.PIPELINE_VERSION_ATTR = "pipeline_version"
+        self.PIPELINE_DIRTY_ATTR = "pipeline_dirty"
+        self.PIPELINE_TIMESTAMP_ATTR = "pipeline_timestamp"
+        self.PIPELINE_HOSTNAME_ATTR = "pipeline_hostname"
+        # Backend provenance -- the simulation engine that actually produced
+        # the output.  For Fortran runs these come from the binary's
+        # ``--version`` output; ``backend_commit`` / ``backend_dirty`` /
+        # ``backend_compiler`` / ``backend_type`` are stamped unconditionally
+        # by ``run-*`` commands.  ``backend_dirty`` is the 3-state string
+        # ``"clean"`` / ``"dirty"`` / ``"unknown"``.  ``backend_type`` is
+        # ``"fortran"`` (or ``"python"`` for a future Python backend).
+        # ``stale_backend_override`` is set only when the binary's stamp
         # disagrees with the source tree and the user has explicitly
         # overridden the preflight check.
-        self.BINARY_COMMIT_ATTR = "binary_commit"
-        self.BINARY_DIRTY_ATTR = "binary_dirty"
-        self.BINARY_COMPILER_ATTR = "binary_compiler"
-        self.STALE_BINARY_OVERRIDE_ATTR = "stale_binary_override"
-        # Marker stamped by the historical-build workflow
-        # (``lysis run-{micro,macro} --fortran-commit <ref>``).  Value is
-        # ``f"historical:{resolved_sha}"``; the field is absent on every
-        # other run.  Lets a reader of the HDF5 file see at a glance that
-        # this run's binary was rebuilt from an earlier commit rather
-        # than being the build that matches the current source tree.
-        self.BINARY_SOURCE_ATTR = "binary_source"
+        self.BACKEND_COMMIT_ATTR = "backend_commit"
+        self.BACKEND_DIRTY_ATTR = "backend_dirty"
+        self.BACKEND_COMPILER_ATTR = "backend_compiler"
+        self.BACKEND_TYPE_ATTR = "backend_type"
+        self.STALE_BINARY_OVERRIDE_ATTR = "stale_backend_override"
+        # Boolean marker stamped (``True``) by the historical-build workflow
+        # (``lysis run-{micro,macro} --fortran-commit <ref>``); absent on every
+        # other run.  Lets a reader of the HDF5 file see at a glance that this
+        # run's binary was rebuilt from an earlier commit rather than being the
+        # build that matches the current source tree.  The commit SHA itself
+        # lives in ``backend_commit``.
+        self.BACKEND_HISTORICAL_ATTR = "backend_historical"
         self.LYSIS_ALLOW_STALE_BINARY_ENV = "LYSIS_ALLOW_STALE_BINARY"
         self.LYSIS_ALLOW_DIRTY_ENV = "LYSIS_ALLOW_DIRTY"
         self.LYSIS_ALLOW_COMMIT_MISMATCH_ENV = "LYSIS_ALLOW_COMMIT_MISMATCH"

--- a/src/lysis/config/constants.py
+++ b/src/lysis/config/constants.py
@@ -98,7 +98,7 @@ class Const:
         self.BACKEND_DIRTY_ATTR = "backend_dirty"
         self.BACKEND_COMPILER_ATTR = "backend_compiler"
         self.BACKEND_TYPE_ATTR = "backend_type"
-        self.STALE_BINARY_OVERRIDE_ATTR = "stale_backend_override"
+        self.STALE_BACKEND_OVERRIDE_ATTR = "stale_backend_override"
         # Boolean marker stamped (``True``) by the historical-build workflow
         # (``lysis run-{micro,macro} --fortran-commit <ref>``); absent on every
         # other run.  Lets a reader of the HDF5 file see at a glance that this

--- a/src/lysis/dataio/datastore.py
+++ b/src/lysis/dataio/datastore.py
@@ -1011,59 +1011,59 @@ class DataStore:
         kind,
         *,
         executable=None,
-        binary_override=None,
-        replace_binary_attrs=None,
+        backend_override=None,
+        replace_backend_attrs=None,
     ):
         """Stamp provenance attributes onto the per-scale params group.
 
-        Writes the ``init_*``, ``execution_*``, or ``binary_*`` attribute
+        Writes the ``init_*``, ``pipeline_*``, or ``backend_*`` attribute
         family to the HDF5 group at ``{scale}_data`` (the params group
         for the named scale).
 
         :param scale: ``"micro"`` (targets ``micro_data``) or ``"macro"``
             (targets ``macro_data``).
         :type scale: str
-        :param kind: One of ``"init"``, ``"execution"``, ``"binary"``.
+        :param kind: One of ``"init"``, ``"pipeline"``, ``"backend"``.
 
             * ``"init"`` calls
               :func:`~lysis.tools.provenance.gather_init_provenance`.
-            * ``"execution"`` calls
-              :func:`~lysis.tools.provenance.gather_execution_provenance`.
-            * ``"binary"`` calls
-              :func:`~lysis.tools.provenance.gather_binary_provenance`
-              against *executable* and additionally writes any keys in
-              *binary_override*.
+            * ``"pipeline"`` calls
+              :func:`~lysis.tools.provenance.gather_pipeline_provenance`.
+            * ``"backend"`` calls
+              :func:`~lysis.tools.provenance.gather_backend_provenance`
+              against *executable*, stamps ``backend_type = "fortran"``,
+              and additionally writes any keys in *backend_override*.
         :type kind: str
-        :param executable: Required when ``kind="binary"`` — path to the
+        :param executable: Required when ``kind="backend"`` — path to the
             Fortran binary whose ``--version`` output supplies commit /
             dirty / compiler stamps.  May be ``None`` when
-            *replace_binary_attrs* is supplied (historical-build mode,
+            *replace_backend_attrs* is supplied (historical-build mode,
             where the binary's commit/dirty/compiler are synthesised
             externally rather than queried).  Ignored for other kinds.
         :type executable: pathlib.Path or str, optional
-        :param binary_override: Optional dict of extra attrs to merge in
+        :param backend_override: Optional dict of extra attrs to merge in
             *on top of* the gathered (or replaced) attrs — typically
-            ``{stale_binary_override: True}`` from
+            ``{stale_backend_override: True}`` from
             :func:`~lysis.tools.provenance.verify_binary_matches_source`
             when the staleness check was overridden.  Ignored when
-            ``kind != "binary"``.
-        :type binary_override: dict, optional
-        :param replace_binary_attrs: Optional pre-computed dict that
+            ``kind != "backend"``.
+        :type backend_override: dict, optional
+        :param replace_backend_attrs: Optional pre-computed dict that
             *replaces* the default
-            :func:`~lysis.tools.provenance.gather_binary_provenance`
-            call when ``kind="binary"``.  Used by the historical-build
+            :func:`~lysis.tools.provenance.gather_backend_provenance`
+            call when ``kind="backend"``.  Used by the historical-build
             workflow to ship a synthesised provenance dict (commit SHA,
             ``iso_fortran_env`` compiler probe output, and the
-            ``binary_source = "historical:<sha>"`` marker) for a binary
-            whose own ``--version`` may not match — or be absent.  When
-            supplied, *executable* may be ``None`` and no subprocess is
-            spawned against the binary.  ``binary_override`` (if also
-            supplied) is merged on top.  Ignored for other kinds.
-        :type replace_binary_attrs: dict, optional
+            ``backend_historical = True`` marker) for a binary whose own
+            ``--version`` may not match — or be absent.  When supplied,
+            *executable* may be ``None`` and no subprocess is spawned
+            against the binary.  ``backend_override`` (if also supplied)
+            is merged on top.  Ignored for other kinds.
+        :type replace_backend_attrs: dict, optional
         :raises IOError: If the DataStore is in read-only mode.
         :raises ValueError: For an unknown *scale*/*kind*, a missing
-            target group, or ``kind="binary"`` with neither
-            *executable* nor *replace_binary_attrs*.
+            target group, or ``kind="backend"`` with neither
+            *executable* nor *replace_backend_attrs*.
         """
         if self._mode == "r":
             raise IOError(
@@ -1082,25 +1082,28 @@ class DataStore:
         if kind == "init":
             from ..tools.provenance import gather_init_provenance  # noqa: PLC0415
             attrs = gather_init_provenance()
-        elif kind == "execution":
-            from ..tools.provenance import gather_execution_provenance  # noqa: PLC0415
-            attrs = gather_execution_provenance()
-        elif kind == "binary":
-            if replace_binary_attrs is not None:
-                attrs = dict(replace_binary_attrs)
+        elif kind == "pipeline":
+            from ..tools.provenance import gather_pipeline_provenance  # noqa: PLC0415
+            attrs = gather_pipeline_provenance()
+        elif kind == "backend":
+            if replace_backend_attrs is not None:
+                attrs = dict(replace_backend_attrs)
             else:
                 if executable is None:
                     raise ValueError(
-                        "stamp_provenance(kind='binary') requires either "
-                        "an 'executable' argument or 'replace_binary_attrs'."
+                        "stamp_provenance(kind='backend') requires either "
+                        "an 'executable' argument or 'replace_backend_attrs'."
                     )
-                from ..tools.provenance import gather_binary_provenance  # noqa: PLC0415
-                attrs = gather_binary_provenance(executable)
-            if binary_override:
-                attrs = {**attrs, **binary_override}
+                from ..tools.provenance import gather_backend_provenance  # noqa: PLC0415
+                attrs = gather_backend_provenance(executable)
+            # Every current run is Fortran; the future Python backend will
+            # stamp "python" here once wired into run-* (see #35).
+            attrs = {**attrs, CONST.BACKEND_TYPE_ATTR: "fortran"}
+            if backend_override:
+                attrs = {**attrs, **backend_override}
         else:
             raise ValueError(
-                f"kind must be 'init', 'execution', or 'binary'; "
+                f"kind must be 'init', 'pipeline', or 'backend'; "
                 f"got {kind!r}"
             )
 
@@ -1193,9 +1196,9 @@ class DataStore:
         file_codes,
         param_overrides=None,
         param_aliases=None,
-        binary_executable=None,
-        binary_override=None,
-        replace_binary_attrs=None,
+        backend_executable=None,
+        backend_override=None,
+        replace_backend_attrs=None,
     ):
         """Import a data collection from an external source into this DataStore.
 
@@ -1244,29 +1247,29 @@ class DataStore:
             example, ``{"micro_simulations": "runs"}`` renames the ``runs``
             key produced by v1.90.0 log parsing.
         :type param_aliases: dict, optional
-        :param binary_executable: Path to the Fortran binary that produced
-            the source data.  When provided, the binary's commit/dirty/
+        :param backend_executable: Path to the Fortran binary that produced
+            the source data.  When provided, the backend's commit/dirty/
             compiler stamps (from ``<executable> --version``) are written
             to the per-scale params group via
             :meth:`stamp_provenance`.  ``None`` (the default) skips the
-            binary stamp — appropriate for HDF5→HDF5 conversions and tests.
-        :type binary_executable: pathlib.Path or str, optional
-        :param binary_override: Optional dict of override-only attrs from
+            backend stamp — appropriate for HDF5→HDF5 conversions and tests.
+        :type backend_executable: pathlib.Path or str, optional
+        :param backend_override: Optional dict of override-only attrs from
             :func:`~lysis.tools.provenance.verify_binary_matches_source`
-            (typically ``{stale_binary_override: True}``) when the binary
-            preflight check was bypassed.  Merged into the binary-stamp
-            group attrs.  Ignored when neither ``binary_executable`` nor
-            ``replace_binary_attrs`` is provided.
-        :type binary_override: dict, optional
-        :param replace_binary_attrs: Optional pre-computed binary-provenance
+            (typically ``{stale_backend_override: True}``) when the binary
+            preflight check was bypassed.  Merged into the backend-stamp
+            group attrs.  Ignored when neither ``backend_executable`` nor
+            ``replace_backend_attrs`` is provided.
+        :type backend_override: dict, optional
+        :param replace_backend_attrs: Optional pre-computed backend-provenance
             dict from
-            :func:`~lysis.tools.provenance.gather_historical_binary_provenance`
-            (historical-build workflow).  When supplied, the binary stamp
+            :func:`~lysis.tools.provenance.gather_historical_backend_provenance`
+            (historical-build workflow).  When supplied, the backend stamp
             is written from this dict instead of querying
-            ``<binary_executable> --version``; ``binary_executable`` may
+            ``<backend_executable> --version``; ``backend_executable`` may
             be ``None`` in that case.  See
             :meth:`stamp_provenance` for details.
-        :type replace_binary_attrs: dict, optional
+        :type replace_backend_attrs: dict, optional
         :raises IOError: If the DataStore is in read-only mode.
         :raises ValueError: If *collection_name* is not ``"microscale_out"``
             or ``"macroscale_out"``, if the target collection does not yet
@@ -1398,19 +1401,19 @@ class DataStore:
                 converted["params"][CONST.CONVERTED_FROM_ATTR]
             )
 
-        # Stamp execution provenance on the per-scale params group, plus
-        # unconditional binary provenance (commit/dirty/compiler) when an
-        # executable path is known.  Both stamps go onto the same params
+        # Stamp pipeline provenance on the per-scale params group, plus
+        # unconditional backend provenance (commit/dirty/compiler/type) when
+        # an executable path is known.  Both stamps go onto the same params
         # group via the shared :meth:`stamp_provenance` helper.
         scale = "micro" if collection_name == "microscale_out" else "macro"
-        self.stamp_provenance(scale, "execution")
-        if binary_executable is not None or replace_binary_attrs is not None:
+        self.stamp_provenance(scale, "pipeline")
+        if backend_executable is not None or replace_backend_attrs is not None:
             self.stamp_provenance(
                 scale,
-                "binary",
-                executable=binary_executable,
-                binary_override=binary_override,
-                replace_binary_attrs=replace_binary_attrs,
+                "backend",
+                executable=backend_executable,
+                backend_override=backend_override,
+                replace_backend_attrs=replace_backend_attrs,
             )
 
         # Re-initialize in place (reloads all collections, params, etc.)

--- a/src/lysis/execution/fortran.py
+++ b/src/lysis/execution/fortran.py
@@ -107,18 +107,18 @@ class FortranRunner(SimulationRunner):
     #: (``lysis run-{micro,macro} --fortran-commit ...``) where the
     #: binary↔``src/fortran/`` mismatch is intentional and the historical
     #: binary may not implement ``--version`` at all.  Pair with
-    #: :attr:`historical_binary_attrs` so the synthesised binary
+    #: :attr:`historical_backend_attrs` so the synthesised binary
     #: provenance is still stamped into the HDF5 file.
     skip_binary_verification: bool = False
     #: Optional pre-computed binary-provenance dict shipped to
     #: :meth:`~lysis.dataio.datastore.DataStore.import_collection` as
-    #: ``replace_binary_attrs``.  Populated by the historical-build
+    #: ``replace_backend_attrs``.  Populated by the historical-build
     #: workflow from
-    #: :func:`~lysis.tools.provenance.gather_historical_binary_provenance`.
+    #: :func:`~lysis.tools.provenance.gather_historical_backend_provenance`.
     #: When ``None``, the default
-    #: :func:`~lysis.tools.provenance.gather_binary_provenance` path is
+    #: :func:`~lysis.tools.provenance.gather_backend_provenance` path is
     #: used (queries ``<binary> --version``).
-    historical_binary_attrs: "dict | None" = None
+    historical_backend_attrs: "dict | None" = None
     #: Optional pre-computed ``(commit, dirty)`` tuple for the
     #: ``src/fortran/`` source tree, forwarded to
     #: :func:`~lysis.tools.provenance.verify_binary_matches_source`.
@@ -270,14 +270,14 @@ class FortranRunner(SimulationRunner):
         workflow), this is a no-op — no subprocess is spawned, no
         warning banner is generated.  The caller has independently
         synthesised the binary provenance and will pass it through
-        :attr:`historical_binary_attrs`.
+        :attr:`historical_backend_attrs`.
 
         :return: The verify dict — empty on match or when skipped; on
             overridden mismatch contains ``"banner"`` (text to prepend
-            to the Fortran stdout log) plus the ``stale_binary_override``
+            to the Fortran stdout log) plus the ``stale_backend_override``
             flag forwarded to
             :meth:`~lysis.dataio.datastore.DataStore.import_collection`
-            via :meth:`_binary_hdf5_attrs`.  The binary's
+            via :meth:`_backend_hdf5_attrs`.  The binary's
             commit/dirty/compiler stamps are no longer included here —
             they are gathered fresh and stamped unconditionally by
             :meth:`~lysis.dataio.datastore.DataStore.stamp_provenance`
@@ -305,7 +305,7 @@ class FortranRunner(SimulationRunner):
         return self._binary_check_info
 
     @property
-    def _binary_hdf5_attrs(self) -> dict:
+    def _backend_hdf5_attrs(self) -> dict:
         """Override-only attrs from :meth:`_verify_binary_version` to merge
         into the binary stamp; ``{}`` when the binary matched the source.
 
@@ -523,9 +523,9 @@ class FortranRunner(SimulationRunner):
                     self._fortran_dataspec_version(),
                     str(data_dir),
                     [self.out_file_code],
-                    binary_executable=self.executable,
-                    binary_override=self._binary_hdf5_attrs,
-                    replace_binary_attrs=self.historical_binary_attrs,
+                    backend_executable=self.executable,
+                    backend_override=self._backend_hdf5_attrs,
+                    replace_backend_attrs=self.historical_backend_attrs,
                 )
 
             if not keep_tmpdir:

--- a/src/lysis/execution/fortran.py
+++ b/src/lysis/execution/fortran.py
@@ -309,7 +309,7 @@ class FortranRunner(SimulationRunner):
         """Override-only attrs from :meth:`_verify_binary_version` to merge
         into the binary stamp; ``{}`` when the binary matched the source.
 
-        Today this carries only :data:`CONST.STALE_BINARY_OVERRIDE_ATTR`
+        Today this carries only :data:`CONST.STALE_BACKEND_OVERRIDE_ATTR`
         when the staleness check was overridden.  The binary's commit /
         dirty / compiler stamps are written unconditionally by
         :meth:`~lysis.dataio.datastore.DataStore.stamp_provenance` —

--- a/src/lysis/execution/fortran_macro.py
+++ b/src/lysis/execution/fortran_macro.py
@@ -136,7 +136,7 @@ class FortranMacro(FortranRunner):
         index: "int | None" = None,
         allow_stale_binary: bool = False,
         skip_binary_verification: bool = False,
-        historical_binary_attrs: "dict | None" = None,
+        historical_backend_attrs: "dict | None" = None,
         source_stamp: "tuple[str, str] | None" = None,
     ) -> "FortranMacro":
         """Construct a :class:`FortranMacro` from an existing HDF5 run file.
@@ -168,12 +168,12 @@ class FortranMacro(FortranRunner):
             workflow where the mismatch is intentional and the binary
             may not implement ``--version``.  Defaults to ``False``.
         :type skip_binary_verification: bool, optional
-        :param historical_binary_attrs: Pre-computed binary provenance
+        :param historical_backend_attrs: Pre-computed binary provenance
             dict (from
-            :func:`~lysis.tools.provenance.gather_historical_binary_provenance`)
+            :func:`~lysis.tools.provenance.gather_historical_backend_provenance`)
             stamped into the HDF5 file in place of the default
             ``<binary> --version`` query.  Defaults to ``None``.
-        :type historical_binary_attrs: dict, optional
+        :type historical_backend_attrs: dict, optional
         :param source_stamp: Optional pre-computed ``(commit, dirty)``
             tuple for ``src/fortran/``, forwarded to
             :func:`~lysis.tools.provenance.verify_binary_matches_source`.
@@ -224,7 +224,7 @@ class FortranMacro(FortranRunner):
             index=index,
             allow_stale_binary=allow_stale_binary,
             skip_binary_verification=skip_binary_verification,
-            historical_binary_attrs=historical_binary_attrs,
+            historical_backend_attrs=historical_backend_attrs,
             source_stamp=source_stamp,
         )
 

--- a/src/lysis/execution/fortran_micro.py
+++ b/src/lysis/execution/fortran_micro.py
@@ -128,7 +128,7 @@ class FortranMicro(FortranRunner):
         num_children: "int | None" = None,
         allow_stale_binary: bool = False,
         skip_binary_verification: bool = False,
-        historical_binary_attrs: "dict | None" = None,
+        historical_backend_attrs: "dict | None" = None,
         source_stamp: "tuple[str, str] | None" = None,
     ) -> "FortranMicro":
         """Construct a :class:`FortranMicro` from an existing HDF5 run file.
@@ -164,12 +164,12 @@ class FortranMicro(FortranRunner):
             workflow where the mismatch is intentional and the binary
             may not implement ``--version``.  Defaults to ``False``.
         :type skip_binary_verification: bool, optional
-        :param historical_binary_attrs: Pre-computed binary provenance
+        :param historical_backend_attrs: Pre-computed binary provenance
             dict (from
-            :func:`~lysis.tools.provenance.gather_historical_binary_provenance`)
+            :func:`~lysis.tools.provenance.gather_historical_backend_provenance`)
             stamped into the HDF5 file in place of the default
             ``<binary> --version`` query.  Defaults to ``None``.
-        :type historical_binary_attrs: dict, optional
+        :type historical_backend_attrs: dict, optional
         :param source_stamp: Optional pre-computed ``(commit, dirty)``
             tuple for ``src/fortran/``, forwarded to
             :func:`~lysis.tools.provenance.verify_binary_matches_source`.
@@ -213,7 +213,7 @@ class FortranMicro(FortranRunner):
             num_children=num_children,
             allow_stale_binary=allow_stale_binary,
             skip_binary_verification=skip_binary_verification,
-            historical_binary_attrs=historical_binary_attrs,
+            historical_backend_attrs=historical_backend_attrs,
             source_stamp=source_stamp,
         )
 

--- a/src/lysis/execution/historical_build.py
+++ b/src/lysis/execution/historical_build.py
@@ -14,7 +14,7 @@ Backs the ``--fortran-commit <ref>`` flag on ``lysis run-micro`` and
    so the binary links against the same toolchain that Slurm jobs will
    load at runtime.
 4. Compute a synthesised provenance dict via
-   :func:`~lysis.tools.provenance.gather_historical_binary_provenance`.
+   :func:`~lysis.tools.provenance.gather_historical_backend_provenance`.
 5. Yield ``(binary_path, provenance_dict)`` for the caller to thread
    through to :class:`~lysis.execution.fortran_macro.FortranMacro` /
    :class:`~lysis.execution.fortran_micro.FortranMicro`.
@@ -34,7 +34,7 @@ import tempfile
 from pathlib import Path
 from typing import Iterator, Optional
 
-from ..tools.provenance import gather_historical_binary_provenance
+from ..tools.provenance import gather_historical_backend_provenance
 from ..tools.provenance._git import _git, _package_repo_root
 
 __all__ = [
@@ -203,7 +203,7 @@ def build_historical_binary(
     :yields: ``(binary_path, provenance_dict)`` where *binary_path* is
         the absolute path to the requested binary inside the build dir,
         and *provenance_dict* is the result of
-        :func:`~lysis.tools.provenance.gather_historical_binary_provenance`.
+        :func:`~lysis.tools.provenance.gather_historical_backend_provenance`.
     :raises HistoricalBuildError: If ref resolution, source extraction,
         ``make``, or binary lookup fails.
     """
@@ -250,7 +250,7 @@ def build_historical_binary(
                 f"{build_dir / 'bin'}; available: {available}."
             )
 
-        provenance = gather_historical_binary_provenance(
+        provenance = gather_historical_backend_provenance(
             binary_path,
             resolved_sha=resolved_sha,
             build_log=build_log,

--- a/src/lysis/tools/provenance/__init__.py
+++ b/src/lysis/tools/provenance/__init__.py
@@ -2,35 +2,35 @@
 
 Two parallel concerns share this package:
 
-- :mod:`~lysis.tools.provenance.execution` — Python-side stamps (lysis
+- :mod:`~lysis.tools.provenance.execution` — Python-pipeline stamps (lysis
   version, dirty bit, timestamp, hostname) gathered at init time
   (:func:`gather_init_provenance`) and at HDF5 write time
-  (:func:`gather_execution_provenance`).  Both functions scope their
+  (:func:`gather_pipeline_provenance`).  Both functions scope their
   git checks to the ``src/lysis/`` subtree.
 - :mod:`~lysis.tools.provenance.binary` — Fortran-binary staleness check
   run by :class:`~lysis.execution.fortran.FortranRunner` before launching
   a compiled simulation binary (:func:`verify_binary_matches_source`),
-  plus :func:`gather_binary_provenance` which records the binary's
+  plus :func:`gather_backend_provenance` which records the backend's
   embedded commit/dirty/compiler stamps unconditionally on every run.
 
 The public API is re-exported here so callers can ``from
-lysis.tools.provenance import gather_execution_provenance`` (or any
+lysis.tools.provenance import gather_pipeline_provenance`` (or any
 other public function) without reaching into a submodule.
 """
 
 from .binary import (
     StaleBinaryError,
     allow_stale_from_env,
-    gather_binary_provenance,
+    gather_backend_provenance,
     gather_fortran_source_provenance,
-    gather_historical_binary_provenance,
+    gather_historical_backend_provenance,
     query_binary_version,
     verify_binary_matches_source,
 )
 from .execution import (
     allow_commit_mismatch_from_env,
     allow_dirty_from_env,
-    gather_execution_provenance,
+    gather_pipeline_provenance,
     gather_init_provenance,
     mark_dirty_warning_emitted,
 )
@@ -40,10 +40,10 @@ __all__ = [
     "allow_commit_mismatch_from_env",
     "allow_dirty_from_env",
     "allow_stale_from_env",
-    "gather_binary_provenance",
-    "gather_execution_provenance",
+    "gather_backend_provenance",
+    "gather_pipeline_provenance",
     "gather_fortran_source_provenance",
-    "gather_historical_binary_provenance",
+    "gather_historical_backend_provenance",
     "gather_init_provenance",
     "mark_dirty_warning_emitted",
     "query_binary_version",

--- a/src/lysis/tools/provenance/binary.py
+++ b/src/lysis/tools/provenance/binary.py
@@ -222,7 +222,7 @@ def verify_binary_matches_source(
     :type source_stamp: tuple[str, str] or None
     :return: Empty dict on match.  On overridden mismatch, a dict
         containing ``"banner"`` (text to prepend to the Fortran stdout
-        log file) and :data:`CONST.STALE_BINARY_OVERRIDE_ATTR` for
+        log file) and :data:`CONST.STALE_BACKEND_OVERRIDE_ATTR` for
         forwarding to
         :meth:`~lysis.dataio.datastore.DataStore.stamp_provenance` as
         ``backend_override``.  The binary's commit/dirty/compiler are
@@ -270,7 +270,7 @@ def verify_binary_matches_source(
             source_commit=source_commit,
             source_dirty=source_dirty,
         ),
-        CONST.STALE_BINARY_OVERRIDE_ATTR: True,
+        CONST.STALE_BACKEND_OVERRIDE_ATTR: True,
     }
 
 

--- a/src/lysis/tools/provenance/binary.py
+++ b/src/lysis/tools/provenance/binary.py
@@ -35,8 +35,8 @@ from ._git import _git, _package_repo_root
 __all__ = [
     "StaleBinaryError",
     "query_binary_version",
-    "gather_binary_provenance",
-    "gather_historical_binary_provenance",
+    "gather_backend_provenance",
+    "gather_historical_backend_provenance",
     "gather_fortran_source_provenance",
     "allow_stale_from_env",
     "verify_binary_matches_source",
@@ -100,25 +100,26 @@ def query_binary_version(
     return (parts[1], parts[2], compiler)
 
 
-def gather_binary_provenance(executable: "Path | str") -> dict:
-    """Gather binary provenance attrs from ``<executable> --version``.
+def gather_backend_provenance(executable: "Path | str") -> dict:
+    """Gather backend provenance attrs from ``<executable> --version``.
 
     Pure data gather — never raises, no warnings.  Used by
     :meth:`~lysis.dataio.datastore.DataStore.stamp_provenance` to record
-    what binary actually produced the simulation output.  Stamped on
-    every ``run-*`` invocation, not just stale-binary overrides.
+    what backend actually produced the simulation output.  Stamped on
+    every ``run-*`` invocation, not just stale-binary overrides.  The
+    ``backend_type`` attr is stamped separately by ``stamp_provenance``.
 
     :param executable: Path to the Fortran binary.
-    :return: Dict keyed by :data:`CONST.BINARY_COMMIT_ATTR`,
-        :data:`CONST.BINARY_DIRTY_ATTR`, :data:`CONST.BINARY_COMPILER_ATTR`.
+    :return: Dict keyed by :data:`CONST.BACKEND_COMMIT_ATTR`,
+        :data:`CONST.BACKEND_DIRTY_ATTR`, :data:`CONST.BACKEND_COMPILER_ATTR`.
         Values are ``"unknown"`` on any failure mode.
     :rtype: dict
     """
     commit, dirty, compiler = query_binary_version(executable)
     return {
-        CONST.BINARY_COMMIT_ATTR: commit,
-        CONST.BINARY_DIRTY_ATTR: dirty,
-        CONST.BINARY_COMPILER_ATTR: compiler,
+        CONST.BACKEND_COMMIT_ATTR: commit,
+        CONST.BACKEND_DIRTY_ATTR: dirty,
+        CONST.BACKEND_COMPILER_ATTR: compiler,
     }
 
 
@@ -224,9 +225,9 @@ def verify_binary_matches_source(
         log file) and :data:`CONST.STALE_BINARY_OVERRIDE_ATTR` for
         forwarding to
         :meth:`~lysis.dataio.datastore.DataStore.stamp_provenance` as
-        ``binary_override``.  The binary's commit/dirty/compiler are
+        ``backend_override``.  The binary's commit/dirty/compiler are
         no longer included here — they are gathered fresh and stamped
-        unconditionally via :func:`gather_binary_provenance`.
+        unconditionally via :func:`gather_backend_provenance`.
     :rtype: dict
     :raises StaleBinaryError: When the binary's stamp disagrees with the
         source tree and the override is not active.
@@ -281,7 +282,7 @@ def verify_binary_matches_source(
 # from an old commit, the binary's own ``--version`` flag may not exist
 # (added later in history) or may report a commit different from what the
 # user requested.  We need a provenance dict shaped like the output of
-# :func:`gather_binary_provenance` so it can flow through the same
+# :func:`gather_backend_provenance` so it can flow through the same
 # stamping pipeline.  The two non-obvious pieces are:
 #
 # - **commit / dirty**: take from the resolved git SHA (clean by
@@ -421,33 +422,33 @@ def _module_wrapper_argv(modules: Optional[str]) -> Optional[list[str]]:
     return ["bash", "-c", script, "--"]
 
 
-def gather_historical_binary_provenance(
+def gather_historical_backend_provenance(
     executable: "Path | str",
     *,
     resolved_sha: str,
     build_log: "Path | None" = None,
     modules: Optional[str] = None,
 ) -> dict:
-    """Build a binary-provenance dict for a binary rebuilt from an older commit.
+    """Build a backend-provenance dict for a binary rebuilt from an older commit.
 
-    Drop-in alternative to :func:`gather_binary_provenance`, intended
+    Drop-in alternative to :func:`gather_backend_provenance`, intended
     for the ``lysis run-{micro,macro} --fortran-commit <ref>`` workflow.
     First tries the binary's own ``--version`` output (cheap, and if the
     binary supports it and reports the requested commit, that's already
     the authoritative answer).  Falls back to synthesising the dict when
     ``--version`` is unsupported or reports a different commit:
 
-    - ``binary_commit`` = *resolved_sha* (the SHA we extracted from git).
-    - ``binary_dirty`` = ``"clean"`` (we extracted from a clean git tree).
-    - ``binary_compiler`` = result of
+    - ``backend_commit`` = *resolved_sha* (the SHA we extracted from git).
+    - ``backend_dirty`` = ``"clean"`` (we extracted from a clean git tree).
+    - ``backend_compiler`` = result of
       :func:`_probe_iso_fortran_env_compiler_version`, identifying the
       compiler from *build_log* and running it on a tiny stub to capture
       ``iso_fortran_env.compiler_version()`` — the exact string a
       ``--version``-capable binary would have embedded.
 
-    Always sets :data:`CONST.BINARY_SOURCE_ATTR` to
-    ``f"historical:{resolved_sha}"`` so the deviation is auditable from
-    the HDF5 file alone.
+    Always sets :data:`CONST.BACKEND_HISTORICAL_ATTR` to ``True`` so the
+    deviation is auditable from the HDF5 file alone; the commit SHA itself
+    lives in ``backend_commit``.
 
     :param executable: Path to the rebuilt Fortran binary.  Used only
         for the initial ``--version`` probe; if synthesis is required,
@@ -458,7 +459,7 @@ def gather_historical_binary_provenance(
     :type resolved_sha: str
     :param build_log: Path to the captured ``make`` log used to identify
         which compiler binary actually ran.  ``None`` skips the probe
-        and the result is ``"unknown"`` for *binary_compiler* in the
+        and the result is ``"unknown"`` for *backend_compiler* in the
         synthesis path.
     :type build_log: pathlib.Path or None
     :param modules: Space-separated list of LMod module specs to load
@@ -466,19 +467,20 @@ def gather_historical_binary_provenance(
         Should match the modules that wrapped ``make``.  ``None`` (default)
         runs the probe in the current environment.
     :type modules: str or None
-    :return: Dict keyed by :data:`CONST.BINARY_COMMIT_ATTR`,
-        :data:`CONST.BINARY_DIRTY_ATTR`, :data:`CONST.BINARY_COMPILER_ATTR`,
-        :data:`CONST.BINARY_SOURCE_ATTR`.  All values are strings;
-        unknown fields are ``"unknown"``.
+    :return: Dict keyed by :data:`CONST.BACKEND_COMMIT_ATTR`,
+        :data:`CONST.BACKEND_DIRTY_ATTR`, :data:`CONST.BACKEND_COMPILER_ATTR`,
+        and :data:`CONST.BACKEND_HISTORICAL_ATTR` (``True``).  The
+        commit/dirty/compiler values are strings; unknown fields are
+        ``"unknown"``.
     :rtype: dict
     """
     commit, dirty, compiler = query_binary_version(executable)
     if commit == resolved_sha and commit != "unknown":
         return {
-            CONST.BINARY_COMMIT_ATTR: commit,
-            CONST.BINARY_DIRTY_ATTR: dirty,
-            CONST.BINARY_COMPILER_ATTR: compiler,
-            CONST.BINARY_SOURCE_ATTR: f"historical:{resolved_sha}",
+            CONST.BACKEND_COMMIT_ATTR: commit,
+            CONST.BACKEND_DIRTY_ATTR: dirty,
+            CONST.BACKEND_COMPILER_ATTR: compiler,
+            CONST.BACKEND_HISTORICAL_ATTR: True,
         }
 
     compiler_name = _identify_compiler_binary(build_log)
@@ -490,8 +492,8 @@ def gather_historical_binary_provenance(
             module_wrapper=_module_wrapper_argv(modules),
         )
     return {
-        CONST.BINARY_COMMIT_ATTR: resolved_sha,
-        CONST.BINARY_DIRTY_ATTR: "clean",
-        CONST.BINARY_COMPILER_ATTR: probed or "unknown",
-        CONST.BINARY_SOURCE_ATTR: f"historical:{resolved_sha}",
+        CONST.BACKEND_COMMIT_ATTR: resolved_sha,
+        CONST.BACKEND_DIRTY_ATTR: "clean",
+        CONST.BACKEND_COMPILER_ATTR: probed or "unknown",
+        CONST.BACKEND_HISTORICAL_ATTR: True,
     }

--- a/src/lysis/tools/provenance/execution.py
+++ b/src/lysis/tools/provenance/execution.py
@@ -1,15 +1,18 @@
-"""Execution-time and init-time provenance stamps for HDF5 outputs.
+"""Pipeline-time and init-time provenance stamps for HDF5 outputs.
 
-Captures *when*, *where*, and *with what code* a microscale or macroscale
-simulation was initialised or executed, so the resulting HDF5 file is
-self-describing for future reproducibility checks.
+Captures *when*, *where*, and *with what code* the ``src/lysis/`` Python
+pipeline initialised or orchestrated a microscale or macroscale simulation,
+so the resulting HDF5 file is self-describing for future reproducibility
+checks.  (The simulation *engine* that produced the output is recorded
+separately as the backend; see
+:mod:`lysis.tools.provenance.binary`.)
 
 Two public gather functions are exposed:
 
 - :func:`gather_init_provenance` — written by ``init-experiment`` /
   ``init-macroscale``, keyed by ``CONST.INIT_*_ATTR``.
-- :func:`gather_execution_provenance` — written by ``run-micro`` /
-  ``run-macro`` at HDF5 import time, keyed by ``CONST.EXECUTION_*_ATTR``.
+- :func:`gather_pipeline_provenance` — written by ``run-micro`` /
+  ``run-macro`` at HDF5 import time, keyed by ``CONST.PIPELINE_*_ATTR``.
 
 Both functions scope their version/dirty check to the ``src/lysis/``
 subtree only (mirroring how :func:`~lysis.tools.provenance.binary.
@@ -47,7 +50,7 @@ from ...config.constants import CONST
 from ._git import _git, _package_repo_root
 
 __all__ = [
-    "gather_execution_provenance",
+    "gather_pipeline_provenance",
     "gather_init_provenance",
     "allow_dirty_from_env",
     "allow_commit_mismatch_from_env",
@@ -149,7 +152,7 @@ def mark_dirty_warning_emitted() -> None:
 
     Called by the lysis CLI top-level callback after it prints its own
     coloured warning, so the inline :func:`warnings.warn` inside
-    :func:`gather_execution_provenance` / :func:`gather_init_provenance`
+    :func:`gather_pipeline_provenance` / :func:`gather_init_provenance`
     does not re-fire for the same invocation.  Non-CLI callers
     (notebooks, scripts) never call this and therefore receive the
     inline warning normally.
@@ -158,13 +161,15 @@ def mark_dirty_warning_emitted() -> None:
     _dirty_warning_emitted = True
 
 
-def gather_execution_provenance() -> dict:
-    """Collect execution-time provenance stamps for ``src/lysis/``.
+def gather_pipeline_provenance() -> dict:
+    """Collect pipeline-time provenance stamps for ``src/lysis/``.
 
-    :return: Dict keyed by the ``EXECUTION_*_ATTR`` names in
+    :return: Dict keyed by the ``PIPELINE_*_ATTR`` names in
         :data:`lysis.config.constants.CONST`, ready to write as HDF5 attrs.
-        ``EXECUTION_DIRTY_ATTR`` is a bool (``True`` iff dirty) to preserve
-        backward compatibility with HDF5 files already in the wild.
+        ``PIPELINE_DIRTY_ATTR`` is the 3-state string
+        ``"clean"|"dirty"|"unknown"`` (matching ``INIT_DIRTY_ATTR`` and
+        ``BACKEND_DIRTY_ATTR``), so the ``"unknown"`` case (git unavailable
+        / repo root not found) is never collapsed into ``"clean"``.
     :rtype: dict
 
     Emits a :class:`UserWarning` the first time a dirty ``src/lysis/``
@@ -174,17 +179,17 @@ def gather_execution_provenance() -> dict:
     dirty_str = _resolve_dirty()
     _emit_dirty_warning_if_needed(dirty_str)
     return {
-        CONST.EXECUTION_VERSION_ATTR: _resolve_version(),
-        CONST.EXECUTION_DIRTY_ATTR: dirty_str == "dirty",
-        CONST.EXECUTION_TIMESTAMP_ATTR: _resolve_timestamp(),
-        CONST.EXECUTION_HOSTNAME_ATTR: _resolve_hostname(),
+        CONST.PIPELINE_VERSION_ATTR: _resolve_version(),
+        CONST.PIPELINE_DIRTY_ATTR: dirty_str,
+        CONST.PIPELINE_TIMESTAMP_ATTR: _resolve_timestamp(),
+        CONST.PIPELINE_HOSTNAME_ATTR: _resolve_hostname(),
     }
 
 
 def gather_init_provenance() -> dict:
     """Collect init-time provenance stamps for ``src/lysis/``.
 
-    Same shape as :func:`gather_execution_provenance` but keyed by
+    Same shape as :func:`gather_pipeline_provenance` but keyed by
     ``CONST.INIT_*_ATTR`` and stores the dirty value as the 3-state
     string ``"clean"|"dirty"|"unknown"`` (matches
     :func:`~lysis.tools.provenance.binary.gather_fortran_source_provenance`).
@@ -195,7 +200,7 @@ def gather_init_provenance() -> dict:
     :rtype: dict
 
     Emits a :class:`UserWarning` once per process if ``src/lysis/`` is
-    dirty, just like :func:`gather_execution_provenance`.
+    dirty, just like :func:`gather_pipeline_provenance`.
     """
     dirty_str = _resolve_dirty()
     _emit_dirty_warning_if_needed(dirty_str)

--- a/src/lysis/tools/provenance/migrate.py
+++ b/src/lysis/tools/provenance/migrate.py
@@ -1,0 +1,143 @@
+"""One-time migration of the v2.0.0 HDF5 provenance attribute schema.
+
+Issue #61 renamed and retyped the provenance attributes stamped onto the
+per-scale params groups (``micro_data`` / ``macro_data``) without bumping
+``dataspec_version`` (the format is codified for v1.0.0).  Files written by
+earlier v2.0.0 code therefore carry the *old* attribute names/types:
+
+============================  =================================  ============
+Old attr                      New attr                           Note
+============================  =================================  ============
+``execution_version``         ``pipeline_version``               rename
+``execution_dirty`` (bool)    ``pipeline_dirty`` (3-state str)   bool→string
+``execution_timestamp``       ``pipeline_timestamp``             rename
+``execution_hostname``        ``pipeline_hostname``              rename
+``execution_backend``         ``backend_type``                   rename + move
+``binary_commit``             ``backend_commit``                 rename
+``binary_dirty``              ``backend_dirty``                  rename
+``binary_compiler``           ``backend_compiler``               rename
+``binary_source``             ``backend_historical`` (= True)    drop prefix
+``stale_binary_override``     ``stale_backend_override``         rename
+============================  =================================  ============
+
+``init_*`` attributes are deliberately left untouched.
+
+This module exposes a single **pure** function, :func:`migrate_provenance_group`,
+which operates on a plain ``dict`` snapshot of a group's ``attrs`` (no h5py, no
+I/O) so it is trivially unit-testable and shared by
+``scripts/migrate_provenance_attrs.py``.
+"""
+
+# Old attribute names (literals — the CONST constants no longer define them).
+_OLD_EXECUTION_VERSION = "execution_version"
+_OLD_EXECUTION_DIRTY = "execution_dirty"
+_OLD_EXECUTION_TIMESTAMP = "execution_timestamp"
+_OLD_EXECUTION_HOSTNAME = "execution_hostname"
+_OLD_EXECUTION_BACKEND = "execution_backend"
+_OLD_BINARY_COMMIT = "binary_commit"
+_OLD_BINARY_DIRTY = "binary_dirty"
+_OLD_BINARY_COMPILER = "binary_compiler"
+_OLD_BINARY_SOURCE = "binary_source"
+_OLD_STALE_BINARY_OVERRIDE = "stale_binary_override"
+
+# New attribute names (kept in sync with lysis.config.constants.CONST).
+_NEW_PIPELINE_VERSION = "pipeline_version"
+_NEW_PIPELINE_DIRTY = "pipeline_dirty"
+_NEW_PIPELINE_TIMESTAMP = "pipeline_timestamp"
+_NEW_PIPELINE_HOSTNAME = "pipeline_hostname"
+_NEW_BACKEND_TYPE = "backend_type"
+_NEW_BACKEND_COMMIT = "backend_commit"
+_NEW_BACKEND_DIRTY = "backend_dirty"
+_NEW_BACKEND_COMPILER = "backend_compiler"
+_NEW_BACKEND_HISTORICAL = "backend_historical"
+_NEW_STALE_BACKEND_OVERRIDE = "stale_backend_override"
+
+#: Direct one-to-one renames where the value is carried over verbatim.
+_RENAMES = {
+    _OLD_EXECUTION_VERSION: _NEW_PIPELINE_VERSION,
+    _OLD_EXECUTION_TIMESTAMP: _NEW_PIPELINE_TIMESTAMP,
+    _OLD_EXECUTION_HOSTNAME: _NEW_PIPELINE_HOSTNAME,
+    _OLD_BINARY_COMMIT: _NEW_BACKEND_COMMIT,
+    _OLD_BINARY_DIRTY: _NEW_BACKEND_DIRTY,
+    _OLD_BINARY_COMPILER: _NEW_BACKEND_COMPILER,
+    _OLD_STALE_BINARY_OVERRIDE: _NEW_STALE_BACKEND_OVERRIDE,
+}
+
+#: All old keys the migration consumes (and therefore deletes when present).
+OLD_KEYS = frozenset(
+    list(_RENAMES)
+    + [
+        _OLD_EXECUTION_DIRTY,
+        _OLD_EXECUTION_BACKEND,
+        _OLD_BINARY_SOURCE,
+    ]
+)
+
+#: Keys whose presence means a group carries a Fortran backend stamp.
+_BACKEND_STAMP_KEYS = (_OLD_BINARY_COMMIT, _OLD_BINARY_DIRTY, _OLD_BINARY_COMPILER)
+
+
+def _coerce_str(value) -> str:
+    """Return *value* as a ``str``, decoding ``bytes`` (HDF5 may hand back either)."""
+    if isinstance(value, bytes):
+        return value.decode("utf-8", "replace")
+    return str(value)
+
+
+def _dirty_bool_to_str(value) -> str:
+    """Map an old bool ``execution_dirty`` to the 3-state string.
+
+    Existing v2.0.0 files only ever stored ``False`` (the bool collapsed the
+    ``"unknown"`` case into clean), so ``False`` → ``"clean"`` and ``True`` →
+    ``"dirty"``.  If a file somehow already holds the 3-state string, it is
+    passed through unchanged.
+    """
+    if isinstance(value, str):
+        return value
+    if isinstance(value, bytes):
+        return value.decode("utf-8", "replace")
+    return "dirty" if bool(value) else "clean"
+
+
+def migrate_provenance_group(attrs: dict) -> "tuple[dict, set]":
+    """Compute the provenance-attr migration for one scale group.
+
+    :param attrs: A plain snapshot of an HDF5 group's ``attrs`` (e.g.
+        ``dict(group.attrs)``).  Not mutated.
+    :type attrs: dict
+    :return: ``(sets, deletes)`` where *sets* maps new attribute names to the
+        values to write, and *deletes* is the set of old attribute names to
+        remove.  Both are empty when the group carries no old provenance attrs
+        (so the call is idempotent — re-running on an already-migrated group is
+        a no-op).
+    :rtype: tuple[dict, set]
+    """
+    present_old = OLD_KEYS & attrs.keys()
+    if not present_old:
+        return {}, set()
+
+    sets: dict = {}
+    deletes: set = set(present_old)
+
+    # 1. Verbatim renames.
+    for old, new in _RENAMES.items():
+        if old in attrs:
+            sets[new] = attrs[old]
+
+    # 2. execution_dirty (bool) -> pipeline_dirty (3-state string).
+    if _OLD_EXECUTION_DIRTY in attrs:
+        sets[_NEW_PIPELINE_DIRTY] = _dirty_bool_to_str(attrs[_OLD_EXECUTION_DIRTY])
+
+    # 3. backend_type: prefer the per-scale execution_backend value; otherwise
+    #    default to "fortran" when the group carries a Fortran backend stamp.
+    if _OLD_EXECUTION_BACKEND in attrs:
+        sets[_NEW_BACKEND_TYPE] = _coerce_str(attrs[_OLD_EXECUTION_BACKEND])
+    elif any(k in attrs for k in _BACKEND_STAMP_KEYS):
+        sets[_NEW_BACKEND_TYPE] = "fortran"
+
+    # 4. binary_source ("historical:<sha>") -> backend_historical = True.
+    #    The SHA already lives in backend_commit, so the prefix is dropped.
+    if _OLD_BINARY_SOURCE in attrs:
+        sets[_NEW_BACKEND_HISTORICAL] = True
+
+    return sets, deletes

--- a/src/lysis/tools/provenance/migrate.py
+++ b/src/lysis/tools/provenance/migrate.py
@@ -24,8 +24,10 @@ Old attr                      New attr                           Note
 
 This module exposes a single **pure** function, :func:`migrate_provenance_group`,
 which operates on a plain ``dict`` snapshot of a group's ``attrs`` (no h5py, no
-I/O) so it is trivially unit-testable and shared by
-``scripts/migrate_provenance_attrs.py``.
+I/O) so it is trivially unit-testable and shared by the (now archived) one-off
+driver ``archive/scripts/migrate_provenance_attrs.py``.  The pure transform is
+kept in the package (not archived) so the logic stays unit-tested and reusable
+as a reference for any future attribute migration.
 """
 
 # Old attribute names (literals — the CONST constants no longer define them).

--- a/src/lysis/tools/slurm.py
+++ b/src/lysis/tools/slurm.py
@@ -335,7 +335,7 @@ RUN_CODE = $run_code
 FILE_CODE = $file_code
 BINARY_NAME = $binary_name
 KEEP_TMPDIR = $keep_tmpdir
-HISTORICAL_BINARY_ATTRS = $historical_binary_attrs
+HISTORICAL_BACKEND_ATTRS = $historical_backend_attrs
 
 # ---------------------------------------------------------------------------
 # Submit child jobs
@@ -377,8 +377,8 @@ fm = FortranMicro(
     run=run,
     out_file_code=FILE_CODE,
     executable=str(STAGING_DIR / BINARY_NAME),
-    skip_binary_verification=(HISTORICAL_BINARY_ATTRS is not None),
-    historical_binary_attrs=HISTORICAL_BINARY_ATTRS,
+    skip_binary_verification=(HISTORICAL_BACKEND_ATTRS is not None),
+    historical_backend_attrs=HISTORICAL_BACKEND_ATTRS,
 )
 fm.import_results(
     data_dir,
@@ -405,18 +405,18 @@ def _generate_micro_master_py(
     file_code: str,
     binary_name: str,
     keep_tmpdir: bool,
-    historical_binary_attrs: Optional[dict] = None,
+    historical_backend_attrs: Optional[dict] = None,
 ) -> str:
     """Return the content of the single-child micro master Python script.
 
-    :param historical_binary_attrs: Pre-computed binary-provenance dict
+    :param historical_backend_attrs: Pre-computed binary-provenance dict
         from
-        :func:`~lysis.tools.provenance.gather_historical_binary_provenance`
+        :func:`~lysis.tools.provenance.gather_historical_backend_provenance`
         for the historical-build workflow.  Baked into the master script
         as a literal so the master can stamp it in place of the default
         ``<binary> --version`` query.  ``None`` (default) preserves the
         normal-mode behaviour.
-    :type historical_binary_attrs: dict or None
+    :type historical_backend_attrs: dict or None
     """
     return _MICRO_MASTER_PY_TEMPLATE.substitute(
         staging_dir=repr(str(staging_dir)),
@@ -425,7 +425,7 @@ def _generate_micro_master_py(
         file_code=repr(file_code),
         binary_name=repr(binary_name),
         keep_tmpdir=repr(keep_tmpdir),
-        historical_binary_attrs=repr(historical_binary_attrs),
+        historical_backend_attrs=repr(historical_backend_attrs),
     )
 
 
@@ -508,7 +508,7 @@ BINARY_NAME = $binary_name
 KEEP_TMPDIR = $keep_tmpdir
 NUM_ARRAY_TASKS = $num_array_tasks
 NFS_WAIT_SECONDS = $nfs_wait_seconds
-HISTORICAL_BINARY_ATTRS = $historical_binary_attrs
+HISTORICAL_BACKEND_ATTRS = $historical_backend_attrs
 
 # ---------------------------------------------------------------------------
 # Submit array job
@@ -552,8 +552,8 @@ fm = $runner_class(
     run=run,
     out_file_code=OUT_FILE_CODE,
     executable=str(STAGING_DIR / BINARY_NAME),
-    skip_binary_verification=(HISTORICAL_BINARY_ATTRS is not None),
-    historical_binary_attrs=HISTORICAL_BINARY_ATTRS,
+    skip_binary_verification=(HISTORICAL_BACKEND_ATTRS is not None),
+    historical_backend_attrs=HISTORICAL_BACKEND_ATTRS,
 )
 $concat_block
 fm.import_results(
@@ -581,18 +581,18 @@ def _generate_array_master_py(
     run_code: str,
     binary_name: str,
     keep_tmpdir: bool,
-    historical_binary_attrs: Optional[dict] = None,
+    historical_backend_attrs: Optional[dict] = None,
 ) -> str:
     """Return the master Python script for an array-mode dispatch.
 
-    :param historical_binary_attrs: Pre-computed binary-provenance dict
+    :param historical_backend_attrs: Pre-computed binary-provenance dict
         from
-        :func:`~lysis.tools.provenance.gather_historical_binary_provenance`
+        :func:`~lysis.tools.provenance.gather_historical_backend_provenance`
         for the historical-build workflow.  Baked into the master script
         as a literal so the master can stamp it in place of the default
         ``<binary> --version`` query.  ``None`` (default) preserves the
         normal-mode behaviour.
-    :type historical_binary_attrs: dict or None
+    :type historical_backend_attrs: dict or None
     """
     if spec.needs_concat_step:
         concat_block = (
@@ -617,7 +617,7 @@ def _generate_array_master_py(
         nfs_wait_seconds=spec.nfs_wait_seconds,
         concat_block=concat_block,
         concat_blurb=concat_blurb,
-        historical_binary_attrs=repr(historical_binary_attrs),
+        historical_backend_attrs=repr(historical_backend_attrs),
     )
 
 
@@ -667,7 +667,7 @@ def generate_array_script(
     slurm_log_dir: Optional["Path | str"] = None,
     modules: str = DEFAULT_MODULES,
     sbatch_overrides: Optional[Mapping[str, Optional[str]]] = None,
-    historical_binary_attrs: Optional[dict] = None,
+    historical_backend_attrs: Optional[dict] = None,
     pythonpath: "Path | str | None" = None,
     source_stamp: Optional[tuple] = None,
 ) -> str:
@@ -719,7 +719,7 @@ def generate_array_script(
         A ``None`` value removes the matching default; any other value
         sets/overrides the key.  Defaults to ``None`` (no overrides).
     :type sbatch_overrides: Mapping[str, str or None], optional
-    :param historical_binary_attrs: When non-``None``, indicates the
+    :param historical_backend_attrs: When non-``None``, indicates the
         binary was built from a historical commit (see
         :func:`~lysis.execution.historical_build.build_historical_binary`).
         The generated ``from_hdf5(...)`` call receives
@@ -727,7 +727,7 @@ def generate_array_script(
         does not crash on the intentional binary↔source mismatch.  The
         dict itself is not baked into the task — the master script
         owns the actual provenance stamping.
-    :type historical_binary_attrs: dict or None
+    :type historical_backend_attrs: dict or None
     :param pythonpath: When set, baked into the generated script as
         ``export PYTHONPATH=...`` so each task imports ``lysis`` from
         that path rather than the live editable install.  ``None``
@@ -738,7 +738,7 @@ def generate_array_script(
         call so the binary↔source check on the compute node compares
         against the master's stamp instead of running ``git`` from the
         staging dir (which is outside the repo and would fail).
-        Ignored when ``historical_binary_attrs`` is set (the staleness
+        Ignored when ``historical_backend_attrs`` is set (the staleness
         check is bypassed in that workflow).  ``None`` (default)
         preserves the in-process git lookup.
     :type source_stamp: tuple[str, str] or None
@@ -754,7 +754,7 @@ def generate_array_script(
     if slurm_log_dir is None:
         slurm_log_dir = hdf5_path.parent / ".slurm"
     slurm_log_dir = Path(slurm_log_dir)
-    skip_binary_verification = historical_binary_attrs is not None
+    skip_binary_verification = historical_backend_attrs is not None
 
     repo_root = _repo_root()
     env_preamble = _env_preamble(
@@ -861,7 +861,7 @@ def submit_slurm_job(
     keep_tmpdir: bool = False,
     modules: str = DEFAULT_MODULES,
     sbatch_overrides: Optional[Mapping[str, Optional[str]]] = None,
-    historical_binary_attrs: Optional[dict] = None,
+    historical_backend_attrs: Optional[dict] = None,
 ) -> int:
     """Stage scripts and submit a master Slurm job for an array-mode dispatch.
 
@@ -893,14 +893,14 @@ def submit_slurm_job(
         applied to BOTH the master job and each array task (shape returned
         by :func:`parse_sbatch_tokens`).  Defaults to ``None``.
     :type sbatch_overrides: Mapping[str, str or None], optional
-    :param historical_binary_attrs: Pre-computed binary-provenance dict
+    :param historical_backend_attrs: Pre-computed binary-provenance dict
         from
-        :func:`~lysis.tools.provenance.gather_historical_binary_provenance`
+        :func:`~lysis.tools.provenance.gather_historical_backend_provenance`
         for the historical-build workflow.  Baked into the master Python
         script so the master stamps it (with binary verification skipped)
         in place of the default ``<binary> --version`` query.  ``None``
         (default) preserves normal-mode provenance.
-    :type historical_binary_attrs: dict, optional
+    :type historical_backend_attrs: dict, optional
     :return: Master Slurm job ID.
     :rtype: int
     :raises ImportError: If ``GooseSLURM`` is not installed.
@@ -959,7 +959,7 @@ def submit_slurm_job(
     # raise StaleBinaryError).  Skipped under --fortran-commit, where the
     # binary↔source mismatch is intentional and the check is bypassed.
     source_stamp: Optional[tuple] = None
-    if historical_binary_attrs is None:
+    if historical_backend_attrs is None:
         from lysis.tools.provenance import (  # noqa: PLC0415
             gather_fortran_source_provenance,
         )
@@ -974,7 +974,7 @@ def submit_slurm_job(
         slurm_log_dir=slurm_log_dir,
         modules=modules,
         sbatch_overrides=sbatch_overrides,
-        historical_binary_attrs=historical_binary_attrs,
+        historical_backend_attrs=historical_backend_attrs,
         pythonpath=pythonpath,
         source_stamp=source_stamp,
     )
@@ -987,7 +987,7 @@ def submit_slurm_job(
     # ------------------------------------------------------------------
     master_py_content = _generate_array_master_py(
         spec, staging_dir, hdf5_path, run_code, executable.name, keep_tmpdir,
-        historical_binary_attrs=historical_binary_attrs,
+        historical_backend_attrs=historical_backend_attrs,
     )
     master_py_path = staging_dir / f"lysis-{spec.scale}-master__{run_code}.py"
     master_py_path.write_text(master_py_content)
@@ -1039,7 +1039,7 @@ def generate_micro_child_script(
     slurm_log_dir: Optional["Path | str"] = None,
     modules: str = DEFAULT_MODULES,
     sbatch_overrides: Optional[Mapping[str, Optional[str]]] = None,
-    historical_binary_attrs: Optional[dict] = None,
+    historical_backend_attrs: Optional[dict] = None,
     pythonpath: "Path | str | None" = None,
     source_stamp: Optional[tuple] = None,
 ) -> str:
@@ -1086,7 +1086,7 @@ def generate_micro_child_script(
         header (shape returned by :func:`parse_sbatch_tokens`).  Defaults
         to ``None``.
     :type sbatch_overrides: Mapping[str, str or None], optional
-    :param historical_binary_attrs: When non-``None``, indicates the
+    :param historical_backend_attrs: When non-``None``, indicates the
         binary was built from a historical commit (see
         :func:`~lysis.execution.historical_build.build_historical_binary`).
         The generated ``from_hdf5(...)`` call receives
@@ -1094,7 +1094,7 @@ def generate_micro_child_script(
         does not crash on the intentional binary↔source mismatch.  The
         dict itself is not baked into the child — the master script
         owns the actual provenance stamping.
-    :type historical_binary_attrs: dict or None
+    :type historical_backend_attrs: dict or None
     :param pythonpath: When set, baked into the generated script as
         ``export PYTHONPATH=...`` so the child imports ``lysis`` from
         that path rather than the live editable install.  ``None``
@@ -1105,7 +1105,7 @@ def generate_micro_child_script(
         the binary↔source check on the compute node compares against the
         master's stamp instead of running ``git`` from the staging dir
         (which is outside the repo and would fail).  Ignored when
-        ``historical_binary_attrs`` is set.  ``None`` (default)
+        ``historical_backend_attrs`` is set.  ``None`` (default)
         preserves the in-process git lookup.
     :type source_stamp: tuple[str, str] or None
     :return: Slurm bash script text.
@@ -1142,10 +1142,10 @@ def generate_micro_child_script(
 
     skip_verify_kwarg = (
         ", skip_binary_verification=True"
-        if historical_binary_attrs is not None
+        if historical_backend_attrs is not None
         else ""
     )
-    if source_stamp is not None and historical_binary_attrs is None:
+    if source_stamp is not None and historical_backend_attrs is None:
         commit, dirty = source_stamp
         source_stamp_kwarg = f", source_stamp=('{commit}', '{dirty}')"
     else:
@@ -1290,7 +1290,7 @@ def generate_micro_array_script(
     slurm_log_dir: Optional["Path | str"] = None,
     modules: str = DEFAULT_MODULES,
     sbatch_overrides: Optional[Mapping[str, Optional[str]]] = None,
-    historical_binary_attrs: Optional[dict] = None,
+    historical_backend_attrs: Optional[dict] = None,
 ) -> str:
     """Generate a Slurm array job script for the microscale Fortran simulation.
 
@@ -1321,7 +1321,7 @@ def generate_micro_array_script(
         slurm_log_dir=slurm_log_dir,
         modules=modules,
         sbatch_overrides=sbatch_overrides,
-        historical_binary_attrs=historical_binary_attrs,
+        historical_backend_attrs=historical_backend_attrs,
     )
 
 
@@ -1337,7 +1337,7 @@ def submit_micro_slurm_job(
     num_children: Optional[int] = None,
     modules: str = DEFAULT_MODULES,
     sbatch_overrides: Optional[Mapping[str, Optional[str]]] = None,
-    historical_binary_attrs: Optional[dict] = None,
+    historical_backend_attrs: Optional[dict] = None,
 ) -> int:
     """Submit the full HDF5-integrated microscale workflow as a Slurm master job.
 
@@ -1398,15 +1398,15 @@ def submit_micro_slurm_job(
         applied to BOTH the master and child/array task scripts (shape
         returned by :func:`parse_sbatch_tokens`).  Defaults to ``None``.
     :type sbatch_overrides: Mapping[str, str or None], optional
-    :param historical_binary_attrs: Pre-computed binary-provenance dict
+    :param historical_backend_attrs: Pre-computed binary-provenance dict
         from
-        :func:`~lysis.tools.provenance.gather_historical_binary_provenance`
+        :func:`~lysis.tools.provenance.gather_historical_backend_provenance`
         for the historical-build workflow.  Threaded through to the
         master Python script (in both array and legacy single-child
         paths) so the master stamps it in place of the default
         ``<binary> --version`` query.  ``None`` (default) preserves
         normal-mode provenance.
-    :type historical_binary_attrs: dict, optional
+    :type historical_backend_attrs: dict, optional
     :return: Master Slurm job ID.
     :rtype: int
     :raises subprocess.CalledProcessError: If ``sbatch`` fails.
@@ -1450,7 +1450,7 @@ def submit_micro_slurm_job(
             keep_tmpdir=keep_tmpdir,
             modules=modules,
             sbatch_overrides=sbatch_overrides,
-            historical_binary_attrs=historical_binary_attrs,
+            historical_backend_attrs=historical_backend_attrs,
         )
 
     # ------------------------------------------------------------------
@@ -1494,7 +1494,7 @@ def submit_micro_slurm_job(
     # outside the repo (see submit_slurm_job for the analogous comment in
     # the array path).
     source_stamp: Optional[tuple] = None
-    if historical_binary_attrs is None:
+    if historical_backend_attrs is None:
         from lysis.tools.provenance import (  # noqa: PLC0415
             gather_fortran_source_provenance,
         )
@@ -1509,7 +1509,7 @@ def submit_micro_slurm_job(
         slurm_log_dir=slurm_log_dir,
         modules=modules,
         sbatch_overrides=sbatch_overrides,
-        historical_binary_attrs=historical_binary_attrs,
+        historical_backend_attrs=historical_backend_attrs,
         pythonpath=pythonpath,
         source_stamp=source_stamp,
     )
@@ -1522,7 +1522,7 @@ def submit_micro_slurm_job(
     # ------------------------------------------------------------------
     master_py_content = _generate_micro_master_py(
         staging_dir, hdf5_path, run_code, out_code, executable.name, keep_tmpdir,
-        historical_binary_attrs=historical_binary_attrs,
+        historical_backend_attrs=historical_backend_attrs,
     )
     master_py_path = staging_dir / f"lysis-micro-master__{run_code}.py"
     master_py_path.write_text(master_py_content)
@@ -1592,7 +1592,7 @@ def generate_macro_array_script(
     slurm_log_dir: Optional["Path | str"] = None,
     modules: str = DEFAULT_MODULES,
     sbatch_overrides: Optional[Mapping[str, Optional[str]]] = None,
-    historical_binary_attrs: Optional[dict] = None,
+    historical_backend_attrs: Optional[dict] = None,
 ) -> str:
     """Generate a Slurm array job script for the macroscale Fortran simulation.
 
@@ -1621,7 +1621,7 @@ def generate_macro_array_script(
         slurm_log_dir=slurm_log_dir,
         modules=modules,
         sbatch_overrides=sbatch_overrides,
-        historical_binary_attrs=historical_binary_attrs,
+        historical_backend_attrs=historical_backend_attrs,
     )
 
 
@@ -1637,7 +1637,7 @@ def submit_macro_slurm_job(
     out_code: str = "",
     modules: str = DEFAULT_MODULES,
     sbatch_overrides: Optional[Mapping[str, Optional[str]]] = None,
-    historical_binary_attrs: Optional[dict] = None,
+    historical_backend_attrs: Optional[dict] = None,
 ) -> int:
     """Submit the full HDF5-integrated macroscale workflow as a Slurm master job.
 
@@ -1689,14 +1689,14 @@ def submit_macro_slurm_job(
         applied to BOTH the master and array task scripts (shape returned
         by :func:`parse_sbatch_tokens`).  Defaults to ``None``.
     :type sbatch_overrides: Mapping[str, str or None], optional
-    :param historical_binary_attrs: Pre-computed binary-provenance dict
+    :param historical_backend_attrs: Pre-computed binary-provenance dict
         from
-        :func:`~lysis.tools.provenance.gather_historical_binary_provenance`
+        :func:`~lysis.tools.provenance.gather_historical_backend_provenance`
         for the historical-build workflow.  Threaded through to the
         master Python script so the master stamps it in place of the
         default ``<binary> --version`` query.  ``None`` (default)
         preserves normal-mode provenance.
-    :type historical_binary_attrs: dict, optional
+    :type historical_backend_attrs: dict, optional
     :return: Master Slurm job ID.
     :rtype: int
     :raises subprocess.CalledProcessError: If ``sbatch`` fails.
@@ -1727,5 +1727,5 @@ def submit_macro_slurm_job(
         keep_tmpdir=keep_tmpdir,
         modules=modules,
         sbatch_overrides=sbatch_overrides,
-        historical_binary_attrs=historical_binary_attrs,
+        historical_backend_attrs=historical_backend_attrs,
     )

--- a/tests/cli/test_run_macro.py
+++ b/tests/cli/test_run_macro.py
@@ -550,10 +550,10 @@ class TestRunMacroFortranCommit:
         fake_binary.parent.mkdir(parents=True)
         fake_binary.write_text("not a real binary")
         prov = {
-            "binary_commit": "c" * 40,
-            "binary_dirty": "clean",
-            "binary_compiler": "GCC 11.4.0",
-            "binary_source": "historical:" + "c" * 40,
+            "backend_commit": "c" * 40,
+            "backend_dirty": "clean",
+            "backend_compiler": "GCC 11.4.0",
+            "backend_historical": True,
         }
 
         @contextmanager
@@ -576,7 +576,7 @@ class TestRunMacroFortranCommit:
         )
         assert result.exit_code == 0, result.output
         call_kwargs = mock_cls.from_hdf5.call_args.kwargs
-        assert call_kwargs.get("historical_binary_attrs") == prov
+        assert call_kwargs.get("historical_backend_attrs") == prov
         assert call_kwargs.get("skip_binary_verification") is True
 
     @patch("lysis.tools.slurm.submit_macro_slurm_job", return_value=99)
@@ -590,10 +590,10 @@ class TestRunMacroFortranCommit:
         fake_binary.parent.mkdir(parents=True)
         fake_binary.write_text("not a real binary")
         prov = {
-            "binary_commit": "d" * 40,
-            "binary_dirty": "clean",
-            "binary_compiler": "Intel(R) Fortran",
-            "binary_source": "historical:" + "d" * 40,
+            "backend_commit": "d" * 40,
+            "backend_dirty": "clean",
+            "backend_compiler": "Intel(R) Fortran",
+            "backend_historical": True,
         }
 
         @contextmanager
@@ -614,4 +614,4 @@ class TestRunMacroFortranCommit:
         )
         assert result.exit_code == 0, result.output
         call_kwargs = mock_submit.call_args.kwargs
-        assert call_kwargs.get("historical_binary_attrs") == prov
+        assert call_kwargs.get("historical_backend_attrs") == prov

--- a/tests/cli/test_run_micro.py
+++ b/tests/cli/test_run_micro.py
@@ -735,10 +735,10 @@ class TestRunMicroFortranCommit:
         fake_binary.parent.mkdir(parents=True)
         fake_binary.write_text("not a real binary")
         prov = {
-            "binary_commit": "a" * 40,
-            "binary_dirty": "clean",
-            "binary_compiler": "GCC 11.4.0",
-            "binary_source": "historical:" + "a" * 40,
+            "backend_commit": "a" * 40,
+            "backend_dirty": "clean",
+            "backend_compiler": "GCC 11.4.0",
+            "backend_historical": True,
         }
 
         @contextmanager
@@ -759,7 +759,7 @@ class TestRunMicroFortranCommit:
         )
         assert result.exit_code == 0, result.output
         call_kwargs = mock_cls.from_hdf5.call_args.kwargs
-        assert call_kwargs.get("historical_binary_attrs") == prov
+        assert call_kwargs.get("historical_backend_attrs") == prov
         assert call_kwargs.get("skip_binary_verification") is True
         # The bypass-banner must surface so users see why no staleness
         # check is happening.  Rich's console wraps long lines, so look
@@ -778,10 +778,10 @@ class TestRunMicroFortranCommit:
         fake_binary.parent.mkdir(parents=True)
         fake_binary.write_text("not a real binary")
         prov = {
-            "binary_commit": "b" * 40,
-            "binary_dirty": "clean",
-            "binary_compiler": "Intel(R) Fortran",
-            "binary_source": "historical:" + "b" * 40,
+            "backend_commit": "b" * 40,
+            "backend_dirty": "clean",
+            "backend_compiler": "Intel(R) Fortran",
+            "backend_historical": True,
         }
 
         @contextmanager
@@ -803,4 +803,4 @@ class TestRunMicroFortranCommit:
         )
         assert result.exit_code == 0, result.output
         call_kwargs = mock_submit.call_args.kwargs
-        assert call_kwargs.get("historical_binary_attrs") == prov
+        assert call_kwargs.get("historical_backend_attrs") == prov

--- a/tests/dataio/test_datastore_provenance.py
+++ b/tests/dataio/test_datastore_provenance.py
@@ -57,7 +57,7 @@ class TestStampValidation:
         with pytest.raises(
             ValueError, match="requires either an 'executable'"
         ):
-            micro_only_ds.stamp_provenance("micro", "binary")
+            micro_only_ds.stamp_provenance("micro", "backend")
 
     def test_missing_macro_group_raises(self, micro_only_ds):
         # Only micro_data exists in this fixture.
@@ -121,17 +121,21 @@ class TestStampExecution:
         import warnings
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", UserWarning)
-            micro_only_ds.stamp_provenance("micro", "execution")
+            micro_only_ds.stamp_provenance("micro", "pipeline")
         h5_path = tmp_path / "run-01.h5"
         micro_only_ds.close()
         with h5py.File(str(h5_path), "r") as f:
             attrs = f["micro_data"].attrs
-            assert CONST.EXECUTION_VERSION_ATTR in attrs
-            assert CONST.EXECUTION_DIRTY_ATTR in attrs
-            assert CONST.EXECUTION_TIMESTAMP_ATTR in attrs
-            assert CONST.EXECUTION_HOSTNAME_ATTR in attrs
-            # Execution dirty stays a bool for backward compat.
-            assert isinstance(attrs[CONST.EXECUTION_DIRTY_ATTR], (bool, np.bool_))
+            assert CONST.PIPELINE_VERSION_ATTR in attrs
+            assert CONST.PIPELINE_DIRTY_ATTR in attrs
+            assert CONST.PIPELINE_TIMESTAMP_ATTR in attrs
+            assert CONST.PIPELINE_HOSTNAME_ATTR in attrs
+            # Pipeline dirty is the 3-state string (clean/dirty/unknown),
+            # matching init_* and backend_* — never a bool.
+            dirty = attrs[CONST.PIPELINE_DIRTY_ATTR]
+            if isinstance(dirty, bytes):
+                dirty = dirty.decode()
+            assert dirty in {"clean", "dirty", "unknown"}
 
 
 # ----------------------------------------------------------------------
@@ -141,7 +145,7 @@ class TestStampExecution:
 
 class TestStampBinary:
     def test_binary_writes_three_attrs(self, micro_only_ds, tmp_path, monkeypatch):
-        # Stub gather_binary_provenance via the binary module so we don't
+        # Stub gather_backend_provenance via the binary module so we don't
         # actually need a working executable on disk.
         from lysis.tools.provenance import binary as binary_mod
         monkeypatch.setattr(
@@ -150,17 +154,19 @@ class TestStampBinary:
             lambda exe, **kw: ("abc123", "clean", "Intel"),
         )
         micro_only_ds.stamp_provenance(
-            "micro", "binary", executable="/fake/bin"
+            "micro", "backend", executable="/fake/bin"
         )
         h5_path = tmp_path / "run-01.h5"
         micro_only_ds.close()
         with h5py.File(str(h5_path), "r") as f:
             attrs = f["micro_data"].attrs
-            assert attrs[CONST.BINARY_COMMIT_ATTR].decode() == "abc123" \
-                if isinstance(attrs[CONST.BINARY_COMMIT_ATTR], bytes) \
-                else attrs[CONST.BINARY_COMMIT_ATTR] == "abc123"
-            assert attrs[CONST.BINARY_DIRTY_ATTR] in (b"clean", "clean")
-            assert attrs[CONST.BINARY_COMPILER_ATTR] in (b"Intel", "Intel")
+            assert attrs[CONST.BACKEND_COMMIT_ATTR].decode() == "abc123" \
+                if isinstance(attrs[CONST.BACKEND_COMMIT_ATTR], bytes) \
+                else attrs[CONST.BACKEND_COMMIT_ATTR] == "abc123"
+            assert attrs[CONST.BACKEND_DIRTY_ATTR] in (b"clean", "clean")
+            assert attrs[CONST.BACKEND_COMPILER_ATTR] in (b"Intel", "Intel")
+            # Every Fortran run self-identifies its backend type.
+            assert attrs[CONST.BACKEND_TYPE_ATTR] in (b"fortran", "fortran")
             # No override flag when not provided.
             assert CONST.STALE_BINARY_OVERRIDE_ATTR not in attrs
 
@@ -175,9 +181,9 @@ class TestStampBinary:
         )
         micro_only_ds.stamp_provenance(
             "micro",
-            "binary",
+            "backend",
             executable="/fake/bin",
-            binary_override={CONST.STALE_BINARY_OVERRIDE_ATTR: True},
+            backend_override={CONST.STALE_BINARY_OVERRIDE_ATTR: True},
         )
         h5_path = tmp_path / "run-01.h5"
         micro_only_ds.close()
@@ -185,10 +191,10 @@ class TestStampBinary:
             attrs = f["micro_data"].attrs
             assert bool(attrs[CONST.STALE_BINARY_OVERRIDE_ATTR]) is True
 
-    def test_replace_binary_attrs_skips_gather(
+    def test_replace_backend_attrs_skips_gather(
         self, micro_only_ds, tmp_path, monkeypatch
     ):
-        # When replace_binary_attrs is supplied, gather_binary_provenance
+        # When replace_backend_attrs is supplied, gather_backend_provenance
         # must NOT be called — the historical-build path ships the dict
         # itself (and the binary may not even support --version).
         from lysis.tools.provenance import binary as binary_mod
@@ -199,57 +205,56 @@ class TestStampBinary:
             lambda exe, **kw: sentinel_called.append(exe) or ("X", "X", "X"),
         )
         replacement = {
-            CONST.BINARY_COMMIT_ATTR: "deadbeef" * 5,
-            CONST.BINARY_DIRTY_ATTR: "clean",
-            CONST.BINARY_COMPILER_ATTR: "GCC version 11.4.0",
-            CONST.BINARY_SOURCE_ATTR: f"historical:{'deadbeef' * 5}",
+            CONST.BACKEND_COMMIT_ATTR: "deadbeef" * 5,
+            CONST.BACKEND_DIRTY_ATTR: "clean",
+            CONST.BACKEND_COMPILER_ATTR: "GCC version 11.4.0",
+            CONST.BACKEND_HISTORICAL_ATTR: True,
         }
         micro_only_ds.stamp_provenance(
-            "micro", "binary", replace_binary_attrs=replacement
+            "micro", "backend", replace_backend_attrs=replacement
         )
         assert sentinel_called == []
         h5_path = tmp_path / "run-01.h5"
         micro_only_ds.close()
         with h5py.File(str(h5_path), "r") as f:
             attrs = f["micro_data"].attrs
-            assert attrs[CONST.BINARY_SOURCE_ATTR] in (
-                b"historical:" + b"deadbeef" * 5,
-                f"historical:{'deadbeef' * 5}",
-            )
-            assert attrs[CONST.BINARY_COMPILER_ATTR] in (
+            assert bool(attrs[CONST.BACKEND_HISTORICAL_ATTR]) is True
+            assert attrs[CONST.BACKEND_COMPILER_ATTR] in (
                 b"GCC version 11.4.0", "GCC version 11.4.0",
             )
+            # backend_type is stamped even on the replace path.
+            assert attrs[CONST.BACKEND_TYPE_ATTR] in (b"fortran", "fortran")
 
-    def test_replace_binary_attrs_allows_none_executable(
+    def test_replace_backend_attrs_allows_none_executable(
         self, micro_only_ds, tmp_path
     ):
         # The historical-build workflow does not always have an
-        # executable on hand to query; replace_binary_attrs alone must
+        # executable on hand to query; replace_backend_attrs alone must
         # be sufficient.
         replacement = {
-            CONST.BINARY_COMMIT_ATTR: "f" * 40,
-            CONST.BINARY_DIRTY_ATTR: "clean",
-            CONST.BINARY_COMPILER_ATTR: "unknown",
-            CONST.BINARY_SOURCE_ATTR: f"historical:{'f' * 40}",
+            CONST.BACKEND_COMMIT_ATTR: "f" * 40,
+            CONST.BACKEND_DIRTY_ATTR: "clean",
+            CONST.BACKEND_COMPILER_ATTR: "unknown",
+            CONST.BACKEND_HISTORICAL_ATTR: True,
         }
         # Should not raise.
         micro_only_ds.stamp_provenance(
-            "micro", "binary", executable=None, replace_binary_attrs=replacement
+            "micro", "backend", executable=None, replace_backend_attrs=replacement
         )
 
     def test_binary_kind_without_executable_or_replace_raises(
         self, micro_only_ds
     ):
         import pytest
-        with pytest.raises(ValueError, match="executable.*replace_binary_attrs"):
-            micro_only_ds.stamp_provenance("micro", "binary")
+        with pytest.raises(ValueError, match="executable.*replace_backend_attrs"):
+            micro_only_ds.stamp_provenance("micro", "backend")
 
     def test_replace_and_override_compose(
         self, micro_only_ds, tmp_path, monkeypatch
     ):
-        # When both are given, binary_override merges on top of
-        # replace_binary_attrs (override wins on collision).  Important
-        # so we can still surface stale_binary_override alongside a
+        # When both are given, backend_override merges on top of
+        # replace_backend_attrs (override wins on collision).  Important
+        # so we can still surface stale_backend_override alongside a
         # historical synthesis if some future caller wants that.
         from lysis.tools.provenance import binary as binary_mod
         monkeypatch.setattr(
@@ -258,24 +263,22 @@ class TestStampBinary:
             lambda exe, **kw: ("SHOULD_NOT_BE_CALLED", "x", "x"),
         )
         replacement = {
-            CONST.BINARY_COMMIT_ATTR: "a" * 40,
-            CONST.BINARY_DIRTY_ATTR: "clean",
-            CONST.BINARY_COMPILER_ATTR: "GCC",
-            CONST.BINARY_SOURCE_ATTR: "historical:" + "a" * 40,
+            CONST.BACKEND_COMMIT_ATTR: "a" * 40,
+            CONST.BACKEND_DIRTY_ATTR: "clean",
+            CONST.BACKEND_COMPILER_ATTR: "GCC",
+            CONST.BACKEND_HISTORICAL_ATTR: True,
         }
         micro_only_ds.stamp_provenance(
-            "micro", "binary",
-            replace_binary_attrs=replacement,
-            binary_override={CONST.STALE_BINARY_OVERRIDE_ATTR: True},
+            "micro", "backend",
+            replace_backend_attrs=replacement,
+            backend_override={CONST.STALE_BINARY_OVERRIDE_ATTR: True},
         )
         h5_path = tmp_path / "run-01.h5"
         micro_only_ds.close()
         with h5py.File(str(h5_path), "r") as f:
             attrs = f["micro_data"].attrs
             assert bool(attrs[CONST.STALE_BINARY_OVERRIDE_ATTR]) is True
-            assert attrs[CONST.BINARY_SOURCE_ATTR] in (
-                b"historical:" + b"a" * 40, "historical:" + "a" * 40,
-            )
+            assert bool(attrs[CONST.BACKEND_HISTORICAL_ATTR]) is True
 
 
 # ----------------------------------------------------------------------

--- a/tests/dataio/test_datastore_provenance.py
+++ b/tests/dataio/test_datastore_provenance.py
@@ -168,7 +168,7 @@ class TestStampBinary:
             # Every Fortran run self-identifies its backend type.
             assert attrs[CONST.BACKEND_TYPE_ATTR] in (b"fortran", "fortran")
             # No override flag when not provided.
-            assert CONST.STALE_BINARY_OVERRIDE_ATTR not in attrs
+            assert CONST.STALE_BACKEND_OVERRIDE_ATTR not in attrs
 
     def test_binary_merges_override_attrs(
         self, micro_only_ds, tmp_path, monkeypatch
@@ -183,13 +183,13 @@ class TestStampBinary:
             "micro",
             "backend",
             executable="/fake/bin",
-            backend_override={CONST.STALE_BINARY_OVERRIDE_ATTR: True},
+            backend_override={CONST.STALE_BACKEND_OVERRIDE_ATTR: True},
         )
         h5_path = tmp_path / "run-01.h5"
         micro_only_ds.close()
         with h5py.File(str(h5_path), "r") as f:
             attrs = f["micro_data"].attrs
-            assert bool(attrs[CONST.STALE_BINARY_OVERRIDE_ATTR]) is True
+            assert bool(attrs[CONST.STALE_BACKEND_OVERRIDE_ATTR]) is True
 
     def test_replace_backend_attrs_skips_gather(
         self, micro_only_ds, tmp_path, monkeypatch
@@ -271,13 +271,13 @@ class TestStampBinary:
         micro_only_ds.stamp_provenance(
             "micro", "backend",
             replace_backend_attrs=replacement,
-            backend_override={CONST.STALE_BINARY_OVERRIDE_ATTR: True},
+            backend_override={CONST.STALE_BACKEND_OVERRIDE_ATTR: True},
         )
         h5_path = tmp_path / "run-01.h5"
         micro_only_ds.close()
         with h5py.File(str(h5_path), "r") as f:
             attrs = f["micro_data"].attrs
-            assert bool(attrs[CONST.STALE_BINARY_OVERRIDE_ATTR]) is True
+            assert bool(attrs[CONST.STALE_BACKEND_OVERRIDE_ATTR]) is True
             assert bool(attrs[CONST.BACKEND_HISTORICAL_ATTR]) is True
 
 

--- a/tests/execution/test_fortran.py
+++ b/tests/execution/test_fortran.py
@@ -361,7 +361,7 @@ class TestSkipBinaryVerification:
         assert info == {}
         assert called == []
         # No banner attrs either.
-        assert runner._binary_hdf5_attrs == {}
+        assert runner._backend_hdf5_attrs == {}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/execution/test_historical_build.py
+++ b/tests/execution/test_historical_build.py
@@ -222,7 +222,7 @@ def test_build_head_as_historical_end_to_end():
         binary_path, provenance
     ):
         assert binary_path.is_file()
-        assert provenance["binary_source"].startswith("historical:")
-        # binary_compiler may come from --version (if HEAD's binary supports
+        assert provenance["backend_historical"] is True
+        # backend_compiler may come from --version (if HEAD's binary supports
         # it) OR from the iso_fortran_env probe — either is acceptable.
-        assert provenance["binary_compiler"] != "unknown"
+        assert provenance["backend_compiler"] != "unknown"

--- a/tests/tools/test_provenance_binary.py
+++ b/tests/tools/test_provenance_binary.py
@@ -276,7 +276,7 @@ def test_verify_override_warns_and_returns_dict(monkeypatch):
     # Only the override flag is forwarded as an HDF5 attr — the binary's
     # commit/dirty/compiler are now stamped unconditionally by
     # gather_backend_provenance(), not via this return value.
-    assert info[CONST.STALE_BINARY_OVERRIDE_ATTR] is True
+    assert info[CONST.STALE_BACKEND_OVERRIDE_ATTR] is True
     assert CONST.BACKEND_COMMIT_ATTR not in info
     assert CONST.BACKEND_DIRTY_ATTR not in info
 
@@ -291,7 +291,7 @@ def test_verify_env_var_acts_as_override(monkeypatch):
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", UserWarning)
         info = verify_binary_matches_source("/fake/bin", allow_stale=None)
-    assert info[CONST.STALE_BINARY_OVERRIDE_ATTR] is True
+    assert info[CONST.STALE_BACKEND_OVERRIDE_ATTR] is True
 
 
 def test_verify_explicit_false_overrides_env(monkeypatch):

--- a/tests/tools/test_provenance_binary.py
+++ b/tests/tools/test_provenance_binary.py
@@ -98,30 +98,30 @@ def test_query_binary_version_timeout_is_unknown(monkeypatch):
 
 
 # ----------------------------------------------------------------------
-# gather_binary_provenance
+# gather_backend_provenance
 # ----------------------------------------------------------------------
 
-def test_gather_binary_provenance_keys(monkeypatch):
-    from lysis.tools.provenance import gather_binary_provenance
+def test_gather_backend_provenance_keys(monkeypatch):
+    from lysis.tools.provenance import gather_backend_provenance
 
     _patch_run(monkeypatch, stdout="v0.3.0 abc123 clean Intel\n")
-    result = gather_binary_provenance("/fake/bin")
+    result = gather_backend_provenance("/fake/bin")
     assert result == {
-        CONST.BINARY_COMMIT_ATTR: "abc123",
-        CONST.BINARY_DIRTY_ATTR: "clean",
-        CONST.BINARY_COMPILER_ATTR: "Intel",
+        CONST.BACKEND_COMMIT_ATTR: "abc123",
+        CONST.BACKEND_DIRTY_ATTR: "clean",
+        CONST.BACKEND_COMPILER_ATTR: "Intel",
     }
 
 
-def test_gather_binary_provenance_failure_yields_unknown(monkeypatch):
-    from lysis.tools.provenance import gather_binary_provenance
+def test_gather_backend_provenance_failure_yields_unknown(monkeypatch):
+    from lysis.tools.provenance import gather_backend_provenance
 
     _patch_run(monkeypatch, raises=FileNotFoundError())
-    result = gather_binary_provenance("/fake/bin")
+    result = gather_backend_provenance("/fake/bin")
     assert result == {
-        CONST.BINARY_COMMIT_ATTR: "unknown",
-        CONST.BINARY_DIRTY_ATTR: "unknown",
-        CONST.BINARY_COMPILER_ATTR: "unknown",
+        CONST.BACKEND_COMMIT_ATTR: "unknown",
+        CONST.BACKEND_DIRTY_ATTR: "unknown",
+        CONST.BACKEND_COMPILER_ATTR: "unknown",
     }
 
 
@@ -275,10 +275,10 @@ def test_verify_override_warns_and_returns_dict(monkeypatch):
     assert "STALE FORTRAN BINARY" in info["banner"]
     # Only the override flag is forwarded as an HDF5 attr — the binary's
     # commit/dirty/compiler are now stamped unconditionally by
-    # gather_binary_provenance(), not via this return value.
+    # gather_backend_provenance(), not via this return value.
     assert info[CONST.STALE_BINARY_OVERRIDE_ATTR] is True
-    assert CONST.BINARY_COMMIT_ATTR not in info
-    assert CONST.BINARY_DIRTY_ATTR not in info
+    assert CONST.BACKEND_COMMIT_ATTR not in info
+    assert CONST.BACKEND_DIRTY_ATTR not in info
 
 
 def test_verify_env_var_acts_as_override(monkeypatch):
@@ -393,10 +393,10 @@ def test_verify_source_stamp_dirty_match(monkeypatch):
 
 
 # ----------------------------------------------------------------------
-# gather_historical_binary_provenance
+# gather_historical_backend_provenance
 # ----------------------------------------------------------------------
 
-from lysis.tools.provenance import gather_historical_binary_provenance
+from lysis.tools.provenance import gather_historical_backend_provenance
 from lysis.tools.provenance.binary import (
     _identify_compiler_binary,
     _probe_iso_fortran_env_compiler_version,
@@ -441,14 +441,14 @@ def test_identify_compiler_missing_file_returns_none(tmp_path):
 def test_historical_provenance_uses_binary_version_on_sha_match(monkeypatch):
     sha = "a" * 40
     _patch_run(monkeypatch, stdout=f"v0.3.0 {sha} clean Intel(R) 2021.9\n")
-    result = gather_historical_binary_provenance(
+    result = gather_historical_backend_provenance(
         "/fake/bin", resolved_sha=sha
     )
     assert result == {
-        CONST.BINARY_COMMIT_ATTR: sha,
-        CONST.BINARY_DIRTY_ATTR: "clean",
-        CONST.BINARY_COMPILER_ATTR: "Intel(R) 2021.9",
-        CONST.BINARY_SOURCE_ATTR: f"historical:{sha}",
+        CONST.BACKEND_COMMIT_ATTR: sha,
+        CONST.BACKEND_DIRTY_ATTR: "clean",
+        CONST.BACKEND_COMPILER_ATTR: "Intel(R) 2021.9",
+        CONST.BACKEND_HISTORICAL_ATTR: True,
     }
 
 
@@ -465,13 +465,13 @@ def test_historical_provenance_synthesises_when_version_missing(
         "_probe_iso_fortran_env_compiler_version",
         lambda compiler, **kw: "GCC version 11.4.0",
     )
-    result = gather_historical_binary_provenance(
+    result = gather_historical_backend_provenance(
         "/fake/bin", resolved_sha=sha, build_log=log
     )
-    assert result[CONST.BINARY_COMMIT_ATTR] == sha
-    assert result[CONST.BINARY_DIRTY_ATTR] == "clean"
-    assert result[CONST.BINARY_COMPILER_ATTR] == "GCC version 11.4.0"
-    assert result[CONST.BINARY_SOURCE_ATTR] == f"historical:{sha}"
+    assert result[CONST.BACKEND_COMMIT_ATTR] == sha
+    assert result[CONST.BACKEND_DIRTY_ATTR] == "clean"
+    assert result[CONST.BACKEND_COMPILER_ATTR] == "GCC version 11.4.0"
+    assert result[CONST.BACKEND_HISTORICAL_ATTR] is True
 
 
 def test_historical_provenance_synthesises_when_sha_mismatches(
@@ -487,23 +487,23 @@ def test_historical_provenance_synthesises_when_sha_mismatches(
         "_probe_iso_fortran_env_compiler_version",
         lambda compiler, **kw: "Intel(R) Fortran 2023.0",
     )
-    result = gather_historical_binary_provenance(
+    result = gather_historical_backend_provenance(
         "/fake/bin", resolved_sha=requested, build_log=log
     )
     # Synthesised values, not the embedded ones.
-    assert result[CONST.BINARY_COMMIT_ATTR] == requested
-    assert result[CONST.BINARY_COMPILER_ATTR] == "Intel(R) Fortran 2023.0"
-    assert result[CONST.BINARY_SOURCE_ATTR] == f"historical:{requested}"
+    assert result[CONST.BACKEND_COMMIT_ATTR] == requested
+    assert result[CONST.BACKEND_COMPILER_ATTR] == "Intel(R) Fortran 2023.0"
+    assert result[CONST.BACKEND_HISTORICAL_ATTR] is True
 
 
 def test_historical_provenance_compiler_unknown_when_log_absent(monkeypatch):
     sha = "e" * 40
     _patch_run(monkeypatch, raises=FileNotFoundError())
-    result = gather_historical_binary_provenance(
+    result = gather_historical_backend_provenance(
         "/fake/bin", resolved_sha=sha, build_log=None
     )
-    assert result[CONST.BINARY_COMPILER_ATTR] == "unknown"
-    assert result[CONST.BINARY_SOURCE_ATTR] == f"historical:{sha}"
+    assert result[CONST.BACKEND_COMPILER_ATTR] == "unknown"
+    assert result[CONST.BACKEND_HISTORICAL_ATTR] is True
 
 
 def test_historical_provenance_compiler_unknown_when_probe_fails(
@@ -518,10 +518,10 @@ def test_historical_provenance_compiler_unknown_when_probe_fails(
         "_probe_iso_fortran_env_compiler_version",
         lambda compiler, **kw: None,
     )
-    result = gather_historical_binary_provenance(
+    result = gather_historical_backend_provenance(
         "/fake/bin", resolved_sha=sha, build_log=log
     )
-    assert result[CONST.BINARY_COMPILER_ATTR] == "unknown"
+    assert result[CONST.BACKEND_COMPILER_ATTR] == "unknown"
 
 
 @pytest.mark.fortran_binary

--- a/tests/tools/test_provenance_execution.py
+++ b/tests/tools/test_provenance_execution.py
@@ -1,6 +1,6 @@
 """Unit tests for :mod:`lysis.tools.provenance.execution`.
 
-Covers :func:`gather_execution_provenance`, :func:`gather_init_provenance`,
+Covers :func:`gather_pipeline_provenance`, :func:`gather_init_provenance`,
 the once-per-process dirty-warning machinery, and the path-scoped
 ``src/lysis/`` resolvers:
 
@@ -20,7 +20,7 @@ import pytest
 from lysis.config.constants import CONST
 from lysis.tools.provenance import (
     execution,
-    gather_execution_provenance,
+    gather_pipeline_provenance,
     gather_init_provenance,
     mark_dirty_warning_emitted,
 )
@@ -43,12 +43,12 @@ def reset_dirty_warning_flag():
 def test_gather_returns_expected_keys():
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", UserWarning)
-        result = gather_execution_provenance()
+        result = gather_pipeline_provenance()
     assert set(result.keys()) == {
-        CONST.EXECUTION_VERSION_ATTR,
-        CONST.EXECUTION_DIRTY_ATTR,
-        CONST.EXECUTION_TIMESTAMP_ATTR,
-        CONST.EXECUTION_HOSTNAME_ATTR,
+        CONST.PIPELINE_VERSION_ATTR,
+        CONST.PIPELINE_DIRTY_ATTR,
+        CONST.PIPELINE_TIMESTAMP_ATTR,
+        CONST.PIPELINE_HOSTNAME_ATTR,
     }
 
 
@@ -119,28 +119,28 @@ def test_hostname_is_nonempty():
 def test_dirty_emits_warning(monkeypatch):
     monkeypatch.setattr(execution, "_resolve_dirty", lambda: "dirty")
     with pytest.warns(UserWarning, match="uncommitted changes"):
-        result = gather_execution_provenance()
-    # Stored as bool on the execution attrs for back-compat.
-    assert result[CONST.EXECUTION_DIRTY_ATTR] is True
+        result = gather_pipeline_provenance()
+    # Stored as the 3-state string (matches init_* and backend_*).
+    assert result[CONST.PIPELINE_DIRTY_ATTR] == "dirty"
 
 
 def test_clean_tree_does_not_warn(monkeypatch):
     monkeypatch.setattr(execution, "_resolve_dirty", lambda: "clean")
     with warnings.catch_warnings():
         warnings.simplefilter("error", UserWarning)
-        result = gather_execution_provenance()
-    assert result[CONST.EXECUTION_DIRTY_ATTR] is False
+        result = gather_pipeline_provenance()
+    assert result[CONST.PIPELINE_DIRTY_ATTR] == "clean"
 
 
 def test_dirty_warning_fires_once_per_process(monkeypatch):
     """Second consecutive dirty gather is silent."""
     monkeypatch.setattr(execution, "_resolve_dirty", lambda: "dirty")
     with pytest.warns(UserWarning, match="uncommitted changes"):
-        gather_execution_provenance()
+        gather_pipeline_provenance()
     # No warning on the second call.
     with warnings.catch_warnings():
         warnings.simplefilter("error", UserWarning)
-        gather_execution_provenance()
+        gather_pipeline_provenance()
 
 
 def test_mark_dirty_warning_emitted_suppresses_subsequent(monkeypatch):
@@ -149,7 +149,7 @@ def test_mark_dirty_warning_emitted_suppresses_subsequent(monkeypatch):
     mark_dirty_warning_emitted()
     with warnings.catch_warnings():
         warnings.simplefilter("error", UserWarning)
-        gather_execution_provenance()
+        gather_pipeline_provenance()
         gather_init_provenance()
 
 
@@ -169,7 +169,7 @@ def test_init_and_execution_share_dedup_flag(monkeypatch):
         gather_init_provenance()
     with warnings.catch_warnings():
         warnings.simplefilter("error", UserWarning)
-        gather_execution_provenance()
+        gather_pipeline_provenance()
 
 
 def test_allow_dirty_env_truthy(monkeypatch):

--- a/tests/tools/test_provenance_migrate.py
+++ b/tests/tools/test_provenance_migrate.py
@@ -1,0 +1,182 @@
+"""Tests for the provenance-attr migration: pure transform + file round-trip (#61)."""
+
+import importlib.util
+from pathlib import Path
+
+import h5py
+import numpy as np
+import pytest
+
+from lysis.config.constants import CONST
+from lysis.tools.provenance.migrate import migrate_provenance_group
+
+
+# --------------------------------------------------------------------------- #
+# Load the standalone migration script as a module (it lives under scripts/).
+# --------------------------------------------------------------------------- #
+_SCRIPT = (
+    Path(__file__).resolve().parents[2] / "scripts" / "migrate_provenance_attrs.py"
+)
+_spec = importlib.util.spec_from_file_location("migrate_provenance_attrs", _SCRIPT)
+migrate_script = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(migrate_script)
+
+
+# --------------------------------------------------------------------------- #
+# Pure transform
+# --------------------------------------------------------------------------- #
+class TestMigrateProvenanceGroup:
+    def test_full_old_group_maps_to_new(self):
+        old = {
+            "execution_version": "abc123",
+            "execution_dirty": np.False_,
+            "execution_timestamp": "2025-01-01T00:00:00",
+            "execution_hostname": "node01",
+            "execution_backend": "fortran",
+            "binary_commit": "d" * 40,
+            "binary_dirty": "clean",
+            "binary_compiler": "ifort 2023",
+            "binary_source": "historical:" + "d" * 40,
+            "init_version": "zzz",          # untouched
+            "init_dirty": "clean",          # untouched
+            "dataspec_version": "v2.0.0",   # untouched
+        }
+        sets, deletes = migrate_provenance_group(old)
+
+        assert sets[CONST.PIPELINE_VERSION_ATTR] == "abc123"
+        assert sets[CONST.PIPELINE_DIRTY_ATTR] == "clean"  # bool False -> "clean"
+        assert sets[CONST.PIPELINE_TIMESTAMP_ATTR] == "2025-01-01T00:00:00"
+        assert sets[CONST.PIPELINE_HOSTNAME_ATTR] == "node01"
+        assert sets[CONST.BACKEND_TYPE_ATTR] == "fortran"
+        assert sets[CONST.BACKEND_COMMIT_ATTR] == "d" * 40
+        assert sets[CONST.BACKEND_DIRTY_ATTR] == "clean"
+        assert sets[CONST.BACKEND_COMPILER_ATTR] == "ifort 2023"
+        assert sets[CONST.BACKEND_HISTORICAL_ATTR] is True
+
+        # Old keys removed; init_*/dataspec_version are not in deletes.
+        assert deletes == {
+            "execution_version", "execution_dirty", "execution_timestamp",
+            "execution_hostname", "execution_backend", "binary_commit",
+            "binary_dirty", "binary_compiler", "binary_source",
+        }
+        assert "init_version" not in deletes
+        assert "dataspec_version" not in deletes
+        assert CONST.INIT_VERSION_ATTR not in sets
+
+    def test_dirty_true_maps_to_dirty_string(self):
+        sets, _ = migrate_provenance_group({"execution_dirty": True})
+        assert sets[CONST.PIPELINE_DIRTY_ATTR] == "dirty"
+
+    def test_backend_type_defaults_to_fortran_without_execution_backend(self):
+        sets, _ = migrate_provenance_group(
+            {"binary_commit": "a" * 40, "binary_dirty": "clean"}
+        )
+        assert sets[CONST.BACKEND_TYPE_ATTR] == "fortran"
+
+    def test_backend_type_preserves_python(self):
+        sets, _ = migrate_provenance_group(
+            {"execution_backend": "python", "binary_commit": "a" * 40}
+        )
+        assert sets[CONST.BACKEND_TYPE_ATTR] == "python"
+
+    def test_no_old_attrs_is_noop(self):
+        # Already-migrated group → empty result (idempotent).
+        already = {
+            CONST.PIPELINE_VERSION_ATTR: "x",
+            CONST.BACKEND_COMMIT_ATTR: "y",
+            CONST.INIT_VERSION_ATTR: "z",
+        }
+        sets, deletes = migrate_provenance_group(already)
+        assert sets == {}
+        assert deletes == set()
+
+    def test_binary_source_absent_no_historical_flag(self):
+        sets, _ = migrate_provenance_group({"binary_commit": "a" * 40})
+        assert CONST.BACKEND_HISTORICAL_ATTR not in sets
+
+    def test_stale_override_renamed(self):
+        sets, deletes = migrate_provenance_group(
+            {"binary_commit": "a" * 40, "stale_binary_override": True}
+        )
+        assert sets["stale_backend_override"] is True
+        assert "stale_binary_override" in deletes
+
+
+# --------------------------------------------------------------------------- #
+# File round-trip via the script's migrate_file()
+# --------------------------------------------------------------------------- #
+def _make_old_file(path):
+    """Write a minimal v2.0.0 file with OLD provenance attrs + a couple datasets."""
+    with h5py.File(path, "w") as f:
+        f.attrs["dataspec_version"] = "v2.0.0"
+        g = f.create_group("micro_data")
+        g.attrs["execution_version"] = "abc123"
+        g.attrs["execution_dirty"] = np.False_
+        g.attrs["execution_timestamp"] = "2025-01-01T00:00:00"
+        g.attrs["execution_hostname"] = "node01"
+        g.attrs["binary_commit"] = "d" * 40
+        g.attrs["binary_dirty"] = "clean"
+        g.attrs["binary_compiler"] = "ifort 2023"
+        g.attrs["binary_source"] = "historical:" + "d" * 40
+        g.attrs["init_version"] = "init-sha"   # must survive untouched
+        g.attrs["init_dirty"] = "clean"
+        g.create_dataset("ints", data=np.arange(50, dtype=np.int64))
+        f.create_dataset(
+            "micro_data/strings",
+            data=np.array(["a", "bb", "ccc"], dtype=h5py.string_dtype()),
+        )
+
+
+def test_migrate_file_round_trip(tmp_path):
+    path = str(tmp_path / "old.h5")
+    _make_old_file(path)
+
+    migrate_script.migrate_file(path, backup_dir=str(tmp_path / "bak"))
+
+    with h5py.File(path, "r") as f:
+        attrs = f["micro_data"].attrs
+        # New names present, correctly typed.
+        assert attrs[CONST.PIPELINE_VERSION_ATTR] == "abc123"
+        assert attrs[CONST.PIPELINE_DIRTY_ATTR] == "clean"
+        assert attrs[CONST.BACKEND_COMMIT_ATTR] == "d" * 40
+        assert attrs[CONST.BACKEND_TYPE_ATTR] == "fortran"
+        assert bool(attrs[CONST.BACKEND_HISTORICAL_ATTR]) is True
+        # Old names gone.
+        for old in ("execution_version", "execution_dirty", "binary_commit",
+                    "binary_source", "binary_dirty", "binary_compiler"):
+            assert old not in attrs
+        # init_* untouched; datasets intact.
+        assert attrs["init_version"] == "init-sha"
+        assert attrs["init_dirty"] == "clean"
+        assert list(f["micro_data/ints"][...]) == list(range(50))
+        assert f.attrs["dataspec_version"] == "v2.0.0"
+
+    # Backup was created.
+    assert any((tmp_path / "bak").iterdir())
+
+
+def test_migrate_file_idempotent(tmp_path):
+    path = str(tmp_path / "old.h5")
+    _make_old_file(path)
+    migrate_script.migrate_file(path, backup_dir=str(tmp_path / "bak"))
+    # Second pass: classifier says already-migrated, and migrate_file is a no-op.
+    assert migrate_script.classify(path) == "already-migrated"
+    assert migrate_script.migrate_file(path, backup_dir=str(tmp_path / "bak2")) == {}
+
+
+def test_migrate_file_halts_on_dataset_change(tmp_path, monkeypatch):
+    """If a dataset checksum differs post-edit, migrate_file raises (halt)."""
+    path = str(tmp_path / "old.h5")
+    _make_old_file(path)
+
+    # Force every checksum call to return a unique value so pre != post.
+    counter = {"n": 0}
+
+    def _drifting_checksum(ds):
+        counter["n"] += 1
+        return f"sha-{counter['n']}"
+
+    monkeypatch.setattr(migrate_script, "_dataset_checksum", _drifting_checksum)
+
+    with pytest.raises(migrate_script.IntegrityError, match="dataset changed"):
+        migrate_script.migrate_file(path, backup_dir=str(tmp_path / "bak"))

--- a/tests/tools/test_provenance_migrate.py
+++ b/tests/tools/test_provenance_migrate.py
@@ -12,10 +12,14 @@ from lysis.tools.provenance.migrate import migrate_provenance_group
 
 
 # --------------------------------------------------------------------------- #
-# Load the standalone migration script as a module (it lives under scripts/).
+# Load the standalone migration script as a module.  It is an archived one-off
+# (archive/scripts/), kept as a template; we still test it so the template keeps
+# working.  Its `migrate_file()` is exercised directly, bypassing the CLI safety
+# valve (which only gates the `--apply` path in main()).
 # --------------------------------------------------------------------------- #
 _SCRIPT = (
-    Path(__file__).resolve().parents[2] / "scripts" / "migrate_provenance_attrs.py"
+    Path(__file__).resolve().parents[2]
+    / "archive" / "scripts" / "migrate_provenance_attrs.py"
 )
 _spec = importlib.util.spec_from_file_location("migrate_provenance_attrs", _SCRIPT)
 migrate_script = importlib.util.module_from_spec(_spec)

--- a/tests/tools/test_provenance_migrate.py
+++ b/tests/tools/test_provenance_migrate.py
@@ -164,6 +164,30 @@ def test_migrate_file_idempotent(tmp_path):
     assert migrate_script.migrate_file(path, backup_dir=str(tmp_path / "bak2")) == {}
 
 
+def test_migrate_file_writes_sha_log(tmp_path):
+    path = str(tmp_path / "old.h5")
+    _make_old_file(path)
+    bak = str(tmp_path / "bak")
+    migrate_script.migrate_file(path, backup_dir=bak)
+
+    # A per-file .sha256.txt sits next to the backup copy.
+    flat = migrate_script._backup_basename(path)
+    log = Path(bak) / (flat + ".sha256.txt")
+    assert log.is_file()
+    text = log.read_text()
+
+    assert "[pre-edit]" in text and "[post-edit]" in text
+    pre_block, post_block = text.split("[post-edit]")
+    # Every dataset appears in both sections, and (since datasets are untouched)
+    # each dataset's pre and post sha are identical.
+    for ds in ("micro_data/ints", "micro_data/strings"):
+        assert ds in pre_block and ds in post_block
+        pre_sha = [l for l in pre_block.splitlines() if l.startswith(ds + "  ")][0].split()[1]
+        post_sha = [l for l in post_block.splitlines() if l.startswith(ds + "  ")][0].split()[1]
+        assert pre_sha == post_sha
+        assert len(pre_sha) == 64  # sha256 hexdigest
+
+
 def test_migrate_file_halts_on_dataset_change(tmp_path, monkeypatch):
     """If a dataset checksum differs post-edit, migrate_file raises (halt)."""
     path = str(tmp_path / "old.h5")

--- a/tests/tools/test_slurm.py
+++ b/tests/tools/test_slurm.py
@@ -529,41 +529,41 @@ class TestSubmitMicroSlurmJob:
     def test_master_py_historical_attrs_absent_by_default(
         self, mock_sbatch, micro_hdf5, tmp_path
     ):
-        """Without --fortran-commit, the master script keeps HISTORICAL_BINARY_ATTRS = None."""
+        """Without --fortran-commit, the master script keeps HISTORICAL_BACKEND_ATTRS = None."""
         staging_root = tmp_path / "staging_root"
         staging_root.mkdir()
         submit_micro_slurm_job(micro_hdf5, "/bin/micro.exe",
                                staging_root=staging_root)
         staging_dir = list(staging_root.iterdir())[0]
         master_content = (staging_dir / "lysis-micro-master__run-01.py").read_text()
-        assert "HISTORICAL_BINARY_ATTRS = None" in master_content
+        assert "HISTORICAL_BACKEND_ATTRS = None" in master_content
 
     @patch("lysis.tools.slurm.gs.sbatch", return_value=1)
     def test_master_py_bakes_historical_attrs(
         self, mock_sbatch, micro_hdf5, tmp_path
     ):
-        """When historical_binary_attrs is given, the dict is repr'd into the master script."""
+        """When historical_backend_attrs is given, the dict is repr'd into the master script."""
         staging_root = tmp_path / "staging_root"
         staging_root.mkdir()
         prov = {
-            "binary_commit": "a" * 40,
-            "binary_dirty": "clean",
-            "binary_compiler": "GCC 11.4.0",
-            "binary_source": "historical:" + "a" * 40,
+            "backend_commit": "a" * 40,
+            "backend_dirty": "clean",
+            "backend_compiler": "GCC 11.4.0",
+            "backend_historical": True,
         }
         submit_micro_slurm_job(
             micro_hdf5, "/bin/micro.exe",
             staging_root=staging_root,
-            historical_binary_attrs=prov,
+            historical_backend_attrs=prov,
         )
         staging_dir = list(staging_root.iterdir())[0]
         master_content = (staging_dir / "lysis-micro-master__run-01.py").read_text()
         # The literal dict must round-trip through repr() into the script.
-        assert "HISTORICAL_BINARY_ATTRS = {" in master_content
-        assert "'binary_source': 'historical:" + "a" * 40 + "'" in master_content
+        assert "HISTORICAL_BACKEND_ATTRS = {" in master_content
+        assert "'backend_historical': True" in master_content
         # And the runner construction must opt in to skip_binary_verification.
         assert (
-            "skip_binary_verification=(HISTORICAL_BINARY_ATTRS is not None)"
+            "skip_binary_verification=(HISTORICAL_BACKEND_ATTRS is not None)"
             in master_content
         )
 
@@ -903,26 +903,26 @@ class TestSubmitMacroSlurmJob:
     def test_master_py_bakes_historical_attrs(
         self, mock_sbatch, macro_hdf5, tmp_path, mock_write_setup
     ):
-        """Macro slurm path: historical_binary_attrs dict gets repr'd into the master script."""
+        """Macro slurm path: historical_backend_attrs dict gets repr'd into the master script."""
         staging_root = tmp_path / "staging_root"
         staging_root.mkdir()
         prov = {
-            "binary_commit": "b" * 40,
-            "binary_dirty": "clean",
-            "binary_compiler": "Intel(R) Fortran 2023.0",
-            "binary_source": "historical:" + "b" * 40,
+            "backend_commit": "b" * 40,
+            "backend_dirty": "clean",
+            "backend_compiler": "Intel(R) Fortran 2023.0",
+            "backend_historical": True,
         }
         submit_macro_slurm_job(
             macro_hdf5, "/bin/macro.exe",
             staging_root=staging_root,
-            historical_binary_attrs=prov,
+            historical_backend_attrs=prov,
         )
         staging_dir = list(staging_root.iterdir())[0]
         master_content = (staging_dir / "lysis-macro-master__run-01.py").read_text()
-        assert "HISTORICAL_BINARY_ATTRS = {" in master_content
-        assert "'binary_source': 'historical:" + "b" * 40 + "'" in master_content
+        assert "HISTORICAL_BACKEND_ATTRS = {" in master_content
+        assert "'backend_historical': True" in master_content
         assert (
-            "skip_binary_verification=(HISTORICAL_BINARY_ATTRS is not None)"
+            "skip_binary_verification=(HISTORICAL_BACKEND_ATTRS is not None)"
             in master_content
         )
 
@@ -1557,9 +1557,9 @@ class TestHistoricalBinaryAttrsInChildAndArrayScripts:
     """
 
     _HIST = {
-        "binary_commit": "a" * 40,
-        "binary_dirty": False,
-        "binary_source": "historical:" + "a" * 40,
+        "backend_commit": "a" * 40,
+        "backend_dirty": False,
+        "backend_historical": True,
     }
 
     # -- generate_micro_child_script (legacy single-child path) ------------
@@ -1569,7 +1569,7 @@ class TestHistoricalBinaryAttrsInChildAndArrayScripts:
         script = generate_micro_child_script(
             tmp_path / "stage", "run-01", tmp_path / "run-01.h5",
             "/build/bin/micro_rates", "",
-            historical_binary_attrs=self._HIST,
+            historical_backend_attrs=self._HIST,
         )
         assert "/build/bin/micro_rates" not in script
         assert "cp " not in script
@@ -1578,7 +1578,7 @@ class TestHistoricalBinaryAttrsInChildAndArrayScripts:
         script = generate_micro_child_script(
             tmp_path / "stage", "run-01", tmp_path / "run-01.h5",
             "/build/bin/micro_rates", "",
-            historical_binary_attrs=self._HIST,
+            historical_backend_attrs=self._HIST,
         )
         assert "skip_binary_verification=True" in script
 
@@ -1589,7 +1589,7 @@ class TestHistoricalBinaryAttrsInChildAndArrayScripts:
             staging, "run-01", tmp_path / "run-01.h5",
             "/build/bin/micro_rates", "",
             fast_tmp_root="/nvme/scratch",
-            historical_binary_attrs=self._HIST,
+            historical_backend_attrs=self._HIST,
         )
         assert "/build/bin/micro_rates" not in script
         assert f'cp "{staging}/micro_rates" "${{local_work_dir}}/"' in script
@@ -1599,7 +1599,7 @@ class TestHistoricalBinaryAttrsInChildAndArrayScripts:
             tmp_path / "stage", "run-01", tmp_path / "run-01.h5",
             "/build/bin/micro_rates", "",
             fast_tmp_root="/nvme/scratch",
-            historical_binary_attrs=self._HIST,
+            historical_backend_attrs=self._HIST,
         )
         assert "skip_binary_verification=True" in script
 
@@ -1617,7 +1617,7 @@ class TestHistoricalBinaryAttrsInChildAndArrayScripts:
         script = generate_micro_array_script(
             tmp_path / "stage", "run-01", tmp_path / "run-01.h5",
             "/build/bin/micro_rates", num_children=4,
-            historical_binary_attrs=self._HIST,
+            historical_backend_attrs=self._HIST,
         )
         assert "skip_binary_verification=True" in script
 
@@ -1627,7 +1627,7 @@ class TestHistoricalBinaryAttrsInChildAndArrayScripts:
             staging, "run-01", tmp_path / "run-01.h5",
             "/build/bin/micro_rates", num_children=4,
             fast_tmp_root="/nvme/scratch",
-            historical_binary_attrs=self._HIST,
+            historical_backend_attrs=self._HIST,
         )
         assert "/build/bin/micro_rates" not in script
         assert f'cp "{staging}/micro_rates" "${{local_work_dir}}/"' in script
@@ -1639,7 +1639,7 @@ class TestHistoricalBinaryAttrsInChildAndArrayScripts:
         script = generate_macro_array_script(
             tmp_path / "stage", "run-01", tmp_path / "run-01.h5",
             "/build/bin/macro.exe", n_sims=3,
-            historical_binary_attrs=self._HIST,
+            historical_backend_attrs=self._HIST,
         )
         assert "skip_binary_verification=True" in script
 
@@ -1649,7 +1649,7 @@ class TestHistoricalBinaryAttrsInChildAndArrayScripts:
             staging, "run-01", tmp_path / "run-01.h5",
             "/build/bin/macro.exe", n_sims=3,
             fast_tmp_root="/nvme/scratch",
-            historical_binary_attrs=self._HIST,
+            historical_backend_attrs=self._HIST,
         )
         assert "/build/bin/macro.exe" not in script
         assert f'cp "{staging}/macro.exe" "${{local_work_dir}}/"' in script
@@ -1724,7 +1724,7 @@ class TestSourceStampInGeneratedScripts:
         script = generate_micro_child_script(
             tmp_path / "stage", "run-01", tmp_path / "run-01.h5",
             "/bin/micro.exe", "",
-            historical_binary_attrs={"binary_commit": "h" * 40},
+            historical_backend_attrs={"backend_commit": "h" * 40},
             source_stamp=self._STAMP,
         )
         assert "source_stamp=" not in script
@@ -1759,7 +1759,7 @@ class TestSourceStampInGeneratedScripts:
         script = generate_array_script(
             spec, tmp_path / "stage", "run-01", tmp_path / "run-01.h5",
             "/bin/micro.exe",
-            historical_binary_attrs={"binary_commit": "h" * 40},
+            historical_backend_attrs={"backend_commit": "h" * 40},
             source_stamp=self._STAMP,
         )
         assert "source_stamp=" not in script
@@ -1772,14 +1772,14 @@ class TestSourceStampInGeneratedScripts:
 
 
 class TestSubmitWithHistoricalBinaryAttrsEndToEnd:
-    """End-to-end: submit_*_slurm_job threads historical_binary_attrs into
+    """End-to-end: submit_*_slurm_job threads historical_backend_attrs into
     every generated child/array script.
     """
 
     _HIST = {
-        "binary_commit": "b" * 40,
-        "binary_dirty": False,
-        "binary_source": "historical:" + "b" * 40,
+        "backend_commit": "b" * 40,
+        "backend_dirty": False,
+        "backend_historical": True,
     }
 
     @pytest.fixture(autouse=True)
@@ -1797,7 +1797,7 @@ class TestSubmitWithHistoricalBinaryAttrsEndToEnd:
         submit_micro_slurm_job(
             micro_hdf5, "/build/bin/micro_rates",
             staging_root=staging_root,
-            historical_binary_attrs=self._HIST,
+            historical_backend_attrs=self._HIST,
         )
         staging_dir = list(staging_root.iterdir())[0]
         child = (staging_dir / "lysis-micro-child__run-01.sh").read_text()
@@ -1820,7 +1820,7 @@ class TestSubmitWithHistoricalBinaryAttrsEndToEnd:
                 micro_hdf5, "/build/bin/micro_rates",
                 staging_root=staging_root,
                 num_children=4,
-                historical_binary_attrs=self._HIST,
+                historical_backend_attrs=self._HIST,
             )
         staging_dir = list(staging_root.iterdir())[0]
         array = (staging_dir / "lysis-micro-array__run-01.sh").read_text()


### PR DESCRIPTION
Closes #61.

## Summary

Codifies the v1.0.0 HDF5 provenance schema stamped onto the per-scale params
groups (`micro_data` / `macro_data`). This is a deliberate **hard break** for
the v2.0.0 on-disk format (no reader shim; `dataspec_version` stays `v2.0.0`).

- `execution_*` → `pipeline_*` — the family records the lysis Python *pipeline*
  that orchestrated init/import, not the engine that executes the simulation.
- `binary_*` → `backend_*` — so the same family can describe a future Python
  backend (#35).
- All `*_dirty` are now the 3-state string `clean`/`dirty`/`unknown`.
  `execution_dirty` was a bool that silently collapsed `unknown` into clean.
- New `backend_type` (`fortran`/`python`), stamped on every run.
- Dropped `binary_source` (`historical:<sha>`, redundant with `binary_commit`);
  replaced by a boolean `backend_historical` (SHA already lives in `backend_commit`).
- Renamed the stamped attr `stale_binary_override` → `stale_backend_override`
  (the `--allow-stale-binary` flag and `LYSIS_ALLOW_STALE_BINARY` env var are unchanged).

Touches the gather functions, `DataStore.stamp_provenance`/`import_collection`
(kind `execution`→`pipeline`, `binary`→`backend`; param renames), the Fortran
runners + Slurm plumbing (`historical_binary_attrs`→`historical_backend_attrs`),
the `run-*` CLIs, tests, `data_specification.rst`, and the CHANGELOG.

## Data migration (completed)

Existing files were migrated in place by a guard-railed one-off tool, now parked
in `archive/scripts/` as a template behind a `_SAFETY_VALVE` line (forces
dry-run until removed). Guardrails: dry-run by default, per-dataset SHA-256
verification before/after each edit (halt + name the file on any mismatch),
whole-file backups + per-file `.sha256.txt` audit sidecars, parallel by file,
and an ownership gate.

All **1,198** old-schema files migrated, 0 halts, independently re-verified
(0 leftover old attrs):

| Location | Migrated |
|---|---|
| `~/git/.../data/` | 86 |
| `/shared/lysis-group/` (mine) | 721 |
| `/shared/lysis-group/wpumphrey/` | 391 |

The reusable pure transform stays in-package
(`lysis.tools.provenance.migrate.migrate_provenance_group`) so it remains unit-tested.

## Testing

`make clean && make` (fresh Intel build) then the full suite: **1951 passed,
16 skipped**, 63 benign provenance warnings, 0 failures.

## Follow-up

#77 (v1.1.0): make the #35 Python-backend path stamp `backend_type` instead of
the legacy `execution_backend` it currently writes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)