### PR TITLE
Ingest Slurm worker logs into HDF5 log_files/dispatcher/ (#55)

### DIFF
--- a/docs/source/usage/data_specification.rst
+++ b/docs/source/usage/data_specification.rst
@@ -28,7 +28,14 @@ Group Structure
   Contains a group for each macroscale simulation's datasets, named sim_00, sim_01, sim_02, ...
 
 ``log_files``
-  Contains log files for all executions of code
+  Contains log files for all executions of code.  The binary's own code-output
+  logs live at the top level (``micro_log``, ``macro_log__sim_XX``);
+  scheduler-captured **worker** logs from Slurm-dispatched runs live in the
+  ``dispatcher`` subgroup (optional — absent for direct execution).  The Slurm
+  *master* log is left on disk in ``<run dir>/.slurm/`` and is not ingested.
+  On a successful run the on-disk worker ``.out`` files are removed with the
+  staging directory (the HDF5 becomes the record); on failure they are kept on
+  disk, uningested.
 
 Provenance attributes
 ---------------------
@@ -367,6 +374,29 @@ Log datasets
 
 ``macro_log__sim_XX``
   The log from the macroscale execution of simulation XX, stored one line per row.
+
+  :Data Type:
+    String (``S``)
+  :Dimensions:
+    (log events,)
+
+``dispatcher/micro_dispatcher_log``
+  The scheduler-captured stdout/stderr of the microscale **Slurm worker**
+  job(s) — the identifying header, ``set -x`` trace, and Fortran stdout —
+  concatenated across array tasks into one combined log, stored one line per
+  row.  Complements ``micro_log`` (the binary's own code-output log).  Present
+  only for Slurm-dispatched runs; ``optional`` and absent for direct
+  execution.
+
+  :Data Type:
+    String (``S``)
+  :Dimensions:
+    (log events,)
+
+``dispatcher/macro_dispatcher_log__sim_XX``
+  As above, for macroscale simulation XX's array task (one dataset per
+  simulation, since a macro array task maps 1:1 to a simulation).  ``optional``
+  and absent for direct execution.
 
   :Data Type:
     String (``S``)

--- a/src/lysis/dataio/dataconvert.py
+++ b/src/lysis/dataio/dataconvert.py
@@ -1192,6 +1192,7 @@ data_converters: dict[
         # Microscale output datasets (fully implemented - direct field mapping)
         # ------------------------------------------------------------------------
         "micro_log": lambda data: data["micro_log"],  # Direct mapping
+        "micro_dispatcher_log": lambda data: data["micro_dispatcher_log"],
         "firstPLi": lambda data: data["pli_first_time"],  # Direct mapping
         "lasttPA": lambda data: data["tpa_final_num"],  # Direct mapping
         "lyscomplete": lambda data: data["fiber_degraded"],  # Direct mapping
@@ -1228,6 +1229,7 @@ data_converters: dict[
         # structured arrays and convert_location_snapshot() for location data
         # ------------------------------------------------------------------------
         "macro_log": lambda data: data["macro_log"],  # Direct mapping
+        "macro_dispatcher_log": lambda data: data["macro_dispatcher_log"],
         "Nsave": lambda data: [
             np.int32(len(x) - 1) for x in data["snapshot_time"]
         ],  # Fortran Nsave counts save intervals, excludes initial time
@@ -1270,6 +1272,7 @@ data_converters: dict[
         # Microscale output datasets (fully implemented - direct field mapping)
         # ------------------------------------------------------------------------
         "micro_log": lambda data: data["micro_log"],  # Direct mapping
+        "micro_dispatcher_log": lambda data: data["micro_dispatcher_log"],
         "pli_first_time": lambda data: data["firstPLi"],  # Direct mapping
         "tpa_final_num": lambda data: data["lasttPA"],  # Direct mapping
         "fiber_degraded": lambda data: data["lyscomplete"],  # Direct mapping
@@ -1317,6 +1320,7 @@ data_converters: dict[
         # structured arrays and convert_location_snapshot() for location data
         # ------------------------------------------------------------------------
         "macro_log": lambda data: data["macro_log"],  # Direct mapping
+        "macro_dispatcher_log": lambda data: data["macro_dispatcher_log"],
         "snapshot_time": lambda data: data["tsave"],  # Direct mapping
         "fiber_degrade_time": functools.partial(
             convert_structured_grid_fields,

--- a/src/lysis/dataio/dataspec.py
+++ b/src/lysis/dataio/dataspec.py
@@ -579,6 +579,15 @@ _dataspec_raw: dict[str, dict[str, DataCollectionSpec]] = {
                     dtype=str,
                     delimiter="\u0000",  # Null-terminated strings
                 ),
+                # Scheduler-captured worker stdout (Slurm child/array jobs),
+                # concatenated to one combined log; absent for direct execution.
+                "micro_dispatcher_log": DataSetSpec(
+                    data_location="micro_dispatcher{file_code}.out",
+                    dataset_storage_type=CONST.DATASET_STORAGE_TYPE.FILE_TEXT,
+                    dtype=str,
+                    delimiter="\u0000",
+                    optional=True,
+                ),
                 # Time when first plasmin (PLi) molecule was generated in each simulation
                 "firstPLi": DataSetSpec(
                     data_location="firstPLi{file_code}.dat",
@@ -697,6 +706,15 @@ _dataspec_raw: dict[str, dict[str, DataCollectionSpec]] = {
                     dtype=str,
                     delimiter="\u0000",
                 ),
+                # Scheduler-captured worker stdout for this simulation's array
+                # task (Slurm); absent for direct execution.
+                "macro_dispatcher_log": DataSetSpec(
+                    data_location="macro_dispatcher{file_code}_{sim:02}.out",
+                    dataset_storage_type=CONST.DATASET_STORAGE_TYPE.FILE_TEXT,
+                    dtype=str,
+                    delimiter="\u0000",
+                    optional=True,
+                ),
                 # Number of snapshots recorded during this simulation
                 "Nsave": DataSetSpec(
                     data_location="{sim:02}/Nsave{file_code}_{sim:02}.dat",
@@ -782,6 +800,14 @@ _dataspec_raw: dict[str, dict[str, DataCollectionSpec]] = {
                     data_location="log_files/micro_log",
                     dataset_storage_type=CONST.DATASET_STORAGE_TYPE.HDF5_DATASET,
                     dtype=h5py.string_dtype(),
+                ),
+                # Scheduler-captured worker stdout (Slurm), concatenated; absent
+                # for direct execution.
+                "micro_dispatcher_log": DataSetSpec(
+                    data_location="log_files/dispatcher/micro_dispatcher_log",
+                    dataset_storage_type=CONST.DATASET_STORAGE_TYPE.HDF5_DATASET,
+                    dtype=h5py.string_dtype(),
+                    optional=True,
                 ),
                 # Time when first plasmin (PLi) molecule was generated in each simulation
                 "pli_first_time": DataSetSpec(
@@ -899,6 +925,14 @@ _dataspec_raw: dict[str, dict[str, DataCollectionSpec]] = {
                     data_location="log_files/macro_log__sim_{sim:02}",
                     dataset_storage_type=CONST.DATASET_STORAGE_TYPE.HDF5_DATASET,
                     dtype=h5py.string_dtype(),
+                ),
+                # Scheduler-captured worker stdout for this simulation's array
+                # task (Slurm); absent for direct execution.
+                "macro_dispatcher_log": DataSetSpec(
+                    data_location="log_files/dispatcher/macro_dispatcher_log__sim_{sim:02}",
+                    dataset_storage_type=CONST.DATASET_STORAGE_TYPE.HDF5_DATASET,
+                    dtype=h5py.string_dtype(),
+                    optional=True,
                 ),
                 # Simulation time at each snapshot
                 "snapshot_time": DataSetSpec(

--- a/src/lysis/dataio/datastore.py
+++ b/src/lysis/dataio/datastore.py
@@ -917,8 +917,9 @@ class DataStore:
         :type macro_params: MacroParameters
         :param force: If ``True`` and ``macroscale_out`` already exists,
             wipe the ``macro_data`` group and any ``log_files/macro_log__sim_*``
-            datasets before re-initialising.  Any previously stored
-            execution provenance attributes are lost along with the group.
+            and ``log_files/dispatcher/macro_dispatcher_log__sim_*`` datasets
+            before re-initialising.  Any previously stored execution
+            provenance attributes are lost along with the group.
         :type force: bool
         :raises IOError: If the DataStore is opened in read-only mode.
         :raises TypeError: If ``macro_params`` is not a
@@ -959,6 +960,16 @@ class DataStore:
                 ]
                 for key in macro_log_keys:
                     del self._file[f"log_files/{key}"]
+            # Per-sim macro dispatcher logs live in a nested subgroup; clear
+            # them too so _create_empty_datasets can recreate the placeholders
+            # (this also keeps #85's import-failure rollback consistent).
+            if "log_files/dispatcher" in self._file:
+                for key in [
+                    k
+                    for k in self._file["log_files/dispatcher"]
+                    if k.startswith("macro_dispatcher_log__sim_")
+                ]:
+                    del self._file[f"log_files/dispatcher/{key}"]
             self._file.flush()
 
         # Read microscale unbinding arrays and compute forced_unbind from data.

--- a/src/lysis/dataio/fileops.py
+++ b/src/lysis/dataio/fileops.py
@@ -343,6 +343,7 @@ def _read_file_text(
         os.path.join(path, spec.data_location.format(sim=sim, file_code=file_code)),
         dtype=spec.dtype,
         delimiter=spec.delimiter,
+        comments=None,  # don't strip "#"; log files may contain it (data files don't)
     )
 
 

--- a/src/lysis/execution/fortran.py
+++ b/src/lysis/execution/fortran.py
@@ -571,6 +571,35 @@ class FortranRunner(SimulationRunner):
         """
         raise NotImplementedError
 
+    def _discover_array_logs(self, source_dir: "Path | str") -> "dict[int, Path]":
+        """Map array-task id -> worker ``.out`` path for this run.
+
+        Globs *source_dir* for this run's
+        ``lysis-{scale}-array__{run_code}__*.out`` worker logs (the scale comes
+        from :meth:`_log_prefix`) and parses the trailing ``%a`` task id.
+        Matches whose suffix is not a numeric task id are skipped, so an
+        unexpected filename never aborts staging; parsing with :func:`int` also
+        makes the result robust to ``%a`` vs ``%2a`` zero-padding in the
+        ``--output`` name.  The master ``.out`` lives elsewhere and is never
+        matched.  Shared by the :class:`FortranMicro` / :class:`FortranMacro`
+        :meth:`stage_dispatcher_logs` implementations.
+
+        :param source_dir: Directory holding the worker ``.out`` files.
+        :type source_dir: Path or str
+        :return: ``{task_id: path}`` for each array task that wrote a log.
+        :rtype: dict[int, pathlib.Path]
+        """
+        source_dir = Path(source_dir)
+        scale = self._log_prefix()
+        run_code = self.run.run_code
+        by_task: "dict[int, Path]" = {}
+        for p in source_dir.glob(f"lysis-{scale}-array__{run_code}__*.out"):
+            try:
+                by_task[int(p.stem.rsplit("__", 1)[-1])] = p
+            except ValueError:
+                continue
+        return by_task
+
     def run_full(
         self,
         *,

--- a/src/lysis/execution/fortran.py
+++ b/src/lysis/execution/fortran.py
@@ -481,6 +481,7 @@ class FortranRunner(SimulationRunner):
         *,
         keep_on_failure: bool = False,
         keep_tmpdir: bool = False,
+        dispatcher_log_dir: "Path | str | None" = None,
     ) -> None:
         """Convert Fortran output in *data_dir* and write it to the run's HDF5 file.
 
@@ -517,12 +518,21 @@ class FortranRunner(SimulationRunner):
         :type keep_on_failure: bool, optional
         :param keep_tmpdir: Always preserve *data_dir*, defaults to ``False``.
         :type keep_tmpdir: bool, optional
+        :param dispatcher_log_dir: If given, scheduler-captured worker ``.out``
+            logs are staged from this directory into *data_dir* (under the
+            dispatcher spec filenames) before the import, so they ride the
+            normal import pipeline into ``log_files/dispatcher/``.  ``None``
+            (direct, non-Slurm execution) skips this step.  Staging runs inside
+            the try/except so a staging error honours the cleanup policy.
+        :type dispatcher_log_dir: Path or str or None, optional
         :raises Exception: Re-raises any exception from the import pipeline
             after applying the cleanup policy.
         """
         data_dir = Path(data_dir)
 
         try:
+            if dispatcher_log_dir is not None:
+                self.stage_dispatcher_logs(Path(dispatcher_log_dir), data_dir)
             with DataStore(self.run.run_code, self.run.os_path, mode="a") as ds:
                 ds.import_collection(
                     self._collection_name(),
@@ -541,6 +551,25 @@ class FortranRunner(SimulationRunner):
             if not keep_on_failure and not keep_tmpdir:
                 shutil.rmtree(data_dir, ignore_errors=True)
             raise
+
+    def stage_dispatcher_logs(
+        self, source_dir: "Path | str", data_dir: "Path | str"
+    ) -> None:
+        """Stage scheduler-captured worker ``.out`` logs into *data_dir*.
+
+        Copies/concatenates the Slurm worker ``.out`` files in *source_dir*
+        (the master's staging dir, where ``--output`` now lands) into
+        *data_dir* under the ``{scale}_dispatcher`` filenames expected by the
+        v1.99.0 dispatcher-log specs, so :meth:`import_results` ingests them
+        into ``log_files/dispatcher/`` through the normal pipeline.  Scale
+        specific; implemented by :class:`FortranMicro` / :class:`FortranMacro`.
+
+        :param source_dir: Directory holding the worker ``.out`` files.
+        :type source_dir: Path or str
+        :param data_dir: The Fortran output directory the import reads from.
+        :type data_dir: Path or str
+        """
+        raise NotImplementedError
 
     def run_full(
         self,

--- a/src/lysis/execution/fortran_macro.py
+++ b/src/lysis/execution/fortran_macro.py
@@ -163,14 +163,8 @@ class FortranMacro(FortranRunner):
         """
         source_dir = Path(source_dir)
         data_dir = Path(data_dir)
-        run_code = self.run.run_code
-        # Map array task id -> .out (robust to %a vs %2a padding in the name).
-        by_task: dict[int, Path] = {}
-        for p in source_dir.glob(f"lysis-macro-array__{run_code}__*.out"):
-            try:
-                by_task[int(p.stem.rsplit("__", 1)[-1])] = p
-            except ValueError:
-                continue
+        # Array task id -> .out (1:1 with simulation index).
+        by_task = self._discover_array_logs(source_dir)
         if not by_task:
             return  # no worker logs -> optional dispatcher log is skipped
         sims = sorted(

--- a/src/lysis/execution/fortran_macro.py
+++ b/src/lysis/execution/fortran_macro.py
@@ -11,6 +11,7 @@ For step-by-step control use :meth:`FortranMacro.exec_in_workdir` followed
 by :meth:`FortranMacro.import_results`.
 """
 
+import shutil
 import subprocess
 
 from dataclasses import asdict, dataclass
@@ -139,6 +140,51 @@ class FortranMacro(FortranRunner):
     def _pre_execute(self) -> None:
         """Generate neighborhoods before the legacy ``execute()`` path runs."""
         self.generate_neighborhoods()
+
+    def stage_dispatcher_logs(
+        self, source_dir: "Path | str", data_dir: "Path | str"
+    ) -> None:
+        """Stage each array task's worker ``.out`` into a per-sim dispatcher log.
+
+        A macroscale array maps task ``%a`` 1:1 to a simulation index, so each
+        ``lysis-macro-array__{run_code}__N.out`` becomes
+        ``macro_dispatcher{out_file_code}_{N:02}.out`` in *data_dir*, matching
+        the v1.99.0 ``macro_dispatcher_log`` spec.  Staging is *dense* over the
+        per-simulation subdirectories the run created (``data_dir/{sim:02}/``):
+        a simulation whose task produced no ``.out`` still gets a placeholder so
+        the per-sim dispatcher count stays aligned with ``macro_simulations``
+        (and the import sim-count check).  Does nothing when no worker logs are
+        present (e.g. direct execution).
+
+        :param source_dir: Directory holding the worker ``.out`` files.
+        :type source_dir: Path or str
+        :param data_dir: The Fortran output directory the import reads from.
+        :type data_dir: Path or str
+        """
+        source_dir = Path(source_dir)
+        data_dir = Path(data_dir)
+        run_code = self.run.run_code
+        # Map array task id -> .out (robust to %a vs %2a padding in the name).
+        by_task: dict[int, Path] = {}
+        for p in source_dir.glob(f"lysis-macro-array__{run_code}__*.out"):
+            try:
+                by_task[int(p.stem.rsplit("__", 1)[-1])] = p
+            except ValueError:
+                continue
+        if not by_task:
+            return  # no worker logs -> optional dispatcher log is skipped
+        sims = sorted(
+            int(p.name)
+            for p in data_dir.iterdir()
+            if p.is_dir() and p.name.isdigit()
+        )
+        for sim in sims:
+            dst = data_dir / f"macro_dispatcher{self.out_file_code}_{sim:02}.out"
+            src = by_task.get(sim)
+            if src is not None:
+                shutil.copyfile(src, dst)
+            else:
+                dst.write_text("\n")  # placeholder keeps the per-sim count dense
 
     # ------------------------------------------------------------------
     # Construction helpers

--- a/src/lysis/execution/fortran_micro.py
+++ b/src/lysis/execution/fortran_micro.py
@@ -341,10 +341,15 @@ class FortranMicro(FortranRunner):
         source_dir = Path(source_dir)
         data_dir = Path(data_dir)
         run_code = self.run.run_code
-        sources = sorted(
-            source_dir.glob(f"lysis-micro-array__{run_code}__*.out"),
-            key=lambda p: int(p.stem.rsplit("__", 1)[-1]),
-        )
+        # Order array-task logs by integer task id; skip any glob match whose
+        # suffix isn't numeric (mirrors the guarded parse in FortranMacro).
+        array_logs = []
+        for p in source_dir.glob(f"lysis-micro-array__{run_code}__*.out"):
+            try:
+                array_logs.append((int(p.stem.rsplit("__", 1)[-1]), p))
+            except ValueError:
+                continue
+        sources = [p for _, p in sorted(array_logs, key=lambda t: t[0])]
         child_log = source_dir / f"lysis-micro-child__{run_code}.out"
         if child_log.exists():
             sources.append(child_log)

--- a/src/lysis/execution/fortran_micro.py
+++ b/src/lysis/execution/fortran_micro.py
@@ -319,6 +319,43 @@ class FortranMicro(FortranRunner):
                 with open(log_src, "rb") as in_fh:
                     shutil.copyfileobj(in_fh, out_fh)
 
+    def stage_dispatcher_logs(
+        self, source_dir: "Path | str", data_dir: "Path | str"
+    ) -> None:
+        """Concatenate the worker ``.out`` logs into one combined dispatcher log.
+
+        Microscale output is combined across all array tasks, so the worker
+        logs are likewise concatenated (each ``.out`` already opens with an
+        identifying header) into ``micro_dispatcher{out_file_code}.out`` in
+        *data_dir*, matching the v1.99.0 ``micro_dispatcher_log`` spec.  Both
+        the array-task logs (``lysis-micro-array__{run_code}__N.out``) and the
+        legacy single-child log (``lysis-micro-child__{run_code}.out``) are
+        captured; the master ``.out`` lives elsewhere and is never matched.
+        Does nothing when no worker logs are present.
+
+        :param source_dir: Directory holding the worker ``.out`` files.
+        :type source_dir: Path or str
+        :param data_dir: The Fortran output directory the import reads from.
+        :type data_dir: Path or str
+        """
+        source_dir = Path(source_dir)
+        data_dir = Path(data_dir)
+        run_code = self.run.run_code
+        sources = sorted(
+            source_dir.glob(f"lysis-micro-array__{run_code}__*.out"),
+            key=lambda p: int(p.stem.rsplit("__", 1)[-1]),
+        )
+        child_log = source_dir / f"lysis-micro-child__{run_code}.out"
+        if child_log.exists():
+            sources.append(child_log)
+        if not sources:
+            return  # no worker logs (e.g. direct execution) -> optional, skipped
+        dst = data_dir / f"micro_dispatcher{self.out_file_code}.out"
+        with open(dst, "wb") as out_fh:
+            for src in sources:
+                with open(src, "rb") as in_fh:
+                    shutil.copyfileobj(in_fh, out_fh)
+
     # ------------------------------------------------------------------
     # Execution
     # ------------------------------------------------------------------

--- a/src/lysis/execution/fortran_micro.py
+++ b/src/lysis/execution/fortran_micro.py
@@ -340,17 +340,10 @@ class FortranMicro(FortranRunner):
         """
         source_dir = Path(source_dir)
         data_dir = Path(data_dir)
-        run_code = self.run.run_code
-        # Order array-task logs by integer task id; skip any glob match whose
-        # suffix isn't numeric (mirrors the guarded parse in FortranMacro).
-        array_logs = []
-        for p in source_dir.glob(f"lysis-micro-array__{run_code}__*.out"):
-            try:
-                array_logs.append((int(p.stem.rsplit("__", 1)[-1]), p))
-            except ValueError:
-                continue
-        sources = [p for _, p in sorted(array_logs, key=lambda t: t[0])]
-        child_log = source_dir / f"lysis-micro-child__{run_code}.out"
+        # Array-task logs ordered by task id, then the legacy single-child log.
+        by_task = self._discover_array_logs(source_dir)
+        sources = [by_task[task] for task in sorted(by_task)]
+        child_log = source_dir / f"lysis-micro-child__{self.run.run_code}.out"
         if child_log.exists():
             sources.append(child_log)
         if not sources:

--- a/src/lysis/tools/slurm.py
+++ b/src/lysis/tools/slurm.py
@@ -546,6 +546,7 @@ fm.import_results(
     data_dir,
     keep_on_failure=True,
     keep_tmpdir=KEEP_TMPDIR,
+    dispatcher_log_dir=STAGING_DIR,
 )
 print("Results imported successfully.", flush=True)
 
@@ -722,6 +723,7 @@ fm.import_results(
     data_dir,
     keep_on_failure=True,
     keep_tmpdir=KEEP_TMPDIR,
+    dispatcher_log_dir=STAGING_DIR,
 )
 print("Results imported successfully.", flush=True)
 

--- a/tests/dataio/test_dataspec.py
+++ b/tests/dataio/test_dataspec.py
@@ -285,6 +285,7 @@ class TestDataspecRegistry:
         """v1.99.0 microscale_out has the expected legacy dataset names."""
         expected = {
             "micro_log",
+            "micro_dispatcher_log",
             "firstPLi",
             "lasttPA",
             "lyscomplete",
@@ -301,6 +302,7 @@ class TestDataspecRegistry:
         """v2.0.0 microscale_out has the expected modern dataset names."""
         expected = {
             "micro_log",
+            "micro_dispatcher_log",
             "pli_first_time",
             "tpa_final_num",
             "fiber_degraded",

--- a/tests/dataio/test_datastore.py
+++ b/tests/dataio/test_datastore.py
@@ -1294,6 +1294,29 @@ class TestDataStoreInitializeMacroscale:
         finally:
             ds.close()
 
+    def test_force_reinit_clears_macro_dispatcher_logs(self, tmp_path):
+        """force=True re-init recreates macro dispatcher placeholders without a
+        'name already exists' error, and leaves the microscale dispatcher log."""
+        ds = self._create_micro_store(tmp_path, run_code="force_disp")
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", RuntimeWarning)
+            macro = MacroParameters(micro_params=ds.micro_params, macro_simulations=2)
+        ds.initialize_macroscale(macro)
+        try:
+            assert "log_files/dispatcher/macro_dispatcher_log__sim_00" in ds._file
+            # microscale dispatcher placeholder is created by DataStore.create()
+            assert "log_files/dispatcher/micro_dispatcher_log" in ds._file
+            # Re-initialising with force=True must succeed despite the existing
+            # per-sim macro dispatcher placeholders (regression for #85 rollback).
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", RuntimeWarning)
+                ds.initialize_macroscale(macro, force=True)
+            assert "log_files/dispatcher/macro_dispatcher_log__sim_00" in ds._file
+            # The macro-only wipe must not touch the microscale dispatcher log.
+            assert "log_files/dispatcher/micro_dispatcher_log" in ds._file
+        finally:
+            ds.close()
+
     def test_initialize_sim_groups_exist(self, tmp_path):
         """initialize_macroscale() creates per-simulation groups in HDF5."""
         n_sims = 3

--- a/tests/dataio/test_dispatcher_log.py
+++ b/tests/dataio/test_dispatcher_log.py
@@ -1,0 +1,102 @@
+"""Tests for dispatcher-log capture (issue #55), Stage 1: reader + spec + convert.
+
+Covers:
+
+* ``_read_file_text`` now passes ``comments=None`` so ``#``-containing log lines
+  are preserved (the worker ``.out`` may contain ``#``; numeric data files do not).
+* The ``micro_dispatcher_log`` / ``macro_dispatcher_log`` DataSetSpecs exist at
+  every spec version with the expected storage type and ``optional=True``.
+* Identity converters are registered for the dispatcher logs in both the explicit
+  v1.99.0<->v2.0.0 tables and (via spec inheritance) the v1.95.0<->v1.99.0
+  auto-comprehension tables, so cross-version conversion never KeyErrors.
+"""
+
+import numpy as np
+
+from lysis.config.constants import CONST
+from lysis.dataio.dataspec import DataSetSpec, dataspec
+from lysis.dataio.dataconvert import data_converters
+from lysis.dataio.fileops import _read_file_text
+
+# Pull the null delimiter straight from the loaded spec so the test never has to
+# embed a raw NUL byte in source.
+_DISP_DELIM = (
+    dataspec["v1.99.0"]["microscale_out"].data["micro_dispatcher_log"].delimiter
+)
+
+
+class TestReadFileTextKeepsHashLines:
+    """``comments=None`` keeps ``#`` lines that the old default would drop."""
+
+    def _disp_spec(self):
+        return DataSetSpec(
+            dataset_storage_type=CONST.DATASET_STORAGE_TYPE.FILE_TEXT,
+            dtype=str,
+            data_location="dlog{file_code}.out",
+            delimiter=_DISP_DELIM,
+        )
+
+    def test_hash_lines_preserved(self, tmp_path):
+        (tmp_path / "dlog.out").write_text(
+            "first line\n# a full comment line\nmid # inline part\nlast line\n"
+        )
+        rows = [str(x) for x in _read_file_text(str(tmp_path), self._disp_spec())]
+        # A line that begins with '#' survives (old comments='#' would drop it).
+        assert any(r.lstrip().startswith("#") for r in rows)
+        # Content after an inline '#' is not truncated away.
+        assert any("inline part" in r for r in rows)
+
+    def test_set_x_trace_line_preserved(self, tmp_path):
+        # set -x traces are '+'-prefixed; ensure they round-trip one row per line.
+        (tmp_path / "dlog.out").write_text("+ mkdir -p /tmp/x\n+ echo done\n")
+        rows = [str(x) for x in _read_file_text(str(tmp_path), self._disp_spec())]
+        assert rows == ["+ mkdir -p /tmp/x", "+ echo done"]
+
+
+class TestDispatcherSpecsPresent:
+    """The dispatcher specs exist at every version with the right shape."""
+
+    def test_source_specs(self):
+        for coll, key in [
+            ("microscale_out", "micro_dispatcher_log"),
+            ("macroscale_out", "macro_dispatcher_log"),
+        ]:
+            for ver in ("v1.99.0", "v1.95.0", "v1.90.0"):
+                spec = dataspec[ver][coll].data[key]
+                assert spec.dataset_storage_type == CONST.DATASET_STORAGE_TYPE.FILE_TEXT
+                assert spec.optional is True
+                assert spec.data_location.endswith(".out")
+
+    def test_target_specs(self):
+        micro = dataspec["v2.0.0"]["microscale_out"].data["micro_dispatcher_log"]
+        macro = dataspec["v2.0.0"]["macroscale_out"].data["macro_dispatcher_log"]
+        assert micro.data_location == "log_files/dispatcher/micro_dispatcher_log"
+        assert (
+            macro.data_location
+            == "log_files/dispatcher/macro_dispatcher_log__sim_{sim:02}"
+        )
+        for spec in (micro, macro):
+            assert spec.dataset_storage_type == CONST.DATASET_STORAGE_TYPE.HDF5_DATASET
+            assert spec.optional is True
+
+
+class TestDispatcherConverters:
+    """Identity converters are registered in every relevant direction."""
+
+    def test_explicit_v199_v200_tables(self):
+        for table in [("v1.99.0", "v2.0.0"), ("v2.0.0", "v1.99.0")]:
+            conv = data_converters[table]
+            assert "micro_dispatcher_log" in conv
+            assert "macro_dispatcher_log" in conv
+            payload = {"micro_dispatcher_log": np.array(["a", "b"], dtype=object)}
+            assert (
+                conv["micro_dispatcher_log"](payload) is payload["micro_dispatcher_log"]
+            )
+
+    def test_inherited_v195_v199_tables(self):
+        # v1.95.0/v1.90.0 inherit the specs via deepcopy, so the auto-comprehension
+        # converter tables include the dispatcher keys -> no KeyError mid-chain.
+        for table in [("v1.95.0", "v1.99.0"), ("v1.99.0", "v1.95.0")]:
+            conv = data_converters[table]
+            assert "micro_dispatcher_log" in conv
+            assert "macro_dispatcher_log" in conv

--- a/tests/dataio/test_real_data.py
+++ b/tests/dataio/test_real_data.py
@@ -349,7 +349,11 @@ class TestConvertTruncatedData:
     # ── Microscale datasets ──────────────────────────────────────────
 
     def test_microscale_datasets_present(self, converted):
-        for name in dataspec["v2.0.0"]["microscale_out"].data:
+        for name, spec in dataspec["v2.0.0"]["microscale_out"].data.items():
+            # Optional datasets (e.g. the dispatcher log) are absent when the
+            # source did not produce them.
+            if spec.optional:
+                continue
             assert name in converted, f"Missing: {name}"
 
     def test_pli_first_time(self, converted):
@@ -381,7 +385,9 @@ class TestConvertTruncatedData:
     # ── Macroscale output datasets ───────────────────────────────────
 
     def test_macroscale_out_datasets_present(self, converted):
-        for name in dataspec["v2.0.0"]["macroscale_out"].data:
+        for name, spec in dataspec["v2.0.0"]["macroscale_out"].data.items():
+            if spec.optional:  # e.g. dispatcher log, absent in this source
+                continue
             assert name in converted, f"Missing: {name}"
 
     def test_tpa_location_snapshot(self, converted):
@@ -701,7 +707,9 @@ class TestConvertV190Data:
 
     def test_macroscale_datasets_present_after_v200(self, raw):
         converted = convert_data(raw, "v1.90.0", "v2.0.0")
-        for name in dataspec["v2.0.0"]["macroscale_out"].data:
+        for name, spec in dataspec["v2.0.0"]["macroscale_out"].data.items():
+            if spec.optional:  # e.g. dispatcher log, absent in this source
+                continue
             assert name in converted, f"Missing dataset: {name}"
 
     def test_snapshot_time_shape(self, raw):

--- a/tests/execution/test_dispatcher_staging.py
+++ b/tests/execution/test_dispatcher_staging.py
@@ -56,6 +56,19 @@ class TestMicroStageDispatcherLogs:
         combined = (data / f"micro_dispatcher{micro.out_file_code}.out").read_text()
         assert combined == "A0\nA2\nA10\nCHILD\n"
 
+    def test_non_numeric_array_suffix_is_skipped(self, micro, tmp_path):
+        # A glob match whose suffix isn't a task id must be skipped, not crash.
+        src = tmp_path / "staging"
+        data = tmp_path / "data"
+        src.mkdir()
+        data.mkdir()
+        rc = micro.run.run_code
+        _write(src / f"lysis-micro-array__{rc}__0.out", "A0\n")
+        _write(src / f"lysis-micro-array__{rc}__bad.out", "JUNK\n")
+        micro.stage_dispatcher_logs(src, data)
+        combined = (data / f"micro_dispatcher{micro.out_file_code}.out").read_text()
+        assert combined == "A0\n"
+
     def test_no_worker_logs_stages_nothing(self, micro, tmp_path):
         src = tmp_path / "staging"
         data = tmp_path / "data"

--- a/tests/execution/test_dispatcher_staging.py
+++ b/tests/execution/test_dispatcher_staging.py
@@ -1,0 +1,129 @@
+"""Unit tests for ``stage_dispatcher_logs`` on FortranMicro / FortranMacro (#55).
+
+Synthesises Slurm worker ``.out`` files (no Slurm / Fortran involvement) and
+checks that they are staged into ``data_dir`` under the dispatcher-log spec
+filenames that :meth:`import_results` then ingests.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from lysis.config.run import Run
+from lysis.dataio.dataspec import dataspec
+from lysis.execution.fortran_micro import FortranMicro
+from lysis.execution.fortran_macro import FortranMacro
+
+
+@pytest.fixture
+def micro(tmp_path):
+    r = Run(str(tmp_path))
+    r.initialize_micro_param()
+    return FortranMicro(run=r, executable="/bin/micro.exe", out_file_code="_TST")
+
+
+@pytest.fixture
+def macro(tmp_path):
+    r = Run(str(tmp_path))
+    r.initialize_micro_param()
+    r.initialize_macro_param()
+    return FortranMacro(
+        run=r,
+        executable="/bin/macro.exe",
+        out_file_code="_TST",
+        skip_binary_verification=True,
+    )
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text)
+
+
+class TestMicroStageDispatcherLogs:
+    def test_concatenates_array_and_child_in_task_order(self, micro, tmp_path):
+        src = tmp_path / "staging"
+        data = tmp_path / "data"
+        src.mkdir()
+        data.mkdir()
+        rc = micro.run.run_code
+        # Out-of-order, with a two-digit index to catch lexical-vs-int sorting.
+        _write(src / f"lysis-micro-array__{rc}__0.out", "A0\n")
+        _write(src / f"lysis-micro-array__{rc}__10.out", "A10\n")
+        _write(src / f"lysis-micro-array__{rc}__2.out", "A2\n")
+        _write(src / f"lysis-micro-child__{rc}.out", "CHILD\n")
+        micro.stage_dispatcher_logs(src, data)
+        combined = (data / f"micro_dispatcher{micro.out_file_code}.out").read_text()
+        assert combined == "A0\nA2\nA10\nCHILD\n"
+
+    def test_no_worker_logs_stages_nothing(self, micro, tmp_path):
+        src = tmp_path / "staging"
+        data = tmp_path / "data"
+        src.mkdir()
+        data.mkdir()
+        micro.stage_dispatcher_logs(src, data)
+        assert list(data.iterdir()) == []
+
+    def test_staged_filename_matches_spec(self, micro, tmp_path):
+        # The bridge output must match the v1.99.0 source spec location so
+        # import_results' read_data_collection picks it up.
+        src = tmp_path / "staging"
+        data = tmp_path / "data"
+        src.mkdir()
+        data.mkdir()
+        _write(src / f"lysis-micro-child__{micro.run.run_code}.out", "X\n")
+        micro.stage_dispatcher_logs(src, data)
+        spec = dataspec["v1.99.0"]["microscale_out"].data["micro_dispatcher_log"]
+        expected = spec.data_location.format(file_code=micro.out_file_code)
+        assert (data / expected).exists()
+
+    def test_master_log_is_not_captured(self, micro, tmp_path):
+        src = tmp_path / "staging"
+        data = tmp_path / "data"
+        src.mkdir()
+        data.mkdir()
+        rc = micro.run.run_code
+        _write(src / f"lysis-micro-master__{rc}.out", "MASTER\n")
+        micro.stage_dispatcher_logs(src, data)
+        assert list(data.iterdir()) == []
+
+
+class TestMacroStageDispatcherLogs:
+    def test_dense_per_sim_with_placeholder_for_missing_task(self, macro, tmp_path):
+        src = tmp_path / "staging"
+        data = tmp_path / "data"
+        src.mkdir()
+        data.mkdir()
+        rc = macro.run.run_code
+        for s in (0, 1, 2):
+            (data / f"{s:02}").mkdir()
+        _write(src / f"lysis-macro-array__{rc}__0.out", "S0\n")
+        _write(src / f"lysis-macro-array__{rc}__1.out", "S1\n")
+        # sim 2's task produced no .out file
+        macro.stage_dispatcher_logs(src, data)
+        ofc = macro.out_file_code
+        assert (data / f"macro_dispatcher{ofc}_00.out").read_text() == "S0\n"
+        assert (data / f"macro_dispatcher{ofc}_01.out").read_text() == "S1\n"
+        # placeholder keeps the per-sim count dense (== macro_simulations)
+        assert (data / f"macro_dispatcher{ofc}_02.out").read_text() == "\n"
+
+    def test_no_worker_logs_stages_nothing(self, macro, tmp_path):
+        src = tmp_path / "staging"
+        data = tmp_path / "data"
+        src.mkdir()
+        data.mkdir()
+        (data / "00").mkdir()
+        macro.stage_dispatcher_logs(src, data)
+        assert not list(data.glob("macro_dispatcher*"))
+
+    def test_staged_filename_matches_spec(self, macro, tmp_path):
+        src = tmp_path / "staging"
+        data = tmp_path / "data"
+        src.mkdir()
+        data.mkdir()
+        (data / "00").mkdir()
+        _write(src / f"lysis-macro-array__{macro.run.run_code}__0.out", "X\n")
+        macro.stage_dispatcher_logs(src, data)
+        spec = dataspec["v1.99.0"]["macroscale_out"].data["macro_dispatcher_log"]
+        expected = spec.data_location.format(file_code=macro.out_file_code, sim=0)
+        assert (data / expected).exists()

--- a/tests/tools/test_slurm.py
+++ b/tests/tools/test_slurm.py
@@ -513,6 +513,21 @@ class TestSubmitMicroSlurmJob:
         assert "fm.import_results(" in master_content
 
     @patch("lysis.tools.slurm.gs.sbatch", return_value=1)
+    def test_master_py_passes_dispatcher_log_dir(
+        self, mock_sbatch, micro_hdf5, tmp_path
+    ):
+        """master.py passes dispatcher_log_dir=STAGING_DIR so worker .out logs
+        are ingested into log_files/dispatcher/."""
+        staging_root = tmp_path / "staging_root"
+        staging_root.mkdir()
+        submit_micro_slurm_job(
+            micro_hdf5, "/bin/micro.exe", staging_root=staging_root
+        )
+        staging_dir = list(staging_root.iterdir())[0]
+        master_content = (staging_dir / "lysis-micro-master__run-01.py").read_text()
+        assert "dispatcher_log_dir=STAGING_DIR" in master_content
+
+    @patch("lysis.tools.slurm.gs.sbatch", return_value=1)
     def test_master_py_passes_executable_to_runner(
         self, mock_sbatch, micro_hdf5, tmp_path
     ):
@@ -884,6 +899,21 @@ class TestSubmitMacroSlurmJob:
         staging_dir = list(staging_root.iterdir())[0]
         master_content = (staging_dir / "lysis-macro-master__run-01.py").read_text()
         assert "lysis.execution.fortran_macro" in master_content
+
+    @patch("lysis.tools.slurm.gs.sbatch", return_value=1)
+    def test_master_py_passes_dispatcher_log_dir(
+        self, mock_sbatch, macro_hdf5, tmp_path, mock_write_setup
+    ):
+        """master.py passes dispatcher_log_dir=STAGING_DIR so worker .out logs
+        are ingested into log_files/dispatcher/."""
+        staging_root = tmp_path / "staging_root"
+        staging_root.mkdir()
+        submit_macro_slurm_job(
+            macro_hdf5, "/bin/macro.exe", staging_root=staging_root
+        )
+        staging_dir = list(staging_root.iterdir())[0]
+        master_content = (staging_dir / "lysis-macro-master__run-01.py").read_text()
+        assert "dispatcher_log_dir=STAGING_DIR" in master_content
 
     @patch("lysis.tools.slurm.gs.sbatch", return_value=1)
     def test_master_py_passes_executable_to_runner(


### PR DESCRIPTION
## Summary

Completes the remaining half of #55: capturing each Slurm **worker** job's scheduler-captured stdout (identifying header + `set -x` trace + Fortran stdout) into the run's HDF5, so the file is a self-contained provenance record.

Builds on the merged prerequisites:
- **#83** (optional `DataSetSpec` flag) — used directly.
- **#85** (revert-to-EMPTY / `ImportCollectionError`) — partial dispatcher writes now roll back automatically; on failure the logs are left uningested on disk, which is the preferred outcome.
- **#84** (relocated worker `.out` logs to the staging dir) — that PR deliberately deferred the HDF5 ingestion; this PR adds the bridge that finishes it.

## What's in here

Mirrors the existing `micro_log` / `macro_log` ride-along (spec → identity convert → `_write_array_to_dataset`), with the logs nested under a new `log_files/dispatcher/` group.

- **Schema** — optional `micro_dispatcher_log` (combined) and `macro_dispatcher_log__sim_XX` (per-sim) datasets: v1.99.0 `FILE_TEXT` (NUL-delimited, one line per row) source specs + v2.0.0 `HDF5_DATASET` targets, plus identity converters. Absent for direct (non-Slurm) execution via `optional=True`.
- **Reader fix** — `_read_file_text` now passes `comments=None` so `#`-containing log lines are no longer dropped/truncated by `np.loadtxt`. Verified byte-identical reads of the numeric `.dat` datasets (`f_deg_list`, `m_bind_t` — incl. an 87.4M-row file); no `#` appears in any of them.
- **Ingestion bridge** — `FortranMicro.stage_dispatcher_logs` concatenates the array-task and legacy single-child `.out` logs (in task order) into `micro_dispatcher{code}.out`; `FortranMacro.stage_dispatcher_logs` writes one per-sim `macro_dispatcher{code}_{NN}.out` per simulation subdir, **dense** (placeholder for any task that produced no `.out`) so the per-sim count stays aligned with `macro_simulations`. Wired via a new `import_results(dispatcher_log_dir=…)` kwarg (run inside the existing try/except so staging errors honour `keep_on_failure`); both master templates pass `dispatcher_log_dir=STAGING_DIR`. Direct execution passes nothing → no-op.
- **Force-wipe / rollback** — `initialize_macroscale(force=True)` also clears the nested `log_files/dispatcher/macro_dispatcher_log__sim_*` placeholders. This is required both for re-runs and for #85's macro rollback (otherwise `_create_empty_datasets` raises "name already exists" — a pre-existing rollback test caught this).
- **Docs** — `docs/source/usage/data_specification.rst` documents the new datasets and retention behaviour (worker `.out` removed with staging on success, kept on failure; the Slurm *master* log stays in `.slurm/` and is not ingested).

## Testing

- **Full suite (with Fortran binaries built): 2014 passed, 16 skipped.**
- New tests: reader `#`-preservation; dispatcher specs present at all versions; cross-version convert raises no `KeyError`; macro force-wipe + #85 rollback; runner staging (task-order concat, dense per-sim placeholders, master-log exclusion, spec↔filename consistency); master-template wiring asserts `dispatcher_log_dir=STAGING_DIR`.

## Notes

- The `%2a` zero-padding option for the worker `--output` is **confirmed available** (Slurm 25.05.4 docs), but #84's `--output` is left unchanged — it's cosmetic, since the bridge normalizes padding by parsing the task id.
- End-to-end on a live cluster (worker → staging → HDF5) is the one path unit tests can't exercise; the layered tests plus the spec↔filename consistency checks cover the seams.

Closes #55.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
