### PR TITLE
Fix FortranMacro --nummicro; replace magic 100 with CONST.TPA_LEAVE_TIME_BINS

### DIFF
--- a/src/lysis/config/constants.py
+++ b/src/lysis/config/constants.py
@@ -48,6 +48,9 @@ class Const:
     :vartype MOL_STATUS: MolStatus
     :ivar DATASET_STORAGE_TYPE: Enumeration of data storage formats
     :vartype DATASET_STORAGE_TYPE: DataSetStorageType
+    :ivar TPA_LEAVE_TIME_BINS: Number of tPA-leaving-time quantile bins the
+        micro->macro conversion builds degradation-time distributions for (100)
+    :vartype TPA_LEAVE_TIME_BINS: int
     :ivar NUMPY_SAVETXT_FORMATS: Format strings for numpy.savetxt by dtype
     :vartype NUMPY_SAVETXT_FORMATS: dict
 
@@ -65,6 +68,19 @@ class Const:
         self.NEIGHBORHOOD = Neighbors()
         self.MOL_STATUS = MolStatus
         self.DATASET_STORAGE_TYPE = DataSetStorageType
+        # Number of bins the micro->macro conversion carves the tPA
+        # leaving-time distribution into.  generate_macroscale_in() sorts the
+        # microscale simulations by tPA leaving time and splits them into this
+        # many equal-count quantile bins; each bin yields one sorted
+        # distribution of fiber degradation times (one column of lysismat /
+        # binned_fiber_degrade_time).  The macroscale model later draws a
+        # uniform r in [0, 1] and multiplies by this value to pick which bin's
+        # degradation distribution to sample.  Consequently:
+        #   * lysismat / binned_fiber_degrade_time have this many columns,
+        #   * lenlysisvect / binned_fiber_degraded have this many entries,
+        #   * tPAleave / tsectPA / bin_edge_* have this many + 1 (the bin edges),
+        #   * the Fortran macro binary's --nummicro is micro_simulations // this.
+        self.TPA_LEAVE_TIME_BINS = 100
         self.DATASPEC_VERSION_ATTR = "dataspec_version"
         self.CONVERTED_FROM_ATTR = "converted_from"
         self.RENAMED_FROM_ATTR = "renamed_from"

--- a/src/lysis/dataio/dataconvert.py
+++ b/src/lysis/dataio/dataconvert.py
@@ -369,7 +369,8 @@ def generate_macroscale_in(in_data: DataCollectionType) -> DataCollectionType:
     This function transforms microscale simulation results into the input format
     required by the Fortran macroscale model. It performs several key operations:
 
-    1. Bins microscale simulations (typically 50,000) into 100 groups based on
+    1. Bins microscale simulations (typically 50,000) into
+       :data:`~lysis.config.constants.CONST.TPA_LEAVE_TIME_BINS` groups based on
        tPA leaving time distribution
     2. Computes the cumulative distribution function (CDF) of tPA leaving times
     3. Organizes fiber degradation times by bin and simulation outcome
@@ -405,7 +406,8 @@ def generate_macroscale_in(in_data: DataCollectionType) -> DataCollectionType:
 
     Notes
     -----
-    - Microscale simulations will always be divided into 100 bins
+    - Microscale simulations are divided into
+      :data:`~lysis.config.constants.CONST.TPA_LEAVE_TIME_BINS` bins
     - Uses infinity as marker for incomplete fiber degradation
     - Preserves all parameters from input data in the output
 
@@ -418,14 +420,18 @@ def generate_macroscale_in(in_data: DataCollectionType) -> DataCollectionType:
     # TODO: Add code to check that `in_data` meets the "current" data specification
     out_data = in_data.copy()
 
-    # Determine bin size: divide microscale simulations into 100 bins
-    # Typically 50,000 microscale runs → 500 simulations per bin
-    bin_size = in_data["pli_first_time"].size // 100
+    # Determine bin size: divide microscale simulations into
+    # CONST.TPA_LEAVE_TIME_BINS bins by tPA leaving time.
+    # Typically 50,000 microscale runs → 500 simulations per bin (at 100 bins)
+    bin_size = in_data["pli_first_time"].size // CONST.TPA_LEAVE_TIME_BINS
 
     # Create the CDF of tPA leaving time distribution
