### PR TITLE
Slurm: stage worker .out logs + identifying header & shell tracing (#84, #81)

### DIFF
--- a/src/lysis/tools/slurm.py
+++ b/src/lysis/tools/slurm.py
@@ -168,6 +168,92 @@ def _env_preamble(
     return "\n".join(lines)
 
 
+def _log_header(
+    *,
+    scale: str,
+    role: str,
+    run_code: str,
+    experiment: Optional[str] = None,
+    pythonpath: "Path | str | None" = None,
+) -> str:
+    """Return the bash block that prints a job header, then enables strict tracing.
+
+    Emitted in every generated Slurm script (master, array task, legacy
+    single child) immediately *after* :func:`_env_preamble`.  The block has
+    two parts:
+
+    1. A fenced **identifying header** written to stdout (so it lands in the
+       job's ``.out`` log) that mixes *submit-time* fields baked in here
+       (*scale*, *role*, *run_code*, *experiment*, the generator's
+       ``lysis.__version__``, and the pinned *pythonpath* snapshot) with
+       *runtime* ``${SLURM_*}`` expansions evaluated on the compute node
+       (cluster, host, partition, node list, job/array ids, allocated
+       cpus/mem, submit dir, start time).
+    2. ``set -euo pipefail`` followed by ``set -x``.
+
+    The header is printed **before** strict mode is enabled so its optional
+    ``${SLURM_*}`` reads cannot trip ``set -u`` (each is additionally guarded
+    with a ``${VAR:-…}`` default for readable output); ``set -x`` then traces
+    every subsequent command into the same log.
+
+    :param scale: ``"micro"`` or ``"macro"``.
+    :type scale: str
+    :param role: Job role for the header, e.g. ``"master"``,
+        ``"array task"``, ``"micro child"``.
+    :type role: str
+    :param run_code: Run identifier (HDF5 file stem).
+    :type run_code: str
+    :param experiment: Best-effort experiment identifier; ``None`` (default)
+        renders as ``(unknown)`` (no first-class experiment concept yet).
+    :type experiment: str, optional
+    :param pythonpath: The pinned ``python_src`` snapshot directory baked
+        onto ``PYTHONPATH``; ``None`` (default) renders as
+        ``(editable install)``.
+    :type pythonpath: Path or str, optional
+    :return: Bash snippet (header + strict-mode lines), no trailing newline.
+    :rtype: str
+    """
+    import lysis  # noqa: PLC0415 — avoids pulling lysis at module import
+
+    version = getattr(lysis, "__version__", "(unknown)")
+    experiment_field = experiment if experiment else "(unknown)"
+    pythonpath_field = (
+        str(pythonpath) if pythonpath is not None else "(editable install)"
+    )
+    return f"""\
+# Identifying header (to stdout) printed BEFORE strict mode so its optional
+# ${{SLURM_*}} reads can't abort the job under ``set -u``; ``set -x`` then
+# traces every subsequent command into the same .out log.
+cat <<HEADER
+============================================================
+lysis slurm task
+------------------------------------------------------------
+scale       : {scale}
+role        : {role}
+run         : {run_code}
+experiment  : {experiment_field}
+generator   : lysis {version}
+pythonpath  : {pythonpath_field}
+job name    : ${{SLURM_JOB_NAME:-(unknown)}}
+cluster     : ${{SLURM_CLUSTER_NAME:-(unknown)}}
+partition   : ${{SLURM_JOB_PARTITION:-(unknown)}}
+host        : $(hostname -f 2>/dev/null || hostname)
+node list   : ${{SLURM_JOB_NODELIST:-(unknown)}}
+user        : ${{USER:-$(id -un)}}
+submit dir  : ${{SLURM_SUBMIT_DIR:-(unknown)}}
+job id      : ${{SLURM_JOB_ID:-(unknown)}}
+array       : ${{SLURM_ARRAY_JOB_ID:-n/a}}_${{SLURM_ARRAY_TASK_ID:-n/a}}
+cpus        : ${{SLURM_CPUS_ON_NODE:-(unknown)}}
+mem (MB)    : ${{SLURM_MEM_PER_NODE:-(unknown)}}
+started     : $(date -Iseconds)
+============================================================
+HEADER
+
+# Strict mode + command tracing for the remainder of the script.
+set -euo pipefail
+set -x"""
+
+
 def _snapshot_lysis_src(repo_root: Path, staging_dir: Path) -> Path:
     """Copy ``src/lysis/`` into the staging dir and return the importable root.
 
@@ -670,11 +756,19 @@ def generate_array_script(
     historical_backend_attrs: Optional[dict] = None,
     pythonpath: "Path | str | None" = None,
     source_stamp: Optional[tuple] = None,
+    experiment: Optional[str] = None,
 ) -> str:
     """Generate a Slurm array job bash script for an array-mode dispatch.
 
     Each array task indexed by ``SLURM_ARRAY_TASK_ID`` calls
     ``{spec.runner_class}.from_hdf5(...).exec_in_workdir(...)``.
+
+    Every generated task begins with an identifying header (see
+    :func:`_log_header`) and then enables ``set -euo pipefail`` + ``set -x``,
+    so the per-task ``.out`` log records which job/host/allocation ran and
+    traces each shell step.  Because Slurm does not substitute ``%a`` in
+    ``--job-name`` (only in ``--output``), the array shares a single job
+    name and the per-task index is surfaced via that header.
 
     For the *macroscale* path each task isolates its output in a
     per-simulation subdirectory ``data/{run_code}/{sim:02}/`` (managed by
@@ -706,8 +800,12 @@ def generate_array_script(
     :type partition: str, optional
     :param fast_tmp_root: Root directory for fast node-local scratch.
     :type fast_tmp_root: str, optional
-    :param slurm_log_dir: Directory for Slurm ``.out`` logs.  Defaults to
-        ``hdf5_path.parent / ".slurm"``.
+    :param slurm_log_dir: Retained for API compatibility; no longer used
+        by this generator.  The array task's ``--output`` now writes into
+        *staging_dir* (alongside the generated scripts), so worker
+        stdout/stderr — including the identifying header and ``set -x``
+        trace — is co-located with the run's scripts and data rather than
+        in ``hdf5_path.parent / ".slurm"``.
     :type slurm_log_dir: Path or str, optional
     :param modules: Space-separated list of LMod module specs to load in
         each generated task script (include a Fortran compiler module so
@@ -742,6 +840,9 @@ def generate_array_script(
         check is bypassed in that workflow).  ``None`` (default)
         preserves the in-process git lookup.
     :type source_stamp: tuple[str, str] or None
+    :param experiment: Best-effort experiment identifier shown in the log
+        header; ``None`` (default) renders as ``(unknown)``.
+    :type experiment: str, optional
     :return: Slurm array job bash script text.
     :rtype: str
     :raises ImportError: If ``GooseSLURM`` is not installed.
@@ -751,21 +852,29 @@ def generate_array_script(
     hdf5_path = Path(hdf5_path)
     executable = Path(executable)
     binary_name = executable.name
-    if slurm_log_dir is None:
-        slurm_log_dir = hdf5_path.parent / ".slurm"
-    slurm_log_dir = Path(slurm_log_dir)
     skip_binary_verification = historical_backend_attrs is not None
 
     repo_root = _repo_root()
-    env_preamble = _env_preamble(
-        repo_root, modules, pythonpath=pythonpath
+    # Leading section: env setup (module/PATH/PYTHONPATH) runs first, then the
+    # header prints and strict mode + tracing engage for the rest of the task.
+    lead = "{}\n{}".format(
+        _env_preamble(repo_root, modules, pythonpath=pythonpath),
+        _log_header(
+            scale=spec.scale, role="array task", run_code=run_code,
+            experiment=experiment, pythonpath=pythonpath,
+        ),
     )
     py = _uv_python_prefix(repo_root)
 
     sbatch_opts = {
         "array": f"0-{spec.num_array_tasks - 1}",
-        "job-name": f"lysis-{spec.scale}-array__{run_code}__%a",
-        "out": str(slurm_log_dir / f"lysis-{spec.scale}-array__{run_code}__%a.out"),
+        # Slurm does not substitute ``%a`` in ``--job-name`` (only in
+        # ``--output``/``--error``), so the whole array shares one name; the
+        # per-task index is surfaced via the log header instead.
+        "job-name": f"lysis-{spec.scale}-array__{run_code}",
+        # Worker stdout/stderr (incl. the header + ``set -x`` trace) lands in
+        # the staging dir alongside the generated scripts — not in ``.slurm``.
+        "out": str(staging_dir / f"lysis-{spec.scale}-array__{run_code}__%a.out"),
         "nodes": 1,
         "mem": 3096,
         "ntasks": 1,
@@ -789,7 +898,6 @@ def generate_array_script(
         )
         execute = f"""\
 # Execute {spec.scale}scale Fortran binary via lysis
-{env_preamble}
 {py} -c "
 import os
 from pathlib import Path
@@ -798,7 +906,7 @@ fm = {init}
 fm.exec_in_workdir(Path('{staging_dir}'))
 " """
 
-        sections = [execute]
+        sections = [lead, execute]
 
     else:
         # ------------------------------------------------------------------
@@ -831,7 +939,6 @@ cp "{staging_dir}/{binary_name}" "${{local_work_dir}}/" """
         )
         execute = f"""\
 # Execute {spec.scale}scale Fortran binary into local fast storage
-{env_preamble}
 {py} -c "
 import os
 from pathlib import Path
@@ -845,7 +952,7 @@ fm.exec_in_workdir(Path('${{local_work_dir}}'))
 {mv_section}
 rm -rf "${{local_work_dir}}" """
 
-        sections = [setup, execute, move]
+        sections = [lead, setup, execute, move]
 
     return gs.scripts.plain(sections, **sbatch_opts)
 
@@ -862,6 +969,7 @@ def submit_slurm_job(
     modules: str = DEFAULT_MODULES,
     sbatch_overrides: Optional[Mapping[str, Optional[str]]] = None,
     historical_backend_attrs: Optional[dict] = None,
+    experiment: Optional[str] = None,
 ) -> int:
     """Stage scripts and submit a master Slurm job for an array-mode dispatch.
 
@@ -901,6 +1009,10 @@ def submit_slurm_job(
         in place of the default ``<binary> --version`` query.  ``None``
         (default) preserves normal-mode provenance.
     :type historical_backend_attrs: dict, optional
+    :param experiment: Best-effort experiment identifier shown in the log
+        header of the master and array-task scripts; ``None`` (default)
+        renders as ``(unknown)``.
+    :type experiment: str, optional
     :return: Master Slurm job ID.
     :rtype: int
     :raises ImportError: If ``GooseSLURM`` is not installed.
@@ -977,6 +1089,7 @@ def submit_slurm_job(
         historical_backend_attrs=historical_backend_attrs,
         pythonpath=pythonpath,
         source_stamp=source_stamp,
+        experiment=experiment,
     )
     array_path = staging_dir / f"lysis-{spec.scale}-array__{run_code}.sh"
     array_path.write_text(array_script)
@@ -1011,6 +1124,10 @@ def submit_slurm_job(
     master_sh_content = gs.scripts.plain(
         [
             _env_preamble(repo_root, modules, pythonpath=pythonpath),
+            _log_header(
+                scale=spec.scale, role="master", run_code=run_code,
+                experiment=experiment, pythonpath=pythonpath,
+            ),
             f'{_uv_python_prefix(repo_root)} "{master_py_path}"',
         ],
         **sbatch_opts,
@@ -1042,6 +1159,7 @@ def generate_micro_child_script(
     historical_backend_attrs: Optional[dict] = None,
     pythonpath: "Path | str | None" = None,
     source_stamp: Optional[tuple] = None,
+    experiment: Optional[str] = None,
 ) -> str:
     """Generate a Slurm bash script for a single child microscale Fortran job.
 
@@ -1051,7 +1169,9 @@ def generate_micro_child_script(
     The child script sources the user's shell environment, copies the
     executable into the working directory, and calls
     :meth:`~lysis.execution.fortran_micro.FortranMicro.exec_in_workdir` via
-    ``python -c``.
+    ``python -c``.  It begins with an identifying header (see
+    :func:`_log_header`) and then enables ``set -euo pipefail`` + ``set -x``
+    so the ``.out`` log records the job context and traces each shell step.
 
     **Single-tier** (default, ``fast_tmp_root=None``): Fortran writes its
     output directly to ``{staging_dir}/data/{run_code}/``.
@@ -1075,8 +1195,12 @@ def generate_micro_child_script(
     :type partition: str, optional
     :param fast_tmp_root: Root directory for fast node-local scratch.
     :type fast_tmp_root: str, optional
-    :param slurm_log_dir: Directory for Slurm ``.out`` logs.  Defaults to
-        ``hdf5_path.parent / ".slurm"``.
+    :param slurm_log_dir: Retained for API compatibility; no longer used
+        by this generator.  The child's ``--output`` now writes into
+        *staging_dir* (alongside the generated scripts), so worker
+        stdout/stderr — including the identifying header and ``set -x``
+        trace — is co-located with the run's scripts and data rather than
+        in ``hdf5_path.parent / ".slurm"``.
     :type slurm_log_dir: Path or str, optional
     :param modules: Space-separated list of LMod module specs (include a
         Fortran compiler module so the binary finds its runtime), baked into the generated script.  Defaults to
@@ -1108,6 +1232,9 @@ def generate_micro_child_script(
         ``historical_backend_attrs`` is set.  ``None`` (default)
         preserves the in-process git lookup.
     :type source_stamp: tuple[str, str] or None
+    :param experiment: Best-effort experiment identifier shown in the log
+        header; ``None`` (default) renders as ``(unknown)``.
+    :type experiment: str, optional
     :return: Slurm bash script text.
     :rtype: str
     :raises ImportError: If ``GooseSLURM`` is not installed.
@@ -1117,19 +1244,24 @@ def generate_micro_child_script(
     hdf5_path = Path(hdf5_path)
     executable = Path(executable)
     binary_name = executable.name
-    if slurm_log_dir is None:
-        slurm_log_dir = hdf5_path.parent / ".slurm"
-    slurm_log_dir = Path(slurm_log_dir)
 
     repo_root = _repo_root()
-    env_preamble = _env_preamble(
-        repo_root, modules, pythonpath=pythonpath
+    # Leading section: env setup runs first, then the header prints and strict
+    # mode + tracing engage for the rest of the child script.
+    lead = "{}\n{}".format(
+        _env_preamble(repo_root, modules, pythonpath=pythonpath),
+        _log_header(
+            scale="micro", role="micro child", run_code=run_code,
+            experiment=experiment, pythonpath=pythonpath,
+        ),
     )
     py = _uv_python_prefix(repo_root)
 
     sbatch_opts = {
         "job-name": f"lysis-micro-child__{run_code}",
-        "out": str(slurm_log_dir / f"lysis-micro-child__{run_code}.out"),
+        # Worker stdout/stderr (incl. the header + ``set -x`` trace) lands in
+        # the staging dir alongside the generated scripts — not in ``.slurm``.
+        "out": str(staging_dir / f"lysis-micro-child__{run_code}.out"),
         "nodes": 1,
         "mem": 3096,
         "ntasks": 1,
@@ -1166,7 +1298,6 @@ mkdir -p "${{staging_datadir}}" """
 
         execute = f"""\
 # Execute Fortran binary via lysis
-{env_preamble}
 {py} -c "
 from pathlib import Path
 from lysis.execution.fortran_micro import FortranMicro
@@ -1174,7 +1305,7 @@ fm = FortranMicro.from_hdf5('{hdf5_path}', '{staging_dir}/{binary_name}', out_fi
 fm.exec_in_workdir(Path('{staging_dir}'))
 " """
 
-        sections = [setup, execute]
+        sections = [lead, setup, execute]
 
     else:
         # ------------------------------------------------------------------
@@ -1194,7 +1325,6 @@ cp "{staging_dir}/{binary_name}" "${{local_work_dir}}/" """
 
         execute = f"""\
 # Execute Fortran binary into local fast storage
-{env_preamble}
 {py} -c "
 from pathlib import Path
 from lysis.execution.fortran_micro import FortranMicro
@@ -1207,7 +1337,7 @@ fm.exec_in_workdir(Path('${{local_work_dir}}'))
 mv "${local_datadir}"/* "${staging_datadir}/"
 rm -rf "${local_work_dir}" """
 
-        sections = [setup, execute, move]
+        sections = [lead, setup, execute, move]
 
     return gs.scripts.plain(sections, **sbatch_opts)
 
@@ -1291,6 +1421,7 @@ def generate_micro_array_script(
     modules: str = DEFAULT_MODULES,
     sbatch_overrides: Optional[Mapping[str, Optional[str]]] = None,
     historical_backend_attrs: Optional[dict] = None,
+    experiment: Optional[str] = None,
 ) -> str:
     """Generate a Slurm array job script for the microscale Fortran simulation.
 
@@ -1322,6 +1453,7 @@ def generate_micro_array_script(
         modules=modules,
         sbatch_overrides=sbatch_overrides,
         historical_backend_attrs=historical_backend_attrs,
+        experiment=experiment,
     )
 
 
@@ -1338,6 +1470,7 @@ def submit_micro_slurm_job(
     modules: str = DEFAULT_MODULES,
     sbatch_overrides: Optional[Mapping[str, Optional[str]]] = None,
     historical_backend_attrs: Optional[dict] = None,
+    experiment: Optional[str] = None,
 ) -> int:
     """Submit the full HDF5-integrated microscale workflow as a Slurm master job.
 
@@ -1407,6 +1540,10 @@ def submit_micro_slurm_job(
         ``<binary> --version`` query.  ``None`` (default) preserves
         normal-mode provenance.
     :type historical_backend_attrs: dict, optional
+    :param experiment: Best-effort experiment identifier shown in the log
+        header of every generated script; ``None`` (default) renders as
+        ``(unknown)``.
+    :type experiment: str, optional
     :return: Master Slurm job ID.
     :rtype: int
     :raises subprocess.CalledProcessError: If ``sbatch`` fails.
@@ -1451,6 +1588,7 @@ def submit_micro_slurm_job(
             modules=modules,
             sbatch_overrides=sbatch_overrides,
             historical_backend_attrs=historical_backend_attrs,
+            experiment=experiment,
         )
 
     # ------------------------------------------------------------------
@@ -1512,6 +1650,7 @@ def submit_micro_slurm_job(
         historical_backend_attrs=historical_backend_attrs,
         pythonpath=pythonpath,
         source_stamp=source_stamp,
+        experiment=experiment,
     )
     child_path = staging_dir / f"lysis-micro-child__{run_code}.sh"
     child_path.write_text(child_script)
@@ -1546,6 +1685,10 @@ def submit_micro_slurm_job(
     master_sh_content = gs.scripts.plain(
         [
             _env_preamble(repo_root, modules, pythonpath=pythonpath),
+            _log_header(
+                scale="micro", role="master", run_code=run_code,
+                experiment=experiment, pythonpath=pythonpath,
+            ),
             f'{_uv_python_prefix(repo_root)} "{master_py_path}"',
         ],
         **sbatch_opts,
@@ -1593,6 +1736,7 @@ def generate_macro_array_script(
     modules: str = DEFAULT_MODULES,
     sbatch_overrides: Optional[Mapping[str, Optional[str]]] = None,
     historical_backend_attrs: Optional[dict] = None,
+    experiment: Optional[str] = None,
 ) -> str:
     """Generate a Slurm array job script for the macroscale Fortran simulation.
 
@@ -1622,6 +1766,7 @@ def generate_macro_array_script(
         modules=modules,
         sbatch_overrides=sbatch_overrides,
         historical_backend_attrs=historical_backend_attrs,
+        experiment=experiment,
     )
 
 
@@ -1638,6 +1783,7 @@ def submit_macro_slurm_job(
     modules: str = DEFAULT_MODULES,
     sbatch_overrides: Optional[Mapping[str, Optional[str]]] = None,
     historical_backend_attrs: Optional[dict] = None,
+    experiment: Optional[str] = None,
 ) -> int:
     """Submit the full HDF5-integrated macroscale workflow as a Slurm master job.
 
@@ -1697,6 +1843,10 @@ def submit_macro_slurm_job(
         default ``<binary> --version`` query.  ``None`` (default)
         preserves normal-mode provenance.
     :type historical_backend_attrs: dict, optional
+    :param experiment: Best-effort experiment identifier shown in the log
+        header of the master and array-task scripts; ``None`` (default)
+        renders as ``(unknown)``.
+    :type experiment: str, optional
     :return: Master Slurm job ID.
     :rtype: int
     :raises subprocess.CalledProcessError: If ``sbatch`` fails.
@@ -1728,4 +1878,5 @@ def submit_macro_slurm_job(
         modules=modules,
         sbatch_overrides=sbatch_overrides,
         historical_backend_attrs=historical_backend_attrs,
+        experiment=experiment,
     )

--- a/src/lysis/tools/slurm.py
+++ b/src/lysis/tools/slurm.py
@@ -49,6 +49,7 @@ dependencies still come from ``.venv`` and are pinned separately by
    for ``/tmp`` that is too small for simulation data.
 """
 
+import shlex
 import shutil
 import subprocess
 import tempfile
@@ -183,12 +184,16 @@ def _log_header(
     two parts:
 
     1. A fenced **identifying header** written to stdout (so it lands in the
-       job's ``.out`` log) that mixes *submit-time* fields baked in here
-       (*scale*, *role*, *run_code*, *experiment*, the generator's
-       ``lysis.__version__``, and the pinned *pythonpath* snapshot) with
-       *runtime* ``${SLURM_*}`` expansions evaluated on the compute node
-       (cluster, host, partition, node list, job/array ids, allocated
-       cpus/mem, submit dir, start time).
+       job's ``.out`` log).  *Submit-time* fields baked in here (*scale*,
+       *role*, *run_code*, *experiment*, the generator's ``lysis.__version__``,
+       and the pinned *pythonpath* snapshot) are emitted via ``printf`` with
+       each line passed as a ``shlex.quote``-escaped shell literal, so bash
+       performs **no** parameter/command substitution on them — a
+       caller-controlled value such as ``experiment="EXP-$(cmd)"`` is printed
+       verbatim, never executed.  *Runtime* fields are emitted via a separate
+       heredoc whose body contains only our own ``${SLURM_*}``/``$(...)``
+       expansions (cluster, host, partition, node list, job/array ids,
+       allocated cpus/mem, submit dir, start time) — no caller input.
     2. ``set -euo pipefail`` followed by ``set -x``.
 
     The header is printed **before** strict mode is enabled so its optional
@@ -220,38 +225,56 @@ def _log_header(
     pythonpath_field = (
         str(pythonpath) if pythonpath is not None else "(editable install)"
     )
-    return f"""\
-# Identifying header (to stdout) printed BEFORE strict mode so its optional
-# ${{SLURM_*}} reads can't abort the job under ``set -u``; ``set -x`` then
-# traces every subsequent command into the same .out log.
-cat <<HEADER
-============================================================
-lysis slurm task
-------------------------------------------------------------
-scale       : {scale}
-role        : {role}
-run         : {run_code}
-experiment  : {experiment_field}
-generator   : lysis {version}
-pythonpath  : {pythonpath_field}
-job name    : ${{SLURM_JOB_NAME:-(unknown)}}
-cluster     : ${{SLURM_CLUSTER_NAME:-(unknown)}}
-partition   : ${{SLURM_JOB_PARTITION:-(unknown)}}
-host        : $(hostname -f 2>/dev/null || hostname)
-node list   : ${{SLURM_JOB_NODELIST:-(unknown)}}
-user        : ${{USER:-$(id -un)}}
-submit dir  : ${{SLURM_SUBMIT_DIR:-(unknown)}}
-job id      : ${{SLURM_JOB_ID:-(unknown)}}
-array       : ${{SLURM_ARRAY_JOB_ID:-n/a}}_${{SLURM_ARRAY_TASK_ID:-n/a}}
-cpus        : ${{SLURM_CPUS_ON_NODE:-(unknown)}}
-mem (MB)    : ${{SLURM_MEM_PER_NODE:-(unknown)}}
-started     : $(date -Iseconds)
-============================================================
-HEADER
-
-# Strict mode + command tracing for the remainder of the script.
-set -euo pipefail
-set -x"""
+    # Submit-time fields: emitted via ``printf`` with each line shell-quoted,
+    # so caller-controlled values (e.g. *experiment*) cannot inject command or
+    # parameter substitution into the unprivileged-looking header.
+    baked_lines = [
+        "============================================================",
+        "lysis slurm task",
+        "------------------------------------------------------------",
+        f"scale       : {scale}",
+        f"role        : {role}",
+        f"run         : {run_code}",
+        f"experiment  : {experiment_field}",
+        f"generator   : lysis {version}",
+        f"pythonpath  : {pythonpath_field}",
+    ]
+    baked_block = "printf '%s\\n' \\\n" + " \\\n".join(
+        "    " + shlex.quote(line) for line in baked_lines
+    )
+    # Runtime fields: intentionally expanded by bash on the compute node.  The
+    # heredoc body contains only our own ${SLURM_*}/$(...) — never caller input.
+    runtime_block = (
+        "cat <<RUNTIME\n"
+        "job name    : ${SLURM_JOB_NAME:-(unknown)}\n"
+        "cluster     : ${SLURM_CLUSTER_NAME:-(unknown)}\n"
+        "partition   : ${SLURM_JOB_PARTITION:-(unknown)}\n"
+        "host        : $(hostname -f 2>/dev/null || hostname)\n"
+        "node list   : ${SLURM_JOB_NODELIST:-(unknown)}\n"
+        "user        : ${USER:-$(id -un)}\n"
+        "submit dir  : ${SLURM_SUBMIT_DIR:-(unknown)}\n"
+        "job id      : ${SLURM_JOB_ID:-(unknown)}\n"
+        "array       : ${SLURM_ARRAY_JOB_ID:-n/a}_${SLURM_ARRAY_TASK_ID:-n/a}\n"
+        "cpus        : ${SLURM_CPUS_ON_NODE:-(unknown)}\n"
+        "mem (MB)    : ${SLURM_MEM_PER_NODE:-(unknown)}\n"
+        "started     : $(date -Iseconds)\n"
+        "============================================================\n"
+        "RUNTIME"
+    )
+    return (
+        "# Identifying header (to stdout) printed BEFORE strict mode so its\n"
+        "# optional ${SLURM_*} reads can't abort the job under ``set -u``;\n"
+        "# ``set -x`` then traces the rest of the script into the same .out\n"
+        "# log.  Submit-time fields are shell-quoted (printf) to prevent\n"
+        "# command injection; runtime ${SLURM_*} fields are expanded on the\n"
+        "# compute node (cat heredoc).\n"
+        f"{baked_block}\n"
+        f"{runtime_block}\n"
+        "\n"
+        "# Strict mode + command tracing for the remainder of the script.\n"
+        "set -euo pipefail\n"
+        "set -x"
+    )
 
 
 def _snapshot_lysis_src(repo_root: Path, staging_dir: Path) -> Path:
@@ -926,6 +949,9 @@ fm.exec_in_workdir(Path('{staging_dir}'))
 # Setup — create local fast dir, copy setup files and binary
 SIM=$(printf "%02d" ${{SLURM_ARRAY_TASK_ID}})
 local_work_dir=$(mktemp -d -p "{fast_tmp_root}")
+# Always reclaim node-local scratch on exit — including a ``set -e`` abort in
+# the mv below — so a failed move never leaks the fast-tmp work dir.
+trap 'rm -rf "${{local_work_dir}}"' EXIT
 local_datadir="${{local_work_dir}}/data/{run_code}"
 staging_datadir="{staging_dir}/data/{run_code}"
 mkdir -p "${{local_datadir}}"
@@ -948,9 +974,8 @@ fm.exec_in_workdir(Path('${{local_work_dir}}'))
 " """
 
         move = f"""\
-# Move per-task output to shared staging, then clean up local dir
-{mv_section}
-rm -rf "${{local_work_dir}}" """
+# Move per-task output to shared staging (local dir reclaimed by EXIT trap)
+{mv_section}"""
 
         sections = [lead, setup, execute, move]
 
@@ -1317,6 +1342,9 @@ fm.exec_in_workdir(Path('{staging_dir}'))
         setup = f"""\
 # Setup — create local fast dir and shared staging dir
 local_work_dir=$(mktemp -d -p "{fast_tmp_root}")
+# Always reclaim node-local scratch on exit — including a ``set -e`` abort in
+# the mv below — so a failed move never leaks the fast-tmp work dir.
+trap 'rm -rf "${{local_work_dir}}"' EXIT
 local_datadir="${{local_work_dir}}/data/{run_code}"
 staging_datadir="{staging_dir}/data/{run_code}"
 mkdir -p "${{local_datadir}}"
@@ -1333,9 +1361,8 @@ fm.exec_in_workdir(Path('${{local_work_dir}}'))
 " """
 
         move = """\
-# Move output to shared staging, then remove local fast dir
-mv "${local_datadir}"/* "${staging_datadir}/"
-rm -rf "${local_work_dir}" """
+# Move output to shared staging (local fast dir reclaimed by EXIT trap)
+mv "${local_datadir}"/* "${staging_datadir}/" """
 
         sections = [lead, setup, execute, move]
 

--- a/tests/tools/test_slurm.py
+++ b/tests/tools/test_slurm.py
@@ -9,6 +9,7 @@ Tests cover:
 """
 
 import os
+import re
 from pathlib import Path
 from unittest.mock import MagicMock, call, patch
 
@@ -1995,3 +1996,172 @@ class TestSourcePinningInGeneratedScripts:
             pythonpath="/snap/python_src",
         )
         assert 'export PYTHONPATH="/snap/python_src"' in script
+
+
+# ---------------------------------------------------------------------------
+# Worker log relocation (#84) + identifying header & shell tracing (#81)
+# ---------------------------------------------------------------------------
+
+
+def _sbatch_value_line(script: str, flag: str) -> str:
+    """Return the ``#SBATCH {flag} ...`` line from a generated script."""
+    for line in script.splitlines():
+        s = line.strip()
+        if s.startswith(f"#SBATCH {flag} "):
+            return s
+    raise AssertionError(f"no '#SBATCH {flag}' directive in script")
+
+
+class TestWorkerLogOutputAndHeader:
+    """#84: worker ``--output`` → staging dir. #81: header + ``set -x`` tracing."""
+
+    # ---- #84: worker --output lands in the staging dir, NOT in .slurm -----
+
+    def test_child_output_in_staging_not_slurm(self, tmp_path):
+        staging = tmp_path / "staging"
+        script = generate_micro_child_script(
+            staging, "run-01", tmp_path / "run-01.h5", "/bin/micro.exe", "",
+        )
+        out_line = _sbatch_value_line(script, "--out")
+        assert str(staging / "lysis-micro-child__run-01.out") in out_line
+        assert ".slurm" not in out_line
+
+    def test_micro_array_output_in_staging_not_slurm(self, tmp_path):
+        staging = tmp_path / "staging"
+        script = generate_micro_array_script(
+            staging, "run-01", tmp_path / "run-01.h5", "/bin/micro.exe", 5,
+        )
+        out_line = _sbatch_value_line(script, "--out")
+        assert str(staging / "lysis-micro-array__run-01__%a.out") in out_line
+        assert ".slurm" not in out_line
+
+    def test_macro_array_output_in_staging_not_slurm(self, tmp_path):
+        staging = tmp_path / "staging"
+        script = generate_macro_array_script(
+            staging, "run-01", tmp_path / "run-01.h5", "/bin/macro.exe", n_sims=5,
+        )
+        out_line = _sbatch_value_line(script, "--out")
+        assert str(staging / "lysis-macro-array__run-01__%a.out") in out_line
+        assert ".slurm" not in out_line
+
+    # ---- #81 comment: array --job-name carries no literal %a --------------
+
+    def test_micro_array_job_name_has_no_literal_percent_a(self, tmp_path):
+        script = generate_micro_array_script(
+            tmp_path / "s", "run-01", tmp_path / "run-01.h5", "/bin/micro.exe", 5,
+        )
+        name_line = _sbatch_value_line(script, "--job-name")
+        assert name_line.endswith("lysis-micro-array__run-01")
+        assert "%a" not in name_line
+
+    def test_macro_array_job_name_has_no_literal_percent_a(self, tmp_path):
+        script = generate_macro_array_script(
+            tmp_path / "s", "run-01", tmp_path / "run-01.h5", "/bin/macro.exe",
+            n_sims=5,
+        )
+        name_line = _sbatch_value_line(script, "--job-name")
+        assert name_line.endswith("lysis-macro-array__run-01")
+        assert "%a" not in name_line
+
+    # ---- #81: identifying header content ----------------------------------
+
+    def test_header_present_with_baked_and_runtime_fields(self, tmp_path):
+        script = generate_micro_array_script(
+            tmp_path / "s", "run-01", tmp_path / "run-01.h5", "/bin/micro.exe", 5,
+        )
+        assert "lysis slurm task" in script
+        # Baked submit-time fields.
+        assert re.search(r"^run\s+: run-01$", script, re.M)
+        assert re.search(r"^scale\s+: micro$", script, re.M)
+        assert re.search(r"^role\s+: array task$", script, re.M)
+        # Runtime ${SLURM_*} expansions (evaluated on the compute node).
+        assert "${SLURM_JOB_ID" in script
+        assert "${SLURM_ARRAY_TASK_ID" in script
+
+    def test_child_header_role_is_micro_child(self, tmp_path):
+        script = generate_micro_child_script(
+            tmp_path / "s", "run-01", tmp_path / "run-01.h5", "/bin/micro.exe", "",
+        )
+        assert re.search(r"^role\s+: micro child$", script, re.M)
+
+    def test_experiment_field_default_unknown(self, tmp_path):
+        script = generate_micro_child_script(
+            tmp_path / "s", "run-01", tmp_path / "run-01.h5", "/bin/micro.exe", "",
+        )
+        assert re.search(r"^experiment\s+: \(unknown\)$", script, re.M)
+
+    def test_experiment_field_threaded(self, tmp_path):
+        script = generate_micro_child_script(
+            tmp_path / "s", "run-01", tmp_path / "run-01.h5", "/bin/micro.exe", "",
+            experiment="EXP-42",
+        )
+        assert re.search(r"^experiment\s+: EXP-42$", script, re.M)
+
+    # ---- #81: strict mode + tracing, enabled AFTER the header -------------
+
+    def test_strict_mode_and_trace_enabled_after_header(self, tmp_path):
+        script = generate_micro_child_script(
+            tmp_path / "s", "run-01", tmp_path / "run-01.h5", "/bin/micro.exe", "",
+        )
+        assert "set -euo pipefail" in script
+        assert "\nset -x" in script
+        header_pos = script.index("lysis slurm task")
+        # Strict mode (incl. nounset) is enabled only after the header prints,
+        # so the header's optional ${SLURM_*} reads can't trip ``set -u``.
+        assert header_pos < script.index("set -euo pipefail")
+        assert header_pos < script.index("\nset -x")
+
+    def test_two_tier_setup_runs_under_trace(self, tmp_path):
+        """SIM/cp/mv setup must come AFTER ``set -x`` so it is traced."""
+        script = generate_macro_array_script(
+            tmp_path / "s", "run-01", tmp_path / "run-01.h5", "/bin/macro.exe",
+            n_sims=5, fast_tmp_root="/scratch",
+        )
+        assert script.index("\nset -x") < script.index("SIM=")
+
+
+class TestMasterLogStaysInSlurm:
+    """#84 scope: master ``--output`` stays in ``.slurm`` (worker-only move)."""
+
+    @pytest.fixture(autouse=True)
+    def _patch_copy2(self):
+        with patch("lysis.tools.slurm.shutil.copy2"):
+            yield
+
+    def _staging_dir(self, root):
+        return next(
+            p for p in root.iterdir() if p.is_dir() and "lysis-micro" in p.name
+        )
+
+    @patch("lysis.tools.slurm.gs.sbatch", return_value=1)
+    def test_legacy_master_output_in_slurm_with_header(
+        self, mock_sbatch, micro_hdf5, tmp_path
+    ):
+        submit_micro_slurm_job(micro_hdf5, "/bin/micro.exe", staging_root=tmp_path)
+        master = (
+            self._staging_dir(tmp_path) / "lysis-micro-master__run-01.sh"
+        ).read_text()
+        out_line = _sbatch_value_line(master, "--out")
+        assert ".slurm" in out_line
+        # The master also gets the identifying header + tracing.
+        assert "lysis slurm task" in master
+        assert re.search(r"^role\s+: master$", master, re.M)
+        assert "set -x" in master
+
+    @patch("lysis.tools.slurm.gs.sbatch", return_value=1)
+    def test_array_master_output_in_slurm_with_header(
+        self, mock_sbatch, micro_hdf5, tmp_path
+    ):
+        with patch(
+            "lysis.execution.fortran_micro.FortranMicro._write_setup_files"
+        ):
+            submit_micro_slurm_job(
+                micro_hdf5, "/bin/micro.exe",
+                staging_root=tmp_path, num_children=5,
+            )
+        master = (
+            self._staging_dir(tmp_path) / "lysis-micro-master__run-01.sh"
+        ).read_text()
+        out_line = _sbatch_value_line(master, "--out")
+        assert ".slurm" in out_line
+        assert re.search(r"^role\s+: master$", master, re.M)

--- a/tests/tools/test_slurm.py
+++ b/tests/tools/test_slurm.py
@@ -2070,10 +2070,10 @@ class TestWorkerLogOutputAndHeader:
             tmp_path / "s", "run-01", tmp_path / "run-01.h5", "/bin/micro.exe", 5,
         )
         assert "lysis slurm task" in script
-        # Baked submit-time fields.
-        assert re.search(r"^run\s+: run-01$", script, re.M)
-        assert re.search(r"^scale\s+: micro$", script, re.M)
-        assert re.search(r"^role\s+: array task$", script, re.M)
+        # Baked submit-time fields (emitted via printf, hence not line-anchored).
+        assert re.search(r"run\s+: run-01", script)
+        assert re.search(r"scale\s+: micro", script)
+        assert re.search(r"role\s+: array task", script)
         # Runtime ${SLURM_*} expansions (evaluated on the compute node).
         assert "${SLURM_JOB_ID" in script
         assert "${SLURM_ARRAY_TASK_ID" in script
@@ -2082,20 +2082,37 @@ class TestWorkerLogOutputAndHeader:
         script = generate_micro_child_script(
             tmp_path / "s", "run-01", tmp_path / "run-01.h5", "/bin/micro.exe", "",
         )
-        assert re.search(r"^role\s+: micro child$", script, re.M)
+        assert re.search(r"role\s+: micro child", script)
 
     def test_experiment_field_default_unknown(self, tmp_path):
         script = generate_micro_child_script(
             tmp_path / "s", "run-01", tmp_path / "run-01.h5", "/bin/micro.exe", "",
         )
-        assert re.search(r"^experiment\s+: \(unknown\)$", script, re.M)
+        assert re.search(r"experiment\s+: \(unknown\)", script)
 
     def test_experiment_field_threaded(self, tmp_path):
         script = generate_micro_child_script(
             tmp_path / "s", "run-01", tmp_path / "run-01.h5", "/bin/micro.exe", "",
             experiment="EXP-42",
         )
-        assert re.search(r"^experiment\s+: EXP-42$", script, re.M)
+        assert re.search(r"experiment\s+: EXP-42", script)
+
+    def test_experiment_value_is_shell_quoted_against_injection(self, tmp_path):
+        """A caller-controlled experiment with $(...) must be baked verbatim.
+
+        The header's submit-time fields are emitted via ``printf`` with each
+        line shell-quoted, so bash never performs command/parameter
+        substitution on them.  The malicious sequence must appear inside a
+        single-quoted printf argument, where ``$(...)`` is inert.
+        """
+        script = generate_micro_child_script(
+            tmp_path / "s", "run-01", tmp_path / "run-01.h5", "/bin/micro.exe", "",
+            experiment="EXP-$(touch /tmp/pwned)",
+        )
+        # The whole header line is a single-quoted printf literal — $() inert.
+        assert "'experiment  : EXP-$(touch /tmp/pwned)'" in script
+        # And it is NOT emitted via the unquoted runtime heredoc.
+        assert "cat <<HEADER" not in script
 
     # ---- #81: strict mode + tracing, enabled AFTER the header -------------
 
@@ -2118,6 +2135,36 @@ class TestWorkerLogOutputAndHeader:
             n_sims=5, fast_tmp_root="/scratch",
         )
         assert script.index("\nset -x") < script.index("SIM=")
+
+    # ---- B: two-tier fast-scratch is reclaimed on any exit (set -e safe) ---
+
+    @pytest.mark.parametrize(
+        "make_script",
+        [
+            lambda p: generate_micro_array_script(
+                p / "s", "run-01", p / "run-01.h5", "/bin/micro.exe", 5,
+                fast_tmp_root="/scratch",
+            ),
+            lambda p: generate_macro_array_script(
+                p / "s", "run-01", p / "run-01.h5", "/bin/macro.exe",
+                n_sims=5, fast_tmp_root="/scratch",
+            ),
+            lambda p: generate_micro_child_script(
+                p / "s", "run-01", p / "run-01.h5", "/bin/micro.exe", "",
+                fast_tmp_root="/scratch",
+            ),
+        ],
+        ids=["micro-array", "macro-array", "micro-child"],
+    )
+    def test_two_tier_registers_cleanup_trap_before_mv(self, tmp_path, make_script):
+        script = make_script(tmp_path)
+        assert 'trap \'rm -rf "${local_work_dir}"\' EXIT' in script
+        # Trap must be registered before the risky mv so a set -e abort there
+        # still reclaims the fast-tmp dir (no permanent node-local leak).
+        assert script.index("trap ") < script.index('mv "${local_datadir}')
+        # The old unconditional post-mv ``rm -rf`` is gone (trap owns cleanup);
+        # only the trap references rm -rf of the work dir.
+        assert script.count('rm -rf "${local_work_dir}"') == 1
 
 
 class TestMasterLogStaysInSlurm:
@@ -2145,7 +2192,7 @@ class TestMasterLogStaysInSlurm:
         assert ".slurm" in out_line
         # The master also gets the identifying header + tracing.
         assert "lysis slurm task" in master
-        assert re.search(r"^role\s+: master$", master, re.M)
+        assert re.search(r"role\s+: master", master)
         assert "set -x" in master
 
     @patch("lysis.tools.slurm.gs.sbatch", return_value=1)
@@ -2164,4 +2211,4 @@ class TestMasterLogStaysInSlurm:
         ).read_text()
         out_line = _sbatch_value_line(master, "--out")
         assert ".slurm" in out_line
-        assert re.search(r"^role\s+: master$", master, re.M)
+        assert re.search(r"role\s+: master", master)


### PR DESCRIPTION
Implements **#84** (simplified) and **#81** together, since both touch `src/lysis/tools/slurm.py` and the same test surface.

## #84 — worker `--output` → staging dir
Per the simplified scope agreed on the issue, this is a plain `--output` retarget (not the original in-script `exec` redirect + `*_dispatcher_log` DataSpec ingestion).

- Array tasks (`generate_array_script`) and the legacy single child (`generate_micro_child_script`) now write their `#SBATCH --output` into the **master job's staging dir**, alongside `lysis-*-array__*.sh` / `lysis-*-master__*.{py,sh}`, instead of the never-cleaned `<hdf5_dir>/.slurm/`.
- **Scope: worker jobs only.** The two master `--output` directives stay in `.slurm/` (the master `shutil.rmtree`s the staging dir on success, which would otherwise self-delete a master log placed there).
- **Retention:** worker logs are removed with the staging dir on success (`keep_tmpdir=False`); kept on failure (the master crashes before its `rmtree`, so staging — logs included — is preserved for triage).
- The unpadded Slurm `%a` is used in the worker `.out` filename (zero-padding deliberately not preserved here; to be handled elsewhere).

## #81 — identifying header + shell tracing
- New `_log_header()` helper: a fenced `lysis slurm task` header printed to stdout mixing **baked** submit-time fields (scale, role, run, experiment, `lysis.__version__`, pythonpath snapshot) with **runtime** `${SLURM_*}` expansions (cluster, host, partition, node list, job/array ids, cpus/mem, submit dir, start time).
- Wired into all four generated scripts (array task, legacy child, array master, legacy micro master), right after `_env_preamble`.
- Strict mode: **full `set -euo pipefail` + `set -x`, enabled only after the header prints** — so the header's optional `${SLURM_*}` reads can't trip `set -u`, and tracing then covers the rest of the script (incl. the two-tier `setup`/`cp`/`mv`).
- **Array `--job-name` fix** (issue comment): drops the literal `%a` (Slurm never substitutes it in `--job-name`, only in `--output`); the per-task index is surfaced via the header. No `scontrol` queue mutation.
- Optional `experiment` kwarg threaded through the public submit functions, defaulting to `(unknown)`.

## Tests
2 new classes (16 tests) in `tests/tools/test_slurm.py`: worker `--output` in staging (+ no `.slurm`), master keeps `.slurm`, header content, header-before-strict-mode ordering, two-tier setup traced, no literal `%a` in `--job-name`, and `experiment` threading.

- `tests/tools/test_slurm.py`: **172 passed**
- `tests/cli/test_run_micro.py` + `test_run_macro.py`: **83 passed**

## Remaining manual step
Live-cluster verification of the new header + traced steps in real `.out` files (noted as manual in #81).

Closes #84
Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)