### PR TITLE
Surface missing microscale params + highlight non-default values in lysis parameters (#91)

### DIFF
--- a/src/lysis/analysis/summary.py
+++ b/src/lysis/analysis/summary.py
@@ -203,6 +203,7 @@ def parameters_table(
     add_names: list,
     natural_units: dict,
     run_codes: list,
+    nondefault_by_run: dict | None = None,
 ) -> pd.DataFrame:
     """Build a summary DataFrame for Run parameters.
 
@@ -229,6 +230,13 @@ def parameters_table(
     :type natural_units: dict[str, str]
     :param run_codes: Ordered list of run codes (determines column order).
     :type run_codes: list[str]
+    :param nondefault_by_run: Optional ``{run_code: {attr_name: bool}}`` marking
+        cells whose value differs from the model default.  When provided, a
+        boolean DataFrame aligned to the returned frame's index and columns is
+        attached as ``df.attrs["nondefault"]`` so renderers (e.g.
+        :func:`~lysis.tools.display.params_df_to_rich`) can highlight those
+        cells.  Markdown rendering ignores it.
+    :type nondefault_by_run: dict[str, dict[str, bool]] or None
     :return: DataFrame with MultiIndex rows and run codes as columns.
     :rtype: pandas.DataFrame
     """
@@ -253,7 +261,18 @@ def parameters_table(
     }
 
     index = pd.MultiIndex.from_tuples(index_tuples, names=["section", "parameter"])
-    return pd.DataFrame(data, index=index, columns=present)
+    df = pd.DataFrame(data, index=index, columns=present)
+
+    if nondefault_by_run is not None:
+        flag_data = {
+            rc: [bool(nondefault_by_run.get(rc, {}).get(a, False)) for a in attr_names]
+            for rc in present
+        }
+        df.attrs["nondefault"] = pd.DataFrame(
+            flag_data, index=index, columns=present
+        )
+
+    return df
 
 
 # ---------------------------------------------------------------------------

--- a/src/lysis/cli/parameters.py
+++ b/src/lysis/cli/parameters.py
@@ -46,8 +46,13 @@ _DEFAULT_PARAMS = [
     ("diss_const_PLG_intact", "micro",   None,         "{:.2f}"),
     ("diss_const_PLG_nicked", "micro",   None,         "{:.2f}"),
     ("deg_rate_fibrin",       "micro",   None,          "{:.2f}"),
+    ("unbind_rate_PLi",       "micro",   None,          "{:.2f}"),
+    ("activation_rate_PLG",   "micro",   None,          "{:.3f}"),
+    ("exposure_rate_binding_site", "micro", None,       "{:.2f}"),
     ("fiber_radius",          "micro",   "nanometers",  "{:.4f}"),
     ("binding_sites",         "micro",   None,          "{:.6f}"),
+    ("nodes_in_micro_row",    "micro",   None,          "{:,}"),
+    ("snap_proportion",       "micro",   None,          "{:.4f}"),
     # ---- Micro run controls -------------------------------------------
     ("micro_simulations",     "micro",   None,          "{:,}"),
     ("micro_seed",            "micro",   None,          "{:,}"),

--- a/src/lysis/cli/parameters.py
+++ b/src/lysis/cli/parameters.py
@@ -344,7 +344,10 @@ def parameters(ctx, path, sort_mode, no_progress, add_params, drop_params, markd
     natural_units = MacroParameters.units()
 
     # Formatted default values, for highlighting cells that differ from them.
-    defaults = _default_formatted(param_specs, add_names)
+    # Only the Rich output highlights, so skip this work for Markdown output.
+    defaults = None if markdown_out is not None else _default_formatted(
+        param_specs, add_names
+    )
 
     if os.path.isfile(path):
         # --- single-file mode ---
@@ -367,7 +370,11 @@ def parameters(ctx, path, sort_mode, no_progress, add_params, drop_params, markd
 
         # Drop macroscale rows when this file has no macroscale collection.
         effective_specs = param_specs if has_macro else _drop_macro_specs(param_specs)
-        nondefault_by_run = {run_code: _nondefault_flags(values, defaults)}
+        nondefault_by_run = (
+            None
+            if defaults is None
+            else {run_code: _nondefault_flags(values, defaults)}
+        )
         df = parameters_table(
             {run_code: values},
             effective_specs,
@@ -449,9 +456,11 @@ def parameters(ctx, path, sort_mode, no_progress, add_params, drop_params, markd
         # columns still line up when the set is mixed.
         ordered = [rc for rc in run_codes if rc in rows]
         effective_specs = param_specs if any_macro else _drop_macro_specs(param_specs)
-        nondefault_by_run = {
-            rc: _nondefault_flags(vals, defaults) for rc, vals in rows.items()
-        }
+        nondefault_by_run = (
+            None
+            if defaults is None
+            else {rc: _nondefault_flags(vals, defaults) for rc, vals in rows.items()}
+        )
         df = parameters_table(
             rows,
             effective_specs,

--- a/src/lysis/cli/parameters.py
+++ b/src/lysis/cli/parameters.py
@@ -108,6 +108,55 @@ def _auto_format(raw):
     return str(raw)
 
 
+def _default_formatted(param_specs, add_names):
+    """Formatted values for freshly-constructed default parameter objects.
+
+    Renders default :class:`~lysis.config.parameters.MicroParameters` and
+    :class:`~lysis.config.parameters.MacroParameters` through the same
+    formatting path as :func:`_load_run_params`, so a run's formatted value can
+    be compared against the model default to decide whether to highlight it.
+
+    :param param_specs: Effective ``(attr_name, source, units, fmt)`` specs.
+    :param add_names: Extra attribute names added via ``--add``.
+    :return: ``{attr_name: formatted_str}`` for every spec row and add name.
+    :rtype: dict[str, str]
+    """
+    import warnings
+
+    from lysis.config.parameters import MacroParameters, MicroParameters
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        micro = MicroParameters()
+        macro = MacroParameters(micro_params=micro)
+
+    defaults = {}
+    for attr_name, _src, display_units, fmt in param_specs:
+        defaults[attr_name] = _format_value(
+            _get_raw(macro, micro, attr_name), display_units, fmt
+        )
+    for attr_name in add_names:
+        defaults[attr_name] = _auto_format(_get_raw(macro, micro, attr_name))
+    return defaults
+
+
+def _nondefault_flags(values, defaults):
+    """Map ``{attr_name: bool}`` marking values that differ from the default.
+
+    A value is non-default when its formatted string differs from the default's
+    and is not ``"N/A"`` (absent macroscale data renders as ``"N/A"`` and is
+    never highlighted).
+
+    :param values: ``{attr_name: formatted_str}`` for one run.
+    :param defaults: ``{attr_name: formatted_str}`` from :func:`_default_formatted`.
+    :rtype: dict[str, bool]
+    """
+    return {
+        attr: val != "N/A" and val != defaults.get(attr)
+        for attr, val in values.items()
+    }
+
+
 def _param_header(attr_name, display_units, natural_units):
     """Build a single-line row label with units in parentheses."""
     units = display_units or natural_units.get(attr_name)
@@ -260,6 +309,10 @@ def parameters(ctx, path, sort_mode, no_progress, add_params, drop_params, markd
     Run and one row per parameter. Parameters are grouped into macro and micro
     sections, separated by a divider.
 
+    In the terminal (Rich) output, values that differ from the model defaults
+    are highlighted in a distinct color, making non-default runs easy to spot.
+    Markdown output (--markdown) is unstyled.
+
     \b
     Examples:
         lysis parameters data/TB-xi__1_582_867.h5
@@ -290,6 +343,9 @@ def parameters(ctx, path, sort_mode, no_progress, add_params, drop_params, markd
     # Pre-build natural-units dict for column headers (no run needed)
     natural_units = MacroParameters.units()
 
+    # Formatted default values, for highlighting cells that differ from them.
+    defaults = _default_formatted(param_specs, add_names)
+
     if os.path.isfile(path):
         # --- single-file mode ---
         run_code = os.path.splitext(os.path.basename(path))[0]
@@ -311,8 +367,14 @@ def parameters(ctx, path, sort_mode, no_progress, add_params, drop_params, markd
 
         # Drop macroscale rows when this file has no macroscale collection.
         effective_specs = param_specs if has_macro else _drop_macro_specs(param_specs)
+        nondefault_by_run = {run_code: _nondefault_flags(values, defaults)}
         df = parameters_table(
-            {run_code: values}, effective_specs, add_names, natural_units, [run_code]
+            {run_code: values},
+            effective_specs,
+            add_names,
+            natural_units,
+            [run_code],
+            nondefault_by_run=nondefault_by_run,
         )
 
         if markdown_out is not None:
@@ -387,7 +449,17 @@ def parameters(ctx, path, sort_mode, no_progress, add_params, drop_params, markd
         # columns still line up when the set is mixed.
         ordered = [rc for rc in run_codes if rc in rows]
         effective_specs = param_specs if any_macro else _drop_macro_specs(param_specs)
-        df = parameters_table(rows, effective_specs, add_names, natural_units, ordered)
+        nondefault_by_run = {
+            rc: _nondefault_flags(vals, defaults) for rc, vals in rows.items()
+        }
+        df = parameters_table(
+            rows,
+            effective_specs,
+            add_names,
+            natural_units,
+            ordered,
+            nondefault_by_run=nondefault_by_run,
+        )
 
         if markdown_out is not None:
             emit_markdown(

--- a/src/lysis/tools/display.py
+++ b/src/lysis/tools/display.py
@@ -18,6 +18,10 @@ import math
 
 import pandas as pd
 
+#: Rich style applied to parameter cells whose value differs from the model
+#: default (see :func:`params_df_to_rich`).
+NONDEFAULT_STYLE = "yellow"
+
 
 # ---------------------------------------------------------------------------
 # Percent-difference formatting
@@ -273,6 +277,11 @@ def params_df_to_rich(df: pd.DataFrame):
     display label.  A section separator is inserted between each distinct
     section group.
 
+    If ``df.attrs["nondefault"]`` holds a boolean DataFrame aligned to ``df``
+    (as produced by :func:`~lysis.analysis.summary.parameters_table`), cells
+    flagged ``True`` are styled with :data:`NONDEFAULT_STYLE` so values that
+    differ from the model defaults stand out.
+
     :param df: Parameters DataFrame as returned by
         :func:`~lysis.analysis.summary.parameters_table`.
     :type df: pandas.DataFrame
@@ -280,6 +289,9 @@ def params_df_to_rich(df: pd.DataFrame):
     :rtype: rich.table.Table
     """
     from rich.table import Table
+    from rich.text import Text
+
+    nondefault = df.attrs.get("nondefault")
 
     table = Table(show_header=True, header_style="bold", show_lines=True)
     table.add_column("Parameter", style="bold", no_wrap=True)
@@ -287,11 +299,18 @@ def params_df_to_rich(df: pd.DataFrame):
         table.add_column(str(col), justify="right")
 
     current_section = None
-    for (section, param_label), row in df.iterrows():
+    for idx, row in df.iterrows():
+        section, param_label = idx
         if current_section is not None and section != current_section:
             table.add_section()
         current_section = section
-        table.add_row(param_label, *[str(v) for v in row])
+        cells = []
+        for col, value in zip(df.columns, row):
+            if nondefault is not None and bool(nondefault.loc[idx, col]):
+                cells.append(Text(str(value), style=NONDEFAULT_STYLE))
+            else:
+                cells.append(str(value))
+        table.add_row(param_label, *cells)
 
     return table
 

--- a/tests/cli/test_parameters.py
+++ b/tests/cli/test_parameters.py
@@ -512,13 +512,15 @@ class TestNonDefaultHighlight:
     def test_rich_render_colors_nondefault_cell(self, tmp_path):
         out = _render_rich(self._df_for(tmp_path, micro_simulations=42))
 
-        # The non-default micro_simulations row carries a color escape; a
-        # left-at-default row (bind_rate_tPA) does not.
+        # The non-default micro_simulations row carries the yellow escape; a
+        # left-at-default row (bind_rate_tPA) does not.  Assert on \x1b[33m
+        # specifically: every row's bold "Parameter" cell already emits \x1b[,
+        # so a bare \x1b[ check would pass even with highlighting removed.
         nondefault_line = next(
             l for l in out.splitlines() if "micro_simulations" in l
         )
         default_line = next(l for l in out.splitlines() if "bind_rate_tPA" in l)
-        assert "\x1b[" in nondefault_line
+        assert "\x1b[33m" in nondefault_line
         assert "\x1b[33m" not in default_line
 
     def test_no_attrs_means_no_color(self, tmp_path):

--- a/tests/cli/test_parameters.py
+++ b/tests/cli/test_parameters.py
@@ -430,3 +430,121 @@ class TestDropMacroSpecs:
         assert "fiber_radius" in kept
         assert "micro_simulations" in kept
         assert "micro_seed" in kept
+
+
+# ---------------------------------------------------------------------------
+# Non-default value highlighting (rich terminal only)
+# ---------------------------------------------------------------------------
+
+
+def _render_rich(df):
+    """Render a parameters DataFrame to an ANSI string via a forced terminal."""
+    import io
+
+    from rich.console import Console
+
+    from lysis.tools.display import params_df_to_rich
+
+    buf = io.StringIO()
+    console = Console(
+        file=buf, force_terminal=True, width=120, color_system="standard"
+    )
+    console.print(params_df_to_rich(df))
+    return buf.getvalue()
+
+
+class TestNonDefaultHighlight:
+    """Values differing from the model defaults are highlighted in rich output."""
+
+    def _flags_for(self, tmp_path, **micro_kwargs):
+        from rich.console import Console
+
+        from lysis.cli.parameters import _default_formatted, _nondefault_flags
+
+        run_code = _make_micro_only_run(tmp_path, **micro_kwargs)
+        values, _has_macro = _load_run_params(
+            str(tmp_path), run_code, _DEFAULT_PARAMS, [], Console()
+        )
+        flags = _nondefault_flags(values, _default_formatted(_DEFAULT_PARAMS, []))
+        return run_code, values, flags
+
+    def _df_for(self, tmp_path, **micro_kwargs):
+        from lysis.analysis.summary import parameters_table
+        from lysis.cli.parameters import _drop_macro_specs
+        from lysis.config.parameters import MacroParameters
+
+        run_code, values, flags = self._flags_for(tmp_path, **micro_kwargs)
+        specs = _drop_macro_specs(_DEFAULT_PARAMS)
+        return parameters_table(
+            {run_code: values},
+            specs,
+            [],
+            MacroParameters.units(),
+            [run_code],
+            nondefault_by_run={run_code: flags},
+        )
+
+    def test_nondefault_flags_mark_changed_only(self, tmp_path):
+        # micro_simulations default is 50000; 42 is non-default.
+        _run_code, _values, flags = self._flags_for(tmp_path, micro_simulations=42)
+
+        assert flags["micro_simulations"] is True
+        # Left at their defaults:
+        assert flags["bind_rate_tPA"] is False
+        assert flags["snap_proportion"] is False
+        assert flags["nodes_in_micro_row"] is False
+
+    def test_na_cells_never_flagged(self, tmp_path):
+        """Macro params (absent here, rendered N/A) are never marked non-default."""
+        _run_code, values, flags = self._flags_for(tmp_path)
+
+        assert values["pore_size"] == "N/A"
+        assert flags["pore_size"] is False
+
+    def test_table_attaches_aligned_nondefault_frame(self, tmp_path):
+        df = self._df_for(tmp_path, micro_simulations=42)
+
+        flags_df = df.attrs.get("nondefault")
+        assert flags_df is not None
+        assert list(flags_df.index) == list(df.index)
+        assert list(flags_df.columns) == list(df.columns)
+
+    def test_rich_render_colors_nondefault_cell(self, tmp_path):
+        out = _render_rich(self._df_for(tmp_path, micro_simulations=42))
+
+        # The non-default micro_simulations row carries a color escape; a
+        # left-at-default row (bind_rate_tPA) does not.
+        nondefault_line = next(
+            l for l in out.splitlines() if "micro_simulations" in l
+        )
+        default_line = next(l for l in out.splitlines() if "bind_rate_tPA" in l)
+        assert "\x1b[" in nondefault_line
+        assert "\x1b[33m" not in default_line
+
+    def test_no_attrs_means_no_color(self, tmp_path):
+        """Without a nondefault frame, the rich table is rendered plain."""
+        from rich.console import Console
+
+        from lysis.analysis.summary import parameters_table
+        from lysis.cli.parameters import _drop_macro_specs
+        from lysis.config.parameters import MacroParameters
+
+        run_code = _make_micro_only_run(tmp_path, micro_simulations=42)
+        values, _ = _load_run_params(
+            str(tmp_path), run_code, _DEFAULT_PARAMS, [], Console()
+        )
+        specs = _drop_macro_specs(_DEFAULT_PARAMS)
+        df = parameters_table(
+            {run_code: values}, specs, [], MacroParameters.units(), [run_code]
+        )  # no nondefault_by_run
+
+        assert "\x1b[33m" not in _render_rich(df)
+
+    def test_markdown_output_is_unstyled(self, runner, tmp_path):
+        run_code = _make_micro_only_run(tmp_path, micro_simulations=42)
+        h5 = tmp_path / f"{run_code}.h5"
+
+        result = runner.invoke(cli, ["parameters", str(h5), "--markdown", "-"])
+
+        assert result.exit_code == 0
+        assert "\x1b[" not in result.output

--- a/tests/cli/test_parameters.py
+++ b/tests/cli/test_parameters.py
@@ -353,6 +353,50 @@ class TestParametersMicroOnly:
         assert result.exit_code == 0
         assert "N/A" not in result.output
 
+    def test_new_micro_params_real_values(self, tmp_path):
+        """The five micro Fortran-CLI inputs added in #91 show real values."""
+        run_code = _make_micro_only_run(tmp_path)
+        from rich.console import Console
+
+        values, _has_macro = _load_run_params(
+            str(tmp_path), run_code, _DEFAULT_PARAMS, [], Console()
+        )
+
+        assert values["nodes_in_micro_row"] == "7"
+        assert values["snap_proportion"] == "0.6667"
+        assert values["unbind_rate_PLi"] == "57.60"
+        assert values["activation_rate_PLG"] == "0.100"
+        assert values["exposure_rate_binding_site"] == "5.00"
+
+    def test_micro_params_broad_coverage_not_na(self, tmp_path):
+        """Every microscale entry in the default table resolves (issue #91)."""
+        run_code = _make_micro_only_run(tmp_path)
+        from rich.console import Console
+
+        values, _has_macro = _load_run_params(
+            str(tmp_path), run_code, _DEFAULT_PARAMS, [], Console()
+        )
+
+        micro_attrs = [attr for attr, src, *_ in _DEFAULT_PARAMS if src == "micro"]
+        na = [a for a in micro_attrs if values[a] == "N/A"]
+        assert na == [], f"micro params unexpectedly N/A: {na}"
+
+    def test_add_micro_fallback_not_in_defaults(self, tmp_path):
+        """``--add`` of a micro attr absent from the defaults still resolves.
+
+        ``protofibril_radius`` is a microscale parameter that is not part of
+        ``_DEFAULT_PARAMS``; pulling it via ``--add`` on a micro-only file
+        exercises the ``_get_raw`` microscale fallback that issue #91 targets.
+        """
+        run_code = _make_micro_only_run(tmp_path)
+        from rich.console import Console
+
+        values, _has_macro = _load_run_params(
+            str(tmp_path), run_code, _DEFAULT_PARAMS, ["protofibril_radius"], Console()
+        )
+
+        assert values["protofibril_radius"] != "N/A"
+
 
 # ---------------------------------------------------------------------------
 # Macro-spec dropping (canonical source)


### PR DESCRIPTION
## Summary

Closes #91.

Investigation found that issue #91's reported symptom — microscale params (e.g. `nodes_in_micro_row`) rendering as `N/A` on micro-only files — **does not reproduce on current `main`**: it was already fixed by the #22 fix (`c0c23b3`). The issue text quotes the *pre-#22* `_get_raw(macro_params, attr_name)` code; the live code already resolves micro params independently.

The **real** gap was that `_DEFAULT_PARAMS` was incomplete. Cross-referencing it against the `MicroParameters`/`MacroParameters` dataclasses and the Fortran CLI inputs (`micro_rates.f90`, `macro_diffuse_into_and_along__{internal,external}.f90`) showed the macroscale table fully covered, but **five user-tunable microscale Fortran-CLI inputs were missing**. Notably, `binding_sites` (shown) is derived from `nodes_in_micro_row` (not shown).

## Changes

1. **Add 5 missing microscale params** to the `lysis parameters` default table: `nodes_in_micro_row`, `snap_proportion`, `unbind_rate_PLi`, `activation_rate_PLG`, `exposure_rate_binding_site`. All five are already in the Fortran↔Python param reference (`docs/source/usage/fortran_microscale.rst`).
2. **Highlight non-default values** in the Rich terminal output: any cell whose value differs from the freshly-constructed model default is styled (yellow). Markdown output is unstyled; `N/A` cells are never highlighted.

## Tests

- Micro-only regression tests: the 5 new params render real values; no micro default-table entry resolves to `N/A`; `--add` micro fallback works for a param outside the defaults.
- Highlighting: flag computation marks only changed values, `N/A` never flagged, aligned `df.attrs["nondefault"]` frame, ANSI styling present for non-default / absent for default, markdown unstyled.
- Full `tests/cli/` + `tests/analysis/` suites pass (551).

🤖 Generated with [Claude Code](https://claude.com/claude-code)