-    # bin_edge_proportions = [0.00, 0.01, 0.02, ..., 0.99, 1.00] (101 values)
+    # bin_edge_proportions = [0.00, 0.01, 0.02, ..., 0.99, 1.00]
+    # (CONST.TPA_LEAVE_TIME_BINS + 1 values)
     # These represent cumulative proportions: 0%, 1%, 2%, ..., 100% of tPA have left
-    out_data["bin_edge_proportions"] = np.append(np.arange(0, 1, 0.01), [1.0])
+    out_data["bin_edge_proportions"] = np.append(
+        np.arange(0, 1, 1 / CONST.TPA_LEAVE_TIME_BINS), [1.0]
+    )
 
     # Sort microscale simulations by tPA leaving time
     # This ordering will be used to assign simulations to bins
@@ -448,7 +454,8 @@ def generate_macroscale_in(in_data: DataCollectionType) -> DataCollectionType:
     # This allows incomplete simulations to be identified and handled separately
     lysis_time[~lysis_complete] = float("inf")
 
-    # Organize fiber degradation times into 100 bins (columns)
+    # Organize fiber degradation times into CONST.TPA_LEAVE_TIME_BINS bins
+    # (columns), one per tPA-leaving-time quantile:
     # 1. Split simulations into bins using the sorted ordering (indices)
     # 2. Sort lysis times within each bin (fastest to slowest degradation)
     # 3. Stack bins as rows, then transpose so bins become columns
@@ -456,7 +463,7 @@ def generate_macroscale_in(in_data: DataCollectionType) -> DataCollectionType:
     out_data["binned_fiber_degrade_time"] = np.stack(
         [
             np.sort(lysis_time[indices[i * bin_size : (i + 1) * bin_size]])
-            for i in range(100)
+            for i in range(CONST.TPA_LEAVE_TIME_BINS)
         ]
     ).T
 

