### PR TITLE
Slurm two-tier: guard all glob-based cp/mv transfers under set -e (micro + macro)

### DIFF
--- a/src/lysis/tools/slurm.py
+++ b/src/lysis/tools/slurm.py
@@ -277,6 +277,59 @@ def _log_header(
     )
 
 
+def _guarded_glob_xfer(
+    verb: str,
+    glob: str,
+    dest: str,
+    *,
+    array_name: str,
+    empty_msg: str,
+) -> str:
+    """Return a bash block that ``cp``/``mv``-es a glob's matches, or fails loud.
+
+    Generated Slurm scripts run under ``set -euo pipefail``.  A bare
+    ``cp``/``mv`` of ``${dir}/*`` is unsafe there: with ``nullglob`` off an
+    empty *dir* leaves the ``*`` unexpanded, so the command aborts the task
+    with a cryptic ``cannot stat '…/*'``.  This helper collects the matches
+    into an array under ``nullglob``, then either prints a clear,
+    lysis-branded error and exits non-zero when there are none (so an
+    unexpectedly empty source is never *silently* skipped), or runs *verb* on
+    the collected files.
+
+    Used for every glob-based transfer in the two-tier (fast-tmp) paths — the
+    staged-setup-file copy and the micro per-task output move.  Named-path
+    transfers (the macro per-sim ``mv`` and the single-file binary ``cp``) do
+    not need it: they already fail clearly on a missing operand.
+
+    :param verb: ``"cp"`` or ``"mv"``.
+    :type verb: str
+    :param glob: Source glob, already quoted for bash (e.g.
+        ``'"${local_datadir}"/*'``).
+    :type glob: str
+    :param dest: Destination, already quoted for bash (e.g.
+        ``'"${staging_datadir}/"'``).
+    :type dest: str
+    :param array_name: Bash array variable to collect matches into; must be
+        unique within the script (e.g. ``"staged_files"``, ``"output_files"``).
+    :type array_name: str
+    :param empty_msg: Reason shown in the "nothing matched" error; may
+        reference bash vars (e.g. ``"no output in ${local_datadir}"``).
+    :type empty_msg: str
+    :return: Multi-line bash snippet, no trailing newline.
+    :rtype: str
+    """
+    return (
+        "shopt -s nullglob\n"
+        f"{array_name}=({glob})\n"
+        "shopt -u nullglob\n"
+        f'if [ "${{#{array_name}[@]}}" -eq 0 ]; then\n'
+        f'    echo "lysis: {empty_msg}" >&2\n'
+        "    exit 1\n"
+        "fi\n"
+        f'{verb} "${{{array_name}[@]}}" {dest}'
+    )
+
+
 def _snapshot_lysis_src(repo_root: Path, staging_dir: Path) -> Path:
     """Copy ``src/lysis/`` into the staging dir and return the importable root.
 
@@ -936,11 +989,25 @@ fm.exec_in_workdir(Path('{staging_dir}'))
         # Two-tier: copy setup files → local fast dir, run, then mv to staging
         # ------------------------------------------------------------------
         if spec.scale == "macro":
-            # Macro tasks write per-sim subdirs; mv just the one this task owns.
+            # Macro tasks write a single named per-sim subdir — mv by name
+            # (no glob, so it fails clearly on a missing operand).
             mv_section = 'mv "${local_datadir}/${SIM}" "${staging_datadir}/"'
         else:
-            # Micro array tasks write flat __NN-suffixed files; mv all of them.
-            mv_section = 'mv "${local_datadir}"/* "${staging_datadir}/"'
+            # Micro array tasks write flat __NN-suffixed files; guard the glob
+            # mv so an empty local dir fails loud instead of choking on ``*``.
+            mv_section = _guarded_glob_xfer(
+                "mv", '"${local_datadir}"/*', '"${staging_datadir}/"',
+                array_name="output_files",
+                empty_msg="no per-task output in ${local_datadir} to move",
+            )
+
+        # Guarded copy of the staged setup files into the local fast dir (the
+        # ``*`` would otherwise choke under ``set -e`` on an empty staging dir).
+        guarded_setup_cp = _guarded_glob_xfer(
+            "cp", '"${staging_datadir}"/*', '"${local_datadir}/"',
+            array_name="staged_files",
+            empty_msg="no staged setup files in ${staging_datadir}",
+        )
 
         # Source the binary from the pre-staged staging-dir copy, not the
         # caller's --executable path: under --fortran-commit the build dir
@@ -955,18 +1022,8 @@ trap 'rm -rf "${{local_work_dir}}"' EXIT
 local_datadir="${{local_work_dir}}/data/{run_code}"
 staging_datadir="{staging_dir}/data/{run_code}"
 mkdir -p "${{local_datadir}}"
-# Copy staged setup files into the local fast dir.  Guard the glob: under
-# ``set -e`` an empty staging dir would make cp choke on an unexpanded ``*``;
-# instead collect matches with nullglob and fail loudly with a clear message
-# (so a missing/empty staging dir never silently skips setup either).
-shopt -s nullglob
-staged_files=("${{staging_datadir}}"/*)
-shopt -u nullglob
-if [ "${{#staged_files[@]}}" -eq 0 ]; then
-    echo "lysis: no staged setup files in ${{staging_datadir}}" >&2
-    exit 1
-fi
-cp "${{staged_files[@]}}" "${{local_datadir}}/"
+# Copy staged setup files into the local fast dir (glob guarded).
+{guarded_setup_cp}
 cp "{staging_dir}/{binary_name}" "${{local_work_dir}}/" """
 
         init = _runner_init_line(
@@ -1371,9 +1428,17 @@ fm = FortranMicro.from_hdf5('{hdf5_path}', '${{local_work_dir}}/{binary_name}', 
 fm.exec_in_workdir(Path('${{local_work_dir}}'))
 " """
 
-        move = """\
+        # Guard the glob mv so an empty local dir fails loud (clear lysis
+        # message + non-zero exit) instead of choking on an unexpanded ``*``
+        # under ``set -e``; the EXIT trap still reclaims the fast-tmp dir.
+        guarded_move = _guarded_glob_xfer(
+            "mv", '"${local_datadir}"/*', '"${staging_datadir}/"',
+            array_name="output_files",
+            empty_msg="no output in ${local_datadir} to move",
+        )
+        move = f"""\
 # Move output to shared staging (local fast dir reclaimed by EXIT trap)
-mv "${local_datadir}"/* "${staging_datadir}/" """
+{guarded_move}"""
 
         sections = [lead, setup, execute, move]
 

--- a/src/lysis/tools/slurm.py
+++ b/src/lysis/tools/slurm.py
@@ -955,7 +955,18 @@ trap 'rm -rf "${{local_work_dir}}"' EXIT
 local_datadir="${{local_work_dir}}/data/{run_code}"
 staging_datadir="{staging_dir}/data/{run_code}"
 mkdir -p "${{local_datadir}}"
-cp "${{staging_datadir}}/"* "${{local_datadir}}/"
+# Copy staged setup files into the local fast dir.  Guard the glob: under
+# ``set -e`` an empty staging dir would make cp choke on an unexpanded ``*``;
+# instead collect matches with nullglob and fail loudly with a clear message
+# (so a missing/empty staging dir never silently skips setup either).
+shopt -s nullglob
+staged_files=("${{staging_datadir}}"/*)
+shopt -u nullglob
+if [ "${{#staged_files[@]}}" -eq 0 ]; then
+    echo "lysis: no staged setup files in ${{staging_datadir}}" >&2
+    exit 1
+fi
+cp "${{staged_files[@]}}" "${{local_datadir}}/"
 cp "{staging_dir}/{binary_name}" "${{local_work_dir}}/" """
 
         init = _runner_init_line(

--- a/tests/tools/test_slurm.py
+++ b/tests/tools/test_slurm.py
@@ -2166,6 +2166,28 @@ class TestWorkerLogOutputAndHeader:
         # only the trap references rm -rf of the work dir.
         assert script.count('rm -rf "${local_work_dir}"') == 1
 
+    def test_two_tier_setup_cp_glob_is_guarded(self, tmp_path):
+        """The staged-files copy must not use a bare glob under ``set -e``.
+
+        A bare ``cp "${staging_datadir}/"*`` aborts on an unexpanded ``*`` when
+        the staging dir is empty.  The guarded form collects matches via
+        nullglob and fails loudly with a clear message instead.
+        """
+        script = generate_macro_array_script(
+            tmp_path / "s", "run-01", tmp_path / "run-01.h5", "/bin/macro.exe",
+            n_sims=5, fast_tmp_root="/scratch",
+        )
+        # No bare glob copy remains.
+        assert 'cp "${staging_datadir}/"*' not in script
+        # Guarded form: nullglob collection + emptiness check + array copy.
+        assert "shopt -s nullglob" in script
+        assert 'staged_files=("${staging_datadir}"/*)' in script
+        assert 'cp "${staged_files[@]}" "${local_datadir}/"' in script
+        # The emptiness guard precedes the cp (fail loud, don't skip setup).
+        assert script.index('${#staged_files[@]}') < script.index(
+            'cp "${staged_files[@]}"'
+        )
+
 
 class TestMasterLogStaysInSlurm:
     """#84 scope: master ``--output`` stays in ``.slurm`` (worker-only move)."""

--- a/tests/tools/test_slurm.py
+++ b/tests/tools/test_slurm.py
@@ -2161,7 +2161,7 @@ class TestWorkerLogOutputAndHeader:
         assert 'trap \'rm -rf "${local_work_dir}"\' EXIT' in script
         # Trap must be registered before the risky mv so a set -e abort there
         # still reclaims the fast-tmp dir (no permanent node-local leak).
-        assert script.index("trap ") < script.index('mv "${local_datadir}')
+        assert script.index("trap ") < script.index("\nmv ")
         # The old unconditional post-mv ``rm -rf`` is gone (trap owns cleanup);
         # only the trap references rm -rf of the work dir.
         assert script.count('rm -rf "${local_work_dir}"') == 1
@@ -2187,6 +2187,47 @@ class TestWorkerLogOutputAndHeader:
         assert script.index('${#staged_files[@]}') < script.index(
             'cp "${staged_files[@]}"'
         )
+
+    @pytest.mark.parametrize(
+        "make_script",
+        [
+            lambda p: generate_micro_array_script(
+                p / "s", "run-01", p / "run-01.h5", "/bin/micro.exe", 5,
+                fast_tmp_root="/scratch",
+            ),
+            lambda p: generate_micro_child_script(
+                p / "s", "run-01", p / "run-01.h5", "/bin/micro.exe", "",
+                fast_tmp_root="/scratch",
+            ),
+        ],
+        ids=["micro-array", "micro-child"],
+    )
+    def test_micro_two_tier_output_mv_glob_is_guarded(self, tmp_path, make_script):
+        """Micro paths move flat ``__NN`` files via a glob — it must be guarded.
+
+        Unlike the macro per-sim ``mv`` (a single named subdir), the micro
+        output move is a ``${local_datadir}/*`` glob with the same unexpanded-
+        ``*`` hazard under ``set -e`` as the staged-files cp.
+        """
+        script = make_script(tmp_path)
+        # No bare glob mv remains.
+        assert 'mv "${local_datadir}"/*' not in script
+        # Guarded form: nullglob collection + emptiness check + array mv.
+        assert 'output_files=("${local_datadir}"/*)' in script
+        assert 'mv "${output_files[@]}" "${staging_datadir}/"' in script
+        assert script.index('${#output_files[@]}') < script.index(
+            'mv "${output_files[@]}"'
+        )
+
+    def test_macro_two_tier_mv_is_named_path_not_glob(self, tmp_path):
+        """The macro per-sim move is a named subdir — no glob, no guard needed."""
+        script = generate_macro_array_script(
+            tmp_path / "s", "run-01", tmp_path / "run-01.h5", "/bin/macro.exe",
+            n_sims=5, fast_tmp_root="/scratch",
+        )
+        assert 'mv "${local_datadir}/${SIM}" "${staging_datadir}/"' in script
+        assert 'mv "${local_datadir}"/*' not in script
+        assert "output_files=" not in script
 
 
 class TestMasterLogStaysInSlurm:


### PR DESCRIPTION
Follow-up to #87 (merged). That PR added `set -euo pipefail` to the generated Slurm scripts and I noted one remaining sharp edge in review: the two-tier `setup` section in `generate_array_script` copies staged setup files with a **bare glob**:

```bash
cp "${staging_datadir}/"* "${local_datadir}/"
```

Under `set -e`, if the staging dir is ever empty the glob stays an unexpanded literal `*`, so `cp` fails with a cryptic `cannot stat '.../*'` and aborts the task.

## Change
Replace the bare glob with a guarded copy:

```bash
shopt -s nullglob
staged_files=("${staging_datadir}"/*)
shopt -u nullglob
if [ "${#staged_files[@]}" -eq 0 ]; then
    echo "lysis: no staged setup files in ${staging_datadir}" >&2
    exit 1
fi
cp "${staged_files[@]}" "${local_datadir}/"
```

- Empty/missing staging dir → **fails loudly** with a clear `lysis:` message and `exit 1` (rather than a cryptic cp error, and without ever *silently* skipping setup).
- Normal (non-empty) case → behaviour unchanged.
- The `EXIT` trap from #87 still reclaims the fast-tmp work dir on the failure path, so there's no node-local leak.

This is the only bare-glob `cp` in the generators — the micro-child two-tier path copies only the named binary (a single file), so it's unaffected.

## Verification
- Ran the guarded block under `set -euo pipefail` both ways: empty dir → clear message + status 1; populated dir → copies all files + status 0.
- `bash -n` on the full generated macro and micro two-tier array scripts: clean.
- `tests/tools/test_slurm.py`: **177 passed** (incl. new `test_two_tier_setup_cp_glob_is_guarded`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)