### PR TITLE
Stamp init_* provenance on CLI test fixtures to silence 62 pytest warnings (#44)

### DIFF
--- a/tests/cli/test_provenance_gates.py
+++ b/tests/cli/test_provenance_gates.py
@@ -25,7 +25,6 @@ from lysis.config.parameters import MacroParameters, MicroParameters
 from lysis.dataio.datastore import DataStore
 from lysis.tools.provenance import execution as execution_mod
 
-
 # ----------------------------------------------------------------------
 # Helpers
 # ----------------------------------------------------------------------
@@ -72,9 +71,7 @@ def force_dirty(monkeypatch):
     monkeypatch.delenv(CONST.LYSIS_ALLOW_DIRTY_ENV, raising=False)
     monkeypatch.delenv(CONST.LYSIS_ALLOW_COMMIT_MISMATCH_ENV, raising=False)
     monkeypatch.setattr(execution_mod, "_resolve_dirty", lambda: "dirty")
-    monkeypatch.setattr(
-        execution_mod, "_resolve_version", lambda: "deadbeefdeadbeef"
-    )
+    monkeypatch.setattr(execution_mod, "_resolve_version", lambda: "deadbeefdeadbeef")
     # Reset the once-per-process dedup flag so each test sees the warning.
     execution_mod._dirty_warning_emitted = False
     yield
@@ -86,9 +83,7 @@ def force_clean(monkeypatch):
     monkeypatch.delenv(CONST.LYSIS_ALLOW_DIRTY_ENV, raising=False)
     monkeypatch.delenv(CONST.LYSIS_ALLOW_COMMIT_MISMATCH_ENV, raising=False)
     monkeypatch.setattr(execution_mod, "_resolve_dirty", lambda: "clean")
-    monkeypatch.setattr(
-        execution_mod, "_resolve_version", lambda: "commit-A" * 4
-    )
+    monkeypatch.setattr(execution_mod, "_resolve_version", lambda: "commit-A" * 4)
     execution_mod._dirty_warning_emitted = False
     yield
 
@@ -161,9 +156,7 @@ class TestInitExperimentDirtyGate:
                 val = val.decode()
             assert val == "dirty"
 
-    def test_env_var_proceeds(
-        self, runner, force_dirty, tmp_path, monkeypatch
-    ):
+    def test_env_var_proceeds(self, runner, force_dirty, tmp_path, monkeypatch):
         monkeypatch.setenv(CONST.LYSIS_ALLOW_DIRTY_ENV, "1")
         csv_path = _one_run_csv(tmp_path)
         data_root = tmp_path / "experiments"
@@ -230,9 +223,10 @@ class TestRunMicroCommitMatch:
 
         assert result.exit_code == 0, result.output
         # The "legacy file" warning surfaces (from Click runner or the env).
-        assert any(
-            "pre-dates" in str(w.message) for w in caught
-        ) or "pre-dates" in result.output
+        assert (
+            any("pre-dates" in str(w.message) for w in caught)
+            or "pre-dates" in result.output
+        )
 
     @patch("lysis.execution.fortran_micro.FortranMicro")
     def test_mismatch_blocks_run_micro(
@@ -242,16 +236,12 @@ class TestRunMicroCommitMatch:
         mp = MicroParameters()
         ds = DataStore.create("mm", str(tmp_path), mp)
         monkeypatch.setattr(execution_mod, "_resolve_dirty", lambda: "clean")
-        monkeypatch.setattr(
-            execution_mod, "_resolve_version", lambda: "old-commit-zzz"
-        )
+        monkeypatch.setattr(execution_mod, "_resolve_version", lambda: "old-commit-zzz")
         ds.stamp_provenance("micro", "init")
         ds.close()
 
         # Now switch the "current" commit back to commit-A.
-        monkeypatch.setattr(
-            execution_mod, "_resolve_version", lambda: "commit-A" * 4
-        )
+        monkeypatch.setattr(execution_mod, "_resolve_version", lambda: "commit-A" * 4)
 
         mock_fm = MagicMock()
         mock_cls.from_hdf5.return_value = mock_fm
@@ -275,25 +265,26 @@ class TestRunMicroCommitMatch:
         mp = MicroParameters()
         ds = DataStore.create("mm2", str(tmp_path), mp)
         monkeypatch.setattr(execution_mod, "_resolve_dirty", lambda: "clean")
-        monkeypatch.setattr(
-            execution_mod, "_resolve_version", lambda: "old-commit"
-        )
+        monkeypatch.setattr(execution_mod, "_resolve_version", lambda: "old-commit")
         ds.stamp_provenance("micro", "init")
         ds.close()
-        monkeypatch.setattr(
-            execution_mod, "_resolve_version", lambda: "commit-A" * 4
-        )
+        monkeypatch.setattr(execution_mod, "_resolve_version", lambda: "commit-A" * 4)
 
         mock_cls.from_hdf5.return_value = MagicMock()
 
-        result = runner.invoke(
-            cli,
-            [
-                "run-micro",
-                str(tmp_path / "mm2.h5"),
-                "--executable",
-                "/fake/bin",
-                "--allow-commit-mismatch",
-            ],
-        )
+        # Capture the warning via pytest.warns so it is asserted *and* consumed
+        # — otherwise it escapes to pytest's run-wide warnings summary even
+        # though firing here is the expected --allow-commit-mismatch behaviour.
+        with pytest.warns(UserWarning, match="commit-match check failed") as record:
+            result = runner.invoke(
+                cli,
+                [
+                    "run-micro",
+                    str(tmp_path / "mm2.h5"),
+                    "--executable",
+                    "/fake/bin",
+                    "--allow-commit-mismatch",
+                ],
+            )
         assert result.exit_code == 0, result.output
+        assert any("old-commit" in str(w.message) for w in record)

--- a/tests/cli/test_run_macro.py
+++ b/tests/cli/test_run_macro.py
@@ -12,10 +12,27 @@ from lysis.cli import cli
 from lysis.config.constants import CONST
 from lysis.config.parameters import MacroParameters, MicroParameters
 
-
 # ---------------------------------------------------------------------------
 # Helpers / fixtures
 # ---------------------------------------------------------------------------
+
+
+def _stamp_test_init_provenance(group) -> None:
+    """Stamp init_* provenance so the run-* commit-match gate stays silent (#44).
+
+    Records the *live* ``src/lysis/`` commit via the same resolver the gate uses
+    (``_resolve_version``) rather than a frozen string: the gate compares the
+    recorded ``init_version`` against ``_resolve_version()`` at run time, so both
+    sides match on a clean checkout, a dirty worktree, or a detached HEAD.
+    ``init_dirty``/``init_timestamp``/``init_hostname`` are never compared, so
+    they can be deterministic.
+    """
+    from lysis.tools.provenance.execution import _resolve_version
+
+    group.attrs[CONST.INIT_VERSION_ATTR] = _resolve_version()
+    group.attrs[CONST.INIT_DIRTY_ATTR] = "clean"
+    group.attrs[CONST.INIT_TIMESTAMP_ATTR] = "2026-01-01T00:00:00"
+    group.attrs[CONST.INIT_HOSTNAME_ATTR] = "test-host"
 
 
 def _write_macro_hdf5(path: Path) -> None:
@@ -30,6 +47,8 @@ def _write_macro_hdf5(path: Path) -> None:
         macro_grp = f.require_group("macro_data")
         for k, v in mcp.to_basedict().items():
             macro_grp.attrs[k] = str(v) if not isinstance(v, (int, float, bool)) else v
+        _stamp_test_init_provenance(micro_grp)
+        _stamp_test_init_provenance(macro_grp)
 
 
 @pytest.fixture
@@ -113,9 +132,7 @@ class TestRunMacroMissingArgs:
         assert result.exit_code != 0
 
     def test_missing_hdf5_path_exits_nonzero(self, runner, tmp_path):
-        result = runner.invoke(
-            cli, ["run-macro", "--executable", "/bin/macro.exe"]
-        )
+        result = runner.invoke(cli, ["run-macro", "--executable", "/bin/macro.exe"])
         assert result.exit_code != 0
 
 
@@ -157,8 +174,10 @@ class TestRunMacroLocal:
         result = runner.invoke(
             cli,
             [
-                "run-macro", str(macro_hdf5),
-                "--executable", "/bin/macro.exe",
+                "run-macro",
+                str(macro_hdf5),
+                "--executable",
+                "/bin/macro.exe",
                 "--keep-tmpdir",
             ],
         )
@@ -174,9 +193,12 @@ class TestRunMacroLocal:
         result = runner.invoke(
             cli,
             [
-                "run-macro", str(macro_hdf5),
-                "--executable", "/bin/macro.exe",
-                "--out-file-code", "_out",
+                "run-macro",
+                str(macro_hdf5),
+                "--executable",
+                "/bin/macro.exe",
+                "--out-file-code",
+                "_out",
             ],
         )
         assert result.exit_code == 0, result.output
@@ -191,9 +213,12 @@ class TestRunMacroLocal:
         result = runner.invoke(
             cli,
             [
-                "run-macro", str(macro_hdf5),
-                "--executable", "/bin/macro.exe",
-                "--in-file-code", "_in",
+                "run-macro",
+                str(macro_hdf5),
+                "--executable",
+                "/bin/macro.exe",
+                "--in-file-code",
+                "_in",
             ],
         )
         assert result.exit_code == 0, result.output
@@ -217,7 +242,9 @@ class TestRunMacroLocal:
         self, mock_cls, runner, macro_hdf5
     ):
         """A ValueError from from_hdf5 (e.g. wrong HDF5 state) must exit non-zero."""
-        mock_cls.from_hdf5.side_effect = ValueError("macroscale simulation has already been run")
+        mock_cls.from_hdf5.side_effect = ValueError(
+            "macroscale simulation has already been run"
+        )
         result = runner.invoke(
             cli,
             ["run-macro", str(macro_hdf5), "--executable", "/bin/macro.exe"],
@@ -229,7 +256,9 @@ class TestRunMacroLocal:
         self, mock_cls, runner, macro_hdf5
     ):
         """Error message from ValueError must appear in CLI output."""
-        mock_cls.from_hdf5.side_effect = ValueError("macroscale simulation has already been run")
+        mock_cls.from_hdf5.side_effect = ValueError(
+            "macroscale simulation has already been run"
+        )
         result = runner.invoke(
             cli,
             ["run-macro", str(macro_hdf5), "--executable", "/bin/macro.exe"],
@@ -248,8 +277,10 @@ class TestRunMacroSlurm:
         result = runner.invoke(
             cli,
             [
-                "run-macro", str(macro_hdf5),
-                "--executable", "/bin/macro.exe",
+                "run-macro",
+                str(macro_hdf5),
+                "--executable",
+                "/bin/macro.exe",
                 "--slurm",
             ],
         )
@@ -261,8 +292,10 @@ class TestRunMacroSlurm:
         result = runner.invoke(
             cli,
             [
-                "run-macro", str(macro_hdf5),
-                "--executable", "/bin/macro.exe",
+                "run-macro",
+                str(macro_hdf5),
+                "--executable",
+                "/bin/macro.exe",
                 "--slurm",
             ],
         )
@@ -274,10 +307,13 @@ class TestRunMacroSlurm:
         result = runner.invoke(
             cli,
             [
-                "run-macro", str(macro_hdf5),
-                "--executable", "/bin/macro.exe",
+                "run-macro",
+                str(macro_hdf5),
+                "--executable",
+                "/bin/macro.exe",
                 "--slurm",
-                "--partition", "long",
+                "--partition",
+                "long",
             ],
         )
         assert result.exit_code == 0, result.output
@@ -291,10 +327,13 @@ class TestRunMacroSlurm:
         result = runner.invoke(
             cli,
             [
-                "run-macro", str(macro_hdf5),
-                "--executable", "/bin/macro.exe",
+                "run-macro",
+                str(macro_hdf5),
+                "--executable",
+                "/bin/macro.exe",
                 "--slurm",
-                "--staging-root", str(staging),
+                "--staging-root",
+                str(staging),
             ],
         )
         assert result.exit_code == 0, result.output
@@ -306,10 +345,13 @@ class TestRunMacroSlurm:
         result = runner.invoke(
             cli,
             [
-                "run-macro", str(macro_hdf5),
-                "--executable", "/bin/macro.exe",
+                "run-macro",
+                str(macro_hdf5),
+                "--executable",
+                "/bin/macro.exe",
                 "--slurm",
-                "--fast-tmp-root", "/nvme/scratch",
+                "--fast-tmp-root",
+                "/nvme/scratch",
             ],
         )
         assert result.exit_code == 0, result.output
@@ -321,10 +363,13 @@ class TestRunMacroSlurm:
         result = runner.invoke(
             cli,
             [
-                "run-macro", str(macro_hdf5),
-                "--executable", "/bin/macro.exe",
+                "run-macro",
+                str(macro_hdf5),
+                "--executable",
+                "/bin/macro.exe",
                 "--slurm",
-                "--in-file-code", "_in",
+                "--in-file-code",
+                "_in",
             ],
         )
         assert result.exit_code == 0, result.output
@@ -336,10 +381,13 @@ class TestRunMacroSlurm:
         result = runner.invoke(
             cli,
             [
-                "run-macro", str(macro_hdf5),
-                "--executable", "/bin/macro.exe",
+                "run-macro",
+                str(macro_hdf5),
+                "--executable",
+                "/bin/macro.exe",
                 "--slurm",
-                "--out-file-code", "_out",
+                "--out-file-code",
+                "_out",
             ],
         )
         assert result.exit_code == 0, result.output
@@ -350,19 +398,19 @@ class TestRunMacroSlurm:
     def test_modules_default_is_forwarded(self, mock_submit, runner, macro_hdf5):
         """Without --modules, the default module spec must be forwarded."""
         from lysis.tools.slurm import DEFAULT_MODULES
+
         result = runner.invoke(
             cli,
             [
-                "run-macro", str(macro_hdf5),
-                "--executable", "/bin/macro.exe",
+                "run-macro",
+                str(macro_hdf5),
+                "--executable",
+                "/bin/macro.exe",
                 "--slurm",
             ],
         )
         assert result.exit_code == 0, result.output
-        assert (
-            mock_submit.call_args.kwargs.get("modules")
-            == DEFAULT_MODULES
-        )
+        assert mock_submit.call_args.kwargs.get("modules") == DEFAULT_MODULES
 
     @patch("lysis.tools.slurm.submit_macro_slurm_job", return_value=1)
     def test_modules_override_is_forwarded(self, mock_submit, runner, macro_hdf5):
@@ -370,27 +418,27 @@ class TestRunMacroSlurm:
         result = runner.invoke(
             cli,
             [
-                "run-macro", str(macro_hdf5),
-                "--executable", "/bin/macro.exe",
+                "run-macro",
+                str(macro_hdf5),
+                "--executable",
+                "/bin/macro.exe",
                 "--slurm",
-                "--modules", "intel-compilers/2024",
+                "--modules",
+                "intel-compilers/2024",
             ],
         )
         assert result.exit_code == 0, result.output
-        assert (
-            mock_submit.call_args.kwargs.get("modules")
-            == "intel-compilers/2024"
-        )
+        assert mock_submit.call_args.kwargs.get("modules") == "intel-compilers/2024"
 
     @patch("lysis.tools.slurm.submit_macro_slurm_job", return_value=1)
-    def test_sbatch_default_is_empty_overrides(
-        self, mock_submit, runner, macro_hdf5
-    ):
+    def test_sbatch_default_is_empty_overrides(self, mock_submit, runner, macro_hdf5):
         result = runner.invoke(
             cli,
             [
-                "run-macro", str(macro_hdf5),
-                "--executable", "/bin/macro.exe",
+                "run-macro",
+                str(macro_hdf5),
+                "--executable",
+                "/bin/macro.exe",
                 "--slurm",
             ],
         )
@@ -398,18 +446,21 @@ class TestRunMacroSlurm:
         assert mock_submit.call_args.kwargs.get("sbatch_overrides") == {}
 
     @patch("lysis.tools.slurm.submit_macro_slurm_job", return_value=1)
-    def test_sbatch_tokens_parsed_and_forwarded(
-        self, mock_submit, runner, macro_hdf5
-    ):
+    def test_sbatch_tokens_parsed_and_forwarded(self, mock_submit, runner, macro_hdf5):
         result = runner.invoke(
             cli,
             [
-                "run-macro", str(macro_hdf5),
-                "--executable", "/bin/macro.exe",
+                "run-macro",
+                str(macro_hdf5),
+                "--executable",
+                "/bin/macro.exe",
                 "--slurm",
-                "--sbatch", "mem=4G",
-                "--sbatch", "hold",
-                "--sbatch", "^exclusive=user",
+                "--sbatch",
+                "mem=4G",
+                "--sbatch",
+                "hold",
+                "--sbatch",
+                "^exclusive=user",
             ],
         )
         assert result.exit_code == 0, result.output
@@ -423,10 +474,13 @@ class TestRunMacroSlurm:
         result = runner.invoke(
             cli,
             [
-                "run-macro", str(macro_hdf5),
-                "--executable", "/bin/macro.exe",
+                "run-macro",
+                str(macro_hdf5),
+                "--executable",
+                "/bin/macro.exe",
                 "--slurm",
-                "--sbatch", "^",
+                "--sbatch",
+                "^",
             ],
         )
         assert result.exit_code != 0
@@ -445,9 +499,7 @@ class TestRunMacroSlurm:
 
 class TestRunMacroExperiment:
     @patch("lysis.execution.fortran_macro.FortranMacro")
-    def test_batch_calls_from_hdf5_for_each_run(
-        self, mock_cls, runner, experiment_dir
-    ):
+    def test_batch_calls_from_hdf5_for_each_run(self, mock_cls, runner, experiment_dir):
         mock_fm = MagicMock()
         mock_cls.from_hdf5.return_value = mock_fm
 
@@ -459,9 +511,7 @@ class TestRunMacroExperiment:
         assert mock_cls.from_hdf5.call_count == 2
 
     @patch("lysis.execution.fortran_macro.FortranMacro")
-    def test_batch_calls_run_full_for_each_run(
-        self, mock_cls, runner, experiment_dir
-    ):
+    def test_batch_calls_run_full_for_each_run(self, mock_cls, runner, experiment_dir):
         mock_fm = MagicMock()
         mock_cls.from_hdf5.return_value = mock_fm
 
@@ -473,9 +523,7 @@ class TestRunMacroExperiment:
         assert mock_fm.run_full.call_count == 2
 
     @patch("lysis.execution.fortran_macro.FortranMacro")
-    def test_batch_output_mentions_run_codes(
-        self, mock_cls, runner, experiment_dir
-    ):
+    def test_batch_output_mentions_run_codes(self, mock_cls, runner, experiment_dir):
         mock_fm = MagicMock()
         mock_cls.from_hdf5.return_value = mock_fm
 
@@ -488,15 +536,16 @@ class TestRunMacroExperiment:
         assert "run-01" in flat
         assert "run-02" in flat
 
-    def test_out_file_code_with_directory_raises_error(
-        self, runner, experiment_dir
-    ):
+    def test_out_file_code_with_directory_raises_error(self, runner, experiment_dir):
         result = runner.invoke(
             cli,
             [
-                "run-macro", str(experiment_dir),
-                "--executable", "/bin/macro.exe",
-                "--out-file-code", "_x",
+                "run-macro",
+                str(experiment_dir),
+                "--executable",
+                "/bin/macro.exe",
+                "--out-file-code",
+                "_x",
             ],
         )
         assert result.exit_code != 0
@@ -512,8 +561,10 @@ class TestRunMacroExperiment:
         result = runner.invoke(
             cli,
             [
-                "run-macro", str(experiment_dir),
-                "--executable", "/bin/macro.exe",
+                "run-macro",
+                str(experiment_dir),
+                "--executable",
+                "/bin/macro.exe",
                 "--slurm",
             ],
         )
@@ -531,9 +582,12 @@ class TestRunMacroFortranCommit:
         result = runner.invoke(
             cli,
             [
-                "run-macro", str(macro_hdf5),
-                "--executable", "macro_diffuse_into_and_along__internal",
-                "--fortran-commit", "this-ref-does-not-exist-deadbeef",
+                "run-macro",
+                str(macro_hdf5),
+                "--executable",
+                "macro_diffuse_into_and_along__internal",
+                "--fortran-commit",
+                "this-ref-does-not-exist-deadbeef",
             ],
         )
         assert result.exit_code != 0
@@ -569,9 +623,12 @@ class TestRunMacroFortranCommit:
         result = runner.invoke(
             cli,
             [
-                "run-macro", str(macro_hdf5),
-                "--executable", "macro_diffuse_into_and_along__internal",
-                "--fortran-commit", "HEAD",
+                "run-macro",
+                str(macro_hdf5),
+                "--executable",
+                "macro_diffuse_into_and_along__internal",
+                "--fortran-commit",
+                "HEAD",
             ],
         )
         assert result.exit_code == 0, result.output
@@ -605,11 +662,15 @@ class TestRunMacroFortranCommit:
         result = runner.invoke(
             cli,
             [
-                "run-macro", str(macro_hdf5),
-                "--executable", "macro_diffuse_into_and_along__internal",
-                "--fortran-commit", "HEAD",
+                "run-macro",
+                str(macro_hdf5),
+                "--executable",
+                "macro_diffuse_into_and_along__internal",
+                "--fortran-commit",
+                "HEAD",
                 "--slurm",
-                "--modules", "intel-compilers/2024",
+                "--modules",
+                "intel-compilers/2024",
             ],
         )
         assert result.exit_code == 0, result.output

--- a/tests/cli/test_run_micro.py
+++ b/tests/cli/test_run_micro.py
@@ -13,10 +13,27 @@ from lysis.cli import cli
 from lysis.config.constants import CONST
 from lysis.config.parameters import MicroParameters
 
-
 # ---------------------------------------------------------------------------
 # Helpers / fixtures
 # ---------------------------------------------------------------------------
+
+
+def _stamp_test_init_provenance(group) -> None:
+    """Stamp init_* provenance so the run-* commit-match gate stays silent (#44).
+
+    Records the *live* ``src/lysis/`` commit via the same resolver the gate uses
+    (``_resolve_version``) rather than a frozen string: the gate compares the
+    recorded ``init_version`` against ``_resolve_version()`` at run time, so both
+    sides match on a clean checkout, a dirty worktree, or a detached HEAD.
+    ``init_dirty``/``init_timestamp``/``init_hostname`` are never compared, so
+    they can be deterministic.
+    """
+    from lysis.tools.provenance.execution import _resolve_version
+
+    group.attrs[CONST.INIT_VERSION_ATTR] = _resolve_version()
+    group.attrs[CONST.INIT_DIRTY_ATTR] = "clean"
+    group.attrs[CONST.INIT_TIMESTAMP_ATTR] = "2026-01-01T00:00:00"
+    group.attrs[CONST.INIT_HOSTNAME_ATTR] = "test-host"
 
 
 def _write_micro_hdf5(path: Path) -> None:
@@ -27,6 +44,7 @@ def _write_micro_hdf5(path: Path) -> None:
         grp = f.require_group("micro_data")
         for k, v in mp.to_basedict().items():
             grp.attrs[k] = str(v) if not isinstance(v, (int, float, bool)) else v
+        _stamp_test_init_provenance(grp)
 
 
 @pytest.fixture
@@ -76,9 +94,7 @@ class TestRunMicroMissingArgs:
         assert result.exit_code != 0
 
     def test_missing_hdf5_path_exits_nonzero(self, runner, tmp_path):
-        result = runner.invoke(
-            cli, ["run-micro", "--executable", "/bin/micro.exe"]
-        )
+        result = runner.invoke(cli, ["run-micro", "--executable", "/bin/micro.exe"])
         assert result.exit_code != 0
 
 
@@ -123,8 +139,10 @@ class TestRunMicroLocal:
         result = runner.invoke(
             cli,
             [
-                "run-micro", str(micro_hdf5),
-                "--executable", "/bin/micro.exe",
+                "run-micro",
+                str(micro_hdf5),
+                "--executable",
+                "/bin/micro.exe",
                 "--keep-tmpdir",
             ],
         )
@@ -140,9 +158,12 @@ class TestRunMicroLocal:
         result = runner.invoke(
             cli,
             [
-                "run-micro", str(micro_hdf5),
-                "--executable", "/bin/micro.exe",
-                "--file-code", "_code",
+                "run-micro",
+                str(micro_hdf5),
+                "--executable",
+                "/bin/micro.exe",
+                "--file-code",
+                "_code",
             ],
         )
         assert result.exit_code == 0, result.output
@@ -167,7 +188,9 @@ class TestRunMicroLocal:
         self, mock_cls, runner, micro_hdf5
     ):
         """A ValueError from from_hdf5 (e.g. wrong HDF5 state) must exit non-zero."""
-        mock_cls.from_hdf5.side_effect = ValueError("microscale simulation has already been run")
+        mock_cls.from_hdf5.side_effect = ValueError(
+            "microscale simulation has already been run"
+        )
         result = runner.invoke(
             cli,
             ["run-micro", str(micro_hdf5), "--executable", "/bin/micro.exe"],
@@ -179,7 +202,9 @@ class TestRunMicroLocal:
         self, mock_cls, runner, micro_hdf5
     ):
         """Error message from ValueError must appear in CLI output."""
-        mock_cls.from_hdf5.side_effect = ValueError("microscale simulation has already been run")
+        mock_cls.from_hdf5.side_effect = ValueError(
+            "microscale simulation has already been run"
+        )
         result = runner.invoke(
             cli,
             ["run-micro", str(micro_hdf5), "--executable", "/bin/micro.exe"],
@@ -198,8 +223,10 @@ class TestRunMicroSlurm:
         result = runner.invoke(
             cli,
             [
-                "run-micro", str(micro_hdf5),
-                "--executable", "/bin/micro.exe",
+                "run-micro",
+                str(micro_hdf5),
+                "--executable",
+                "/bin/micro.exe",
                 "--slurm",
             ],
         )
@@ -211,8 +238,10 @@ class TestRunMicroSlurm:
         result = runner.invoke(
             cli,
             [
-                "run-micro", str(micro_hdf5),
-                "--executable", "/bin/micro.exe",
+                "run-micro",
+                str(micro_hdf5),
+                "--executable",
+                "/bin/micro.exe",
                 "--slurm",
             ],
         )
@@ -224,10 +253,13 @@ class TestRunMicroSlurm:
         result = runner.invoke(
             cli,
             [
-                "run-micro", str(micro_hdf5),
-                "--executable", "/bin/micro.exe",
+                "run-micro",
+                str(micro_hdf5),
+                "--executable",
+                "/bin/micro.exe",
                 "--slurm",
-                "--partition", "long",
+                "--partition",
+                "long",
             ],
         )
         assert result.exit_code == 0, result.output
@@ -241,10 +273,13 @@ class TestRunMicroSlurm:
         result = runner.invoke(
             cli,
             [
-                "run-micro", str(micro_hdf5),
-                "--executable", "/bin/micro.exe",
+                "run-micro",
+                str(micro_hdf5),
+                "--executable",
+                "/bin/micro.exe",
                 "--slurm",
-                "--staging-root", str(staging),
+                "--staging-root",
+                str(staging),
             ],
         )
         assert result.exit_code == 0, result.output
@@ -256,10 +291,13 @@ class TestRunMicroSlurm:
         result = runner.invoke(
             cli,
             [
-                "run-micro", str(micro_hdf5),
-                "--executable", "/bin/micro.exe",
+                "run-micro",
+                str(micro_hdf5),
+                "--executable",
+                "/bin/micro.exe",
                 "--slurm",
-                "--fast-tmp-root", "/nvme/scratch",
+                "--fast-tmp-root",
+                "/nvme/scratch",
             ],
         )
         assert result.exit_code == 0, result.output
@@ -271,8 +309,10 @@ class TestRunMicroSlurm:
         result = runner.invoke(
             cli,
             [
-                "run-micro", str(micro_hdf5),
-                "--executable", "/bin/micro.exe",
+                "run-micro",
+                str(micro_hdf5),
+                "--executable",
+                "/bin/micro.exe",
                 "--slurm",
                 "--keep-tmpdir",
             ],
@@ -282,15 +322,15 @@ class TestRunMicroSlurm:
         assert call_kwargs.get("keep_tmpdir") is True
 
     @patch("lysis.tools.slurm.submit_micro_slurm_job", return_value=1)
-    def test_num_children_default_is_10(
-        self, mock_submit, runner, micro_hdf5
-    ):
+    def test_num_children_default_is_10(self, mock_submit, runner, micro_hdf5):
         """Without --num-children, the default 10 must be forwarded."""
         result = runner.invoke(
             cli,
             [
-                "run-micro", str(micro_hdf5),
-                "--executable", "/bin/micro.exe",
+                "run-micro",
+                str(micro_hdf5),
+                "--executable",
+                "/bin/micro.exe",
                 "--slurm",
             ],
         )
@@ -305,10 +345,13 @@ class TestRunMicroSlurm:
         result = runner.invoke(
             cli,
             [
-                "run-micro", str(micro_hdf5),
-                "--executable", "/bin/micro.exe",
+                "run-micro",
+                str(micro_hdf5),
+                "--executable",
+                "/bin/micro.exe",
                 "--slurm",
-                "--num-children", "0",
+                "--num-children",
+                "0",
             ],
         )
         assert result.exit_code == 0, result.output
@@ -318,19 +361,19 @@ class TestRunMicroSlurm:
     def test_modules_default_is_forwarded(self, mock_submit, runner, micro_hdf5):
         """Without --modules, the default module spec must be forwarded."""
         from lysis.tools.slurm import DEFAULT_MODULES
+
         result = runner.invoke(
             cli,
             [
-                "run-micro", str(micro_hdf5),
-                "--executable", "/bin/micro.exe",
+                "run-micro",
+                str(micro_hdf5),
+                "--executable",
+                "/bin/micro.exe",
                 "--slurm",
             ],
         )
         assert result.exit_code == 0, result.output
-        assert (
-            mock_submit.call_args.kwargs.get("modules")
-            == DEFAULT_MODULES
-        )
+        assert mock_submit.call_args.kwargs.get("modules") == DEFAULT_MODULES
 
     @patch("lysis.tools.slurm.submit_micro_slurm_job", return_value=1)
     def test_modules_override_is_forwarded(self, mock_submit, runner, micro_hdf5):
@@ -338,30 +381,31 @@ class TestRunMicroSlurm:
         result = runner.invoke(
             cli,
             [
-                "run-micro", str(micro_hdf5),
-                "--executable", "/bin/micro.exe",
+                "run-micro",
+                str(micro_hdf5),
+                "--executable",
+                "/bin/micro.exe",
                 "--slurm",
-                "--modules", "intel-compilers/2024",
+                "--modules",
+                "intel-compilers/2024",
             ],
         )
         assert result.exit_code == 0, result.output
-        assert (
-            mock_submit.call_args.kwargs.get("modules")
-            == "intel-compilers/2024"
-        )
+        assert mock_submit.call_args.kwargs.get("modules") == "intel-compilers/2024"
 
     @patch("lysis.tools.slurm.submit_micro_slurm_job", return_value=1)
-    def test_num_children_positive_is_forwarded(
-        self, mock_submit, runner, micro_hdf5
-    ):
+    def test_num_children_positive_is_forwarded(self, mock_submit, runner, micro_hdf5):
         """A positive ``--num-children`` is forwarded as-is."""
         result = runner.invoke(
             cli,
             [
-                "run-micro", str(micro_hdf5),
-                "--executable", "/bin/micro.exe",
+                "run-micro",
+                str(micro_hdf5),
+                "--executable",
+                "/bin/micro.exe",
                 "--slurm",
-                "--num-children", "25",
+                "--num-children",
+                "25",
             ],
         )
         assert result.exit_code == 0, result.output
@@ -372,10 +416,13 @@ class TestRunMicroSlurm:
         result = runner.invoke(
             cli,
             [
-                "run-micro", str(micro_hdf5),
-                "--executable", "/bin/micro.exe",
+                "run-micro",
+                str(micro_hdf5),
+                "--executable",
+                "/bin/micro.exe",
                 "--slurm",
-                "--num-children", "-1",
+                "--num-children",
+                "-1",
             ],
         )
         assert result.exit_code != 0
@@ -394,10 +441,13 @@ class TestRunMicroSlurm:
         result = runner.invoke(
             cli,
             [
-                "run-micro", str(micro_hdf5),
-                "--executable", "/bin/micro.exe",
+                "run-micro",
+                str(micro_hdf5),
+                "--executable",
+                "/bin/micro.exe",
                 "--slurm",
-                "--num-children", "999",
+                "--num-children",
+                "999",
             ],
         )
         assert result.exit_code != 0
@@ -419,9 +469,12 @@ class TestRunMicroSlurm:
         result = runner.invoke(
             cli,
             [
-                "run-micro", str(micro_hdf5),
-                "--executable", "/bin/micro.exe",
-                "--num-children", "5",
+                "run-micro",
+                str(micro_hdf5),
+                "--executable",
+                "/bin/micro.exe",
+                "--num-children",
+                "5",
             ],
         )
         assert result.exit_code == 0, result.output
@@ -436,9 +489,12 @@ class TestRunMicroSlurm:
         result = runner.invoke(
             cli,
             [
-                "run-micro", str(micro_hdf5),
-                "--executable", "/bin/micro.exe",
-                "--partition", "long",
+                "run-micro",
+                str(micro_hdf5),
+                "--executable",
+                "/bin/micro.exe",
+                "--partition",
+                "long",
             ],
         )
         # Should succeed (partition is silently ignored in non-slurm mode)
@@ -446,15 +502,15 @@ class TestRunMicroSlurm:
         mock_fm.run_full.assert_called_once()
 
     @patch("lysis.tools.slurm.submit_micro_slurm_job", return_value=1)
-    def test_sbatch_default_is_empty_overrides(
-        self, mock_submit, runner, micro_hdf5
-    ):
+    def test_sbatch_default_is_empty_overrides(self, mock_submit, runner, micro_hdf5):
         """Without --sbatch, sbatch_overrides must be an empty dict."""
         result = runner.invoke(
             cli,
             [
-                "run-micro", str(micro_hdf5),
-                "--executable", "/bin/micro.exe",
+                "run-micro",
+                str(micro_hdf5),
+                "--executable",
+                "/bin/micro.exe",
                 "--slurm",
             ],
         )
@@ -462,19 +518,22 @@ class TestRunMicroSlurm:
         assert mock_submit.call_args.kwargs.get("sbatch_overrides") == {}
 
     @patch("lysis.tools.slurm.submit_micro_slurm_job", return_value=1)
-    def test_sbatch_tokens_parsed_and_forwarded(
-        self, mock_submit, runner, micro_hdf5
-    ):
+    def test_sbatch_tokens_parsed_and_forwarded(self, mock_submit, runner, micro_hdf5):
         """Repeated --sbatch tokens parse into the documented overrides dict."""
         result = runner.invoke(
             cli,
             [
-                "run-micro", str(micro_hdf5),
-                "--executable", "/bin/micro.exe",
+                "run-micro",
+                str(micro_hdf5),
+                "--executable",
+                "/bin/micro.exe",
                 "--slurm",
-                "--sbatch", "mem=4G",
-                "--sbatch", "hold",
-                "--sbatch", "^exclusive=user",
+                "--sbatch",
+                "mem=4G",
+                "--sbatch",
+                "hold",
+                "--sbatch",
+                "^exclusive=user",
             ],
         )
         assert result.exit_code == 0, result.output
@@ -489,10 +548,13 @@ class TestRunMicroSlurm:
         result = runner.invoke(
             cli,
             [
-                "run-micro", str(micro_hdf5),
-                "--executable", "/bin/micro.exe",
+                "run-micro",
+                str(micro_hdf5),
+                "--executable",
+                "/bin/micro.exe",
                 "--slurm",
-                "--sbatch", "^",
+                "--sbatch",
+                "^",
             ],
         )
         assert result.exit_code != 0
@@ -580,9 +642,7 @@ class TestRunMicroExperimentLocal:
         assert mock_fm.run_full.call_count == 2
 
     @patch("lysis.execution.fortran_micro.FortranMicro")
-    def test_batch_glob_calls_from_hdf5_for_each_run(
-        self, mock_cls, runner, hdf5_dir
-    ):
+    def test_batch_glob_calls_from_hdf5_for_each_run(self, mock_cls, runner, hdf5_dir):
         mock_fm = MagicMock()
         mock_cls.from_hdf5.return_value = mock_fm
 
@@ -594,9 +654,7 @@ class TestRunMicroExperimentLocal:
         assert mock_cls.from_hdf5.call_count == 2
 
     @patch("lysis.execution.fortran_micro.FortranMicro")
-    def test_batch_output_mentions_run_codes(
-        self, mock_cls, runner, experiment_dir
-    ):
+    def test_batch_output_mentions_run_codes(self, mock_cls, runner, experiment_dir):
         mock_fm = MagicMock()
         mock_cls.from_hdf5.return_value = mock_fm
 
@@ -614,13 +672,18 @@ class TestRunMicroExperimentLocal:
         result = runner.invoke(
             cli,
             [
-                "run-micro", str(experiment_dir),
-                "--executable", "/bin/micro.exe",
-                "--file-code", "_x",
+                "run-micro",
+                str(experiment_dir),
+                "--executable",
+                "/bin/micro.exe",
+                "--file-code",
+                "_x",
             ],
         )
         assert result.exit_code != 0
-        assert "file-code" in result.output.lower() or "directory" in result.output.lower()
+        assert (
+            "file-code" in result.output.lower() or "directory" in result.output.lower()
+        )
 
     def test_empty_directory_raises_error(self, runner, tmp_path):
         empty = tmp_path / "empty"
@@ -645,8 +708,10 @@ class TestRunMicroExperimentSlurm:
         result = runner.invoke(
             cli,
             [
-                "run-micro", str(experiment_dir),
-                "--executable", "/bin/micro.exe",
+                "run-micro",
+                str(experiment_dir),
+                "--executable",
+                "/bin/micro.exe",
                 "--slurm",
             ],
         )
@@ -654,14 +719,14 @@ class TestRunMicroExperimentSlurm:
         assert mock_submit.call_count == 2
 
     @patch("lysis.tools.slurm.submit_micro_slurm_job", side_effect=[10001, 10002])
-    def test_batch_slurm_prints_all_job_ids(
-        self, mock_submit, runner, experiment_dir
-    ):
+    def test_batch_slurm_prints_all_job_ids(self, mock_submit, runner, experiment_dir):
         result = runner.invoke(
             cli,
             [
-                "run-micro", str(experiment_dir),
-                "--executable", "/bin/micro.exe",
+                "run-micro",
+                str(experiment_dir),
+                "--executable",
+                "/bin/micro.exe",
                 "--slurm",
             ],
         )
@@ -676,10 +741,13 @@ class TestRunMicroExperimentSlurm:
         result = runner.invoke(
             cli,
             [
-                "run-micro", str(experiment_dir),
-                "--executable", "/bin/micro.exe",
+                "run-micro",
+                str(experiment_dir),
+                "--executable",
+                "/bin/micro.exe",
                 "--slurm",
-                "--partition", "long",
+                "--partition",
+                "long",
             ],
         )
         assert result.exit_code == 0, result.output
@@ -687,14 +755,14 @@ class TestRunMicroExperimentSlurm:
             assert c.kwargs.get("partition") == "long"
 
     @patch("lysis.tools.slurm.submit_micro_slurm_job", side_effect=[20001, 20002])
-    def test_batch_glob_slurm_submits_for_each_h5(
-        self, mock_submit, runner, hdf5_dir
-    ):
+    def test_batch_glob_slurm_submits_for_each_h5(self, mock_submit, runner, hdf5_dir):
         result = runner.invoke(
             cli,
             [
-                "run-micro", str(hdf5_dir),
-                "--executable", "/bin/micro.exe",
+                "run-micro",
+                str(hdf5_dir),
+                "--executable",
+                "/bin/micro.exe",
                 "--slurm",
             ],
         )
@@ -713,17 +781,23 @@ class TestRunMicroFortranCommit:
         result = runner.invoke(
             cli,
             [
-                "run-micro", str(micro_hdf5),
-                "--executable", "micro_rates",
-                "--fortran-commit", "this-ref-does-not-exist-deadbeef",
+                "run-micro",
+                str(micro_hdf5),
+                "--executable",
+                "micro_rates",
+                "--fortran-commit",
+                "this-ref-does-not-exist-deadbeef",
             ],
         )
         assert result.exit_code != 0
         assert "does not resolve" in result.output
 
     @patch("lysis.execution.fortran_micro.FortranMicro")
-    @patch("lysis.cli.run_micro.build_historical_binary"
-           if False else "lysis.execution.historical_build.build_historical_binary")
+    @patch(
+        "lysis.cli.run_micro.build_historical_binary"
+        if False
+        else "lysis.execution.historical_build.build_historical_binary"
+    )
     def test_historical_attrs_threaded_to_runner(
         self, mock_build, mock_cls, runner, micro_hdf5, tmp_path
     ):
@@ -752,9 +826,12 @@ class TestRunMicroFortranCommit:
         result = runner.invoke(
             cli,
             [
-                "run-micro", str(micro_hdf5),
-                "--executable", "micro_rates",
-                "--fortran-commit", "HEAD",
+                "run-micro",
+                str(micro_hdf5),
+                "--executable",
+                "micro_rates",
+                "--fortran-commit",
+                "HEAD",
             ],
         )
         assert result.exit_code == 0, result.output
@@ -794,11 +871,15 @@ class TestRunMicroFortranCommit:
         result = runner.invoke(
             cli,
             [
-                "run-micro", str(micro_hdf5),
-                "--executable", "micro_rates",
-                "--fortran-commit", "HEAD",
+                "run-micro",
+                str(micro_hdf5),
+                "--executable",
+                "micro_rates",
+                "--fortran-commit",
+                "HEAD",
                 "--slurm",
-                "--modules", "intel-compilers/2024",
+                "--modules",
+                "intel-compilers/2024",
             ],
         )
         assert result.exit_code == 0, result.output


### PR DESCRIPTION
## Summary

Fixes #44. The `run-macro` / `run-micro` CLI tests built minimal HDF5 fixtures whose params groups (`micro_data` / `macro_data`) lacked the `init_*` provenance stamps. `enforce_init_commit_match` (called unconditionally in `run_macro.py:229` / `run_micro.py:232`, before the slurm/local split) then found no `init_version`, emitted a `UserWarning`, and continued — flooding pytest with **62 warnings** across **60 plumbing tests**.

## What these tests actually test (and why provenance is irrelevant to them)

All 60 warning-emitting tests are CLI **plumbing** tests (flag forwarding, slurm dispatch, batch/experiment iteration, error surfacing, `--fortran-commit` threading) with the real engine mocked (`FortranMacro`/`FortranMicro`, `submit_*_slurm_job`, `build_historical_binary`). None reads or asserts on provenance — the commit-match gate just sits in the shared code path they all pass through. Full analysis is in the [issue comment](https://github.com/UCO-OpResearch/lysis/issues/44#issuecomment-4583411195).

## Fix (option B): stamp the live commit, not a frozen string

A frozen `init_version` string does **not** silence the gate — the gate compares the recorded value against the live `_resolve_version()` (`cli/__init__.py:45`), with no override hook, so a frozen value just swaps "no init_version" for "commit-match failed".

Instead, a small `_stamp_test_init_provenance(group)` helper stamps `init_version = _resolve_version()` (the same resolver the gate uses) plus three deterministic attrs that are never compared. Because both sides call `_resolve_version()` at run time, `recorded == current` by construction → the gate is silent on a clean checkout, a dirty worktree, or a detached HEAD (non-flaky). It also keeps `test_init_macroscale.py` green by construction — that test imports `_write_micro_hdf5` and asserts the stamped macro provenance equals `_CURRENT_COMMIT()`, itself `_resolve_version()`.

`tests/cli/test_provenance_gates.py` is intentionally left untouched **except** for one improvement: `test_mismatch_override_warns_and_continues` exercises the `--allow-commit-mismatch` path where firing a warning is the *expected* behaviour, but it only asserted on `exit_code`, so its warning leaked to the run-wide summary. It is now wrapped in `pytest.warns(UserWarning, match="commit-match check failed")`, which both asserts the warning fires (the warnings channel was previously unchecked) and consumes it. The other gate fixtures (legacy / mismatch-blocks / clean-stamp) are unchanged.

## Commits

- `82fb830` — Stamp init_* provenance on run-macro test fixtures
- `11f5757` — Stamp init_* provenance on run-micro test fixtures
- `e18b3b8` — Capture the expected commit-mismatch warning in its test

## Verification

- Full target selector (`-m "not real_data and not fortran_binary"`): **1937 passed, 1 skipped, 29 deselected** with **no warnings summary block at all** (zero "no init_version" / "commit-match failed" warnings) — down from 62.
- Control: the *unstamped* fixture still triggers the warning under a warning→error filter (so the check is real); after stamping, it's clean.
- Direct check via the gate's own `DataStore.read_init_provenance`: both fixtures found and matching the current commit.
- Black-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