--- a/src/lysis/dataio/dataspec.py
+++ b/src/lysis/dataio/dataspec.py
@@ -638,33 +638,34 @@ _dataspec_raw: dict[str, dict[str, DataCollectionSpec]] = {
             simulations_combined=True,
             params=None,  # Uses parameters from microscale output
             data={
-                # Bin boundaries of CDF for tPA leaving time distribution (100 bins, 101 edges)
+                # Bin boundaries of CDF for tPA leaving time distribution
+                # (TPA_LEAVE_TIME_BINS bins, TPA_LEAVE_TIME_BINS + 1 edges)
                 "tPAleave": DataSetSpec(
                     data_location="tPAleave{file_code}.dat",
                     dataset_storage_type=CONST.DATASET_STORAGE_TYPE.FILE_TEXT,
                     dtype=np.float64,
-                    shape=(101,),
+                    shape=(CONST.TPA_LEAVE_TIME_BINS + 1,),
                 ),
                 # Times at bin boundaries: i% of simulations have tPA leave by tsectPA[i]
                 "tsectPA": DataSetSpec(
                     data_location="tsectPA{file_code}.dat",
                     dataset_storage_type=CONST.DATASET_STORAGE_TYPE.FILE_TEXT,
                     dtype=np.float64,
-                    shape=(101,),
+                    shape=(CONST.TPA_LEAVE_TIME_BINS + 1,),
                 ),
                 # Fiber degrade times, binned by tPA leaving time, sorted within each bin
                 "lysismat": DataSetSpec(
                     data_location="lysismat{file_code}.dat",
                     dataset_storage_type=CONST.DATASET_STORAGE_TYPE.FILE_TEXT,
                     dtype=np.float64,
-                    shape=(-1, 100),
+                    shape=(-1, CONST.TPA_LEAVE_TIME_BINS),
                 ),
                 # Count of simulations per bin where full fiber lysis occurred
                 "lenlysisvect": DataSetSpec(
                     data_location="lenlysisvect{file_code}.dat",
                     dataset_storage_type=CONST.DATASET_STORAGE_TYPE.FILE_TEXT,
                     dtype=np.float64,
-                    shape=(100,),
+                    shape=(CONST.TPA_LEAVE_TIME_BINS,),
                 ),
                 # 1-indexed Fortran locations of neighboring fibers for each edge in grid
                 "neighbors": DataSetSpec(
@@ -841,33 +842,34 @@ _dataspec_raw: dict[str, dict[str, DataCollectionSpec]] = {
             simulations_combined=True,
             params=None,  # Uses parameters from microscale output
             data={
-                # Bin boundaries of CDF for tPA leaving time distribution (100 bins, 101 edges)
+                # Bin boundaries of CDF for tPA leaving time distribution
+                # (TPA_LEAVE_TIME_BINS bins, TPA_LEAVE_TIME_BINS + 1 edges)
                 "bin_edge_proportions": DataSetSpec(
                     data_location=None,  # Derived dataset, not stored
                     dataset_storage_type=None,
                     dtype=np.float64,
-                    shape=(101,),
+                    shape=(CONST.TPA_LEAVE_TIME_BINS + 1,),
                 ),
                 # Times at bin boundaries: i% of simulations have tPA leave by this time
                 "bin_edge_tpa_leaving_time": DataSetSpec(
                     data_location=None,  # Derived dataset, not stored
                     dataset_storage_type=None,
                     dtype=np.float64,
-                    shape=(101,),
+                    shape=(CONST.TPA_LEAVE_TIME_BINS + 1,),
                 ),
                 # Fiber degrade times, binned by tPA leaving time, sorted within each bin
                 "binned_fiber_degrade_time": DataSetSpec(
                     data_location=None,  # Derived dataset, not stored
                     dataset_storage_type=None,
                     dtype=np.float64,
-                    shape=(-1, 100),
+                    shape=(-1, CONST.TPA_LEAVE_TIME_BINS),
                 ),
                 # Count of simulations per bin where full fiber lysis occurred
                 "binned_fiber_degraded": DataSetSpec(
                     data_location=None,  # Derived dataset, not stored
                     dataset_storage_type=None,
                     dtype=np.uint16,
-                    shape=(100,),
+                    shape=(CONST.TPA_LEAVE_TIME_BINS,),
                 ),
                 # 0-indexed locations of neighboring edges for each edge in grid (8 neighbors each)
                 "edge_grid_neighbors": DataSetSpec(

--- a/src/lysis/execution/fortran_macro.py
+++ b/src/lysis/execution/fortran_macro.py
@@ -86,15 +86,29 @@ class FortranMacro(FortranRunner):
         ]
 
     def _post_arguments(self, params: dict) -> list:
-        """Append ``--radius`` and ``--bs`` from micro_params.
+        """Append ``--radius``, ``--bs`` and ``--nummicro`` from micro_params.
 
-        The macroscale binary needs two microscale-level parameters
-        (fiber radius and binding sites) that are not part of
-        :class:`~lysis.config.parameters.MacroParameters` itself.
+        The macroscale binary needs three microscale-level parameters that
+        are not part of :class:`~lysis.config.parameters.MacroParameters`
+        itself:
+
+        - ``--radius`` (fiber radius) and ``--bs`` (binding sites).
+        - ``--nummicro``: the number of rows in the microscale lysis-time
+          table (``lysismat``), which the Fortran binary reads as
+          ``micro_simulations / 100``.  It defaults to ``500`` inside the
+          binary (the value for the default ``micro_simulations`` of
+          50,000), so it MUST be passed for any other microscale-simulation
+          count or the binary reads past the end of ``lysismat.dat`` and
+          dies with an end-of-file error.
+
+        ``--nummicro`` is needed because ``micro_simulations`` lives on
+        :class:`~lysis.config.parameters.MicroParameters` and so is never
+        visited by the :class:`~lysis.config.parameters.MacroParameters`
+        argument loop.
 
         :param params: Unused; present for interface conformance.
         :type params: dict
-        :return: CLI arguments for radius and binding sites.
+        :return: CLI arguments for radius, binding sites, and nummicro.
         :rtype: list[str]
         """
         micro_units = MicroParameters.units()
@@ -107,6 +121,8 @@ class FortranMacro(FortranRunner):
             str(self.run.micro_params.binding_sites.m_as(
                 micro_units["binding_sites"]
             )),
+            "--nummicro",
+            str(self.run.micro_params.micro_simulations // 100),
         ]
 
     def _log_prefix(self) -> str:

--- a/src/lysis/execution/fortran_macro.py
+++ b/src/lysis/execution/fortran_macro.py
@@ -19,6 +19,7 @@ from typing import AnyStr
 
 import numpy as np
 
+from ..config.constants import CONST
 from ..config.parameters import MacroParameters, MicroParameters
 from ..config.run import Run
 from ..dataio.dataspec import dataspec
@@ -95,11 +96,12 @@ class FortranMacro(FortranRunner):
         - ``--radius`` (fiber radius) and ``--bs`` (binding sites).
         - ``--nummicro``: the number of rows in the microscale lysis-time
           table (``lysismat``), which the Fortran binary reads as
-          ``micro_simulations / 100``.  It defaults to ``500`` inside the
-          binary (the value for the default ``micro_simulations`` of
-          50,000), so it MUST be passed for any other microscale-simulation
-          count or the binary reads past the end of ``lysismat.dat`` and
-          dies with an end-of-file error.
+          ``micro_simulations / CONST.TPA_LEAVE_TIME_BINS`` (the
+          per-tPA-leaving-time-bin simulation count).  It defaults to ``500``
+          inside the binary (the value for the default ``micro_simulations``
+          of 50,000 at 100 bins), so it MUST be passed for any other
+          microscale-simulation count or the binary reads past the end of
+          ``lysismat.dat`` and dies with an end-of-file error.
 
         ``--nummicro`` is needed because ``micro_simulations`` lives on
         :class:`~lysis.config.parameters.MicroParameters` and so is never
@@ -122,7 +124,7 @@ class FortranMacro(FortranRunner):
                 micro_units["binding_sites"]
             )),
             "--nummicro",
-            str(self.run.micro_params.micro_simulations // 100),
+            str(self.run.micro_params.micro_simulations // CONST.TPA_LEAVE_TIME_BINS),
         ]
 
     def _log_prefix(self) -> str:

--- a/src/lysis/macroscale.py
+++ b/src/lysis/macroscale.py
@@ -186,7 +186,7 @@ from functools import partial
 import numpy as np
 from tqdm.auto import tqdm
 
-from .config.constants import MolStatus, RandomDraw
+from .config.constants import CONST, MolStatus, RandomDraw
 from .config.run import Run
 from .dataio.dataspec import dataspec
 from .geometry.edge_grid import EdgeGrid, from_fortran_edge_index, to_fortran_edge_index
@@ -370,8 +370,9 @@ class MacroscaleSim:
         self.reached_back_row = np.full(
             run.macro_params.total_molecules, False, dtype=np.bool_
         )
-        # X-axis values [0, 1, 2, ..., 100] for interpolating microscale data
-        self.xp = np.arange(101)
+        # X-axis values [0, 1, 2, ..., TPA_LEAVE_TIME_BINS] for interpolating
+        # microscale data (one node per tPA-leaving-time bin edge)
+        self.xp = np.arange(CONST.TPA_LEAVE_TIME_BINS + 1)
         # Storage for pre-generated random numbers (Fortran mode only)
         self.random_numbers = None
 
@@ -856,9 +857,10 @@ class MacroscaleSim:
             lysis_time_bin = self.random_numbers[RandomDraw.LYSIS_TIME][m]
         else:
             lysis_time_bin = self.rng.random(count)
-        # Scale to match the number of microscale simulation runs
+        # Scale to match the number of microscale simulation runs per bin
         lysis_time_bin = lysis_time_bin * (
-            self.run.macro_params.micro_params.micro_simulations / 100
+            self.run.macro_params.micro_params.micro_simulations
+            / CONST.TPA_LEAVE_TIME_BINS
         )
         # Initialize all lysis times to infinity (no lysis by default)
         interp = np.full(count, float("inf"), dtype=np.double)
@@ -910,9 +912,12 @@ class MacroscaleSim:
         self.total_binds += count
 
         if self.run.macro_params.duplicate_fortran:
-            unbinding_time_bin = self.random_numbers[RandomDraw.UNBINDING_TIME][m] * 100
+            unbinding_time_bin = (
+                self.random_numbers[RandomDraw.UNBINDING_TIME][m]
+                * CONST.TPA_LEAVE_TIME_BINS
+            )
         else:
-            unbinding_time_bin = self.rng.random(count) * 100
+            unbinding_time_bin = self.rng.random(count) * CONST.TPA_LEAVE_TIME_BINS
         self.binding_time[m] = self.find_unbinding_time(
             unbinding_time_bin, current_time
         )

--- a/tests/execution/test_fortran_macro.py
+++ b/tests/execution/test_fortran_macro.py
@@ -137,6 +137,23 @@ class TestFortranMacroExecCommand:
         )
         assert pytest.approx(float(cmd[idx + 1]), rel=1e-6) == expected
 
+    def test_nummicro_appended(self, fortran_macro):
+        """--nummicro from micro_params must appear in the command."""
+        cmd = fortran_macro.exec_command()
+        assert "--nummicro" in cmd
+
+    def test_nummicro_value_correct(self, fortran_macro):
+        """--nummicro must be micro_simulations // 100 (lysismat row count).
+
+        The Fortran binary defaults nummicro to 500 (for the default 50,000
+        micro simulations); a non-default micro_simulations must override it
+        or the binary reads past the end of lysismat.dat.
+        """
+        cmd = fortran_macro.exec_command()
+        idx = cmd.index("--nummicro")
+        expected = fortran_macro.run.micro_params.micro_simulations // 100
+        assert cmd[idx + 1] == str(expected)
+
     def test_seed_split_uses_macro_simulations(self, tmp_run):
         """Seed split count for FortranMacro must equal macro_simulations."""
         n_sims = tmp_run.macro_params.macro_simulations


### PR DESCRIPTION
## Summary

Two related commits.

### 1. Fix `FortranMacro` not passing `--nummicro` to the macroscale binary
The Fortran macroscale binary reads `nummicro` rows from `lysismat.dat` (the per-bin microscale degradation-time table) and **defaults it to 500** — the value for the default 50,000 microscale simulations. For any other `micro_simulations` count the binary read past the end of the file and died with:

```
forrtl: severe (24): end-of-file during read, unit 201, file .../lysismat.dat
```

`--nummicro` was never emitted because it derives from `micro_simulations`, which lives on `MicroParameters` and so is never visited by the `MacroParameters` command-line loop. It's now injected from `FortranMacro._post_arguments` alongside the existing `--radius`/`--bs` micro→macro workaround, computed as `micro_simulations // 100`.

Reproduced against `data/small-test-set__00/` (10,000 micro sims → `lysismat.dat` has 100 rows, but the binary used its 500-row default). After the fix the command carries `--nummicro 100`.

The broader fix for routing the microscale parameters the macroscale binary needs is tracked in #92.

### 2. Replace magic `100` with `CONST.TPA_LEAVE_TIME_BINS`
The micro→macro conversion sorts microscale sims by tPA leaving time and splits them into 100 equal-count quantile bins, building a separate sorted degradation-time distribution per bin. That `100` was hard-coded across the conversion (`dataconvert.py`), the data specification (`dataspec.py`), the macroscale model (`macroscale.py`), and the Fortran CLI builder (`fortran_macro.py`).

Introduces `CONST.TPA_LEAVE_TIME_BINS` (= 100) and routes every occurrence through it, including the derived bin-edge count (`BINS + 1`) and the bin width (`1 / BINS`). All substitutions are value-identical, so behaviour and on-disk data are unchanged (verified `1/100` is bit-identical to `0.01`, and all dataspec shapes resolve unchanged).

Intentionally left alone: `*100` percentage conversions, grid `rows`/`cols`, the generic `*100` Fortran-suffix handler, the `9.9e100` sentinel, and doctests/CLI examples.

## Testing
- New `test_nummicro_appended` / `test_nummicro_value_correct` (the latter uses a literal `100` as an independent oracle).
- **668 passed** across the dataio / execution / macroscale / degradation / convert / run-macro suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)