### PR TITLE
Resolve the seed sentinel: entropy-string seeds, blank-cell fresh draw, run-micro --direct (#97)

### DIFF
--- a/docs/source/lysis.tools.rst
+++ b/docs/source/lysis.tools.rst
@@ -20,6 +20,14 @@ lysis.tools.kiss module
    :show-inheritance:
    :undoc-members:
 
+lysis.tools.seedcodec module
+----------------------------
+
+.. automodule:: lysis.tools.seedcodec
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
 lysis.tools.slurm module
 ------------------------
 

--- a/docs/source/usage/experiment_init.rst
+++ b/docs/source/usage/experiment_init.rst
@@ -84,6 +84,11 @@ resolver will attempt to derive the missing value algebraically from
 whatever is provided.  If it cannot be derived, the parameter's default
 value is used.
 
+The ``micro_seed`` / ``macro_seed`` columns are a special case: a blank seed
+cell is the "no seed" sentinel and triggers a **fresh random draw** (see
+:ref:`random-seeds` below) rather than falling back to the deterministic
+default.
+
 Special metadata row
 ~~~~~~~~~~~~~~~~~~~~
 
@@ -273,6 +278,44 @@ Error Messages
     **Fix**: check the spelling.  Parameter names are Python attribute
     names (e.g. ``fiber_radius``, ``pore_size``), not Fortran names.
 
+
+.. _random-seeds:
+
+Random seeds and reproducibility
+--------------------------------
+
+Each Run carries an RNG entropy in its ``micro_seed`` / ``macro_seed`` column.
+The value is stored as a **canonical string** holding the
+:class:`numpy.random.SeedSequence` entropy, in one of two interchangeable forms:
+
+- a **bare decimal** (e.g. ``12345``) — a plain integer.  A legacy ``uint32``
+  seed is a bare decimal, so old runs reproduce with **no conversion**; and
+- a **``base58:``-prefixed** value (e.g. ``base58:3xK9q``) — a compact,
+  human-retypeable encoding of full-width OS entropy.
+
+Both decode to a single integer fed to ``SeedSequence``, so the Fortran and
+Python backends derive seeds identically.
+
+How the seed is resolved at ``init-experiment``:
+
+- **Explicit value** in the CSV cell → used verbatim (reproducible).
+- **Blank cell** → fresh OS entropy is drawn, recorded into the Run, and logged
+  at ``INFO``.  This is the recommended default: the run is reproducible *from
+  that point on* (the chosen value is persisted), rather than silently
+  deterministic across every machine.
+- ``--random-entropy`` → draw fresh entropy for **every** Run, ignoring any
+  value in the CSV.  ``init-macroscale --random-entropy`` does the same for
+  ``macro_seed`` on an already-initialised experiment.
+
+To **reproduce** a recorded run, copy its ``micro_seed`` / ``macro_seed`` string
+from the HDF5 params back into the CSV cell.
+
+.. note::
+
+   ``run-micro --direct`` reproduces *legacy* runs whose ``uint32`` seed was fed
+   straight to the Fortran KISS RNG with no ``SeedSequence`` split.  It stamps a
+   ``seed_scheme = "direct"`` provenance attribute (absence ⇒ the default
+   ``"split"``).  Do not use it for new runs.
 
 Template CSV
 ------------

--- a/docs/source/usage/fortran_macroscale.rst
+++ b/docs/source/usage/fortran_macroscale.rst
@@ -288,16 +288,25 @@ Experimental Parameters
 
 :seed:
 
-   :Description: Seed for the random number generator. Stored Python-side as
-      :class:`numpy.uint32`; cast internally to a signed ``INTEGER*4`` for the
-      Fortran CLI and reinterpreted as ``uint_least32_t`` by the C KISS RNG,
-      so a ``np.uint32`` value round-trips bit-exactly.
+   :Description: RNG entropy for the macroscale simulation.  Stored Python-side
+      as a **canonical string** holding the :class:`numpy.random.SeedSequence`
+      entropy — a bare decimal (legacy ``uint32``, "just works") or a
+      ``base58:``-prefixed full-width value (see :mod:`lysis.tools.seedcodec`).
+      A per-simulation ``uint32`` is drawn via
+      ``SeedSequence(entropy).generate_state(macro_simulations)``; each is cast
+      to a signed ``INTEGER*4`` for the Fortran CLI and reinterpreted as
+      ``uint_least32_t`` by the C KISS RNG, so it round-trips bit-exactly.  Both
+      the Fortran and Python macro backends derive seeds from this one field, so
+      they are bit-identical.
 
-   :Default Value: 0 (randomly drawn)
+   :Default Value: ``"0"`` (the deterministic legacy seed).  A **blank** seed
+      cell draws fresh OS entropy at init; ``init-macroscale --random-entropy``
+      forces a fresh draw regardless of the recorded value.
 
    :Units: None
 
-   :Python Name: ``macro_seed`` (Fortran ``INTEGER*4`` bits reinterpreted as ``np.uint32``)
+   :Python Name: ``macro_seed`` (canonical entropy string; per-simulation seed is
+      a Fortran ``INTEGER*4`` whose bits are reinterpreted as ``np.uint32``)
 
 :save_interval:
 

--- a/docs/source/usage/fortran_microscale.rst
+++ b/docs/source/usage/fortran_microscale.rst
@@ -282,13 +282,22 @@ Experimental Parameters
 
 :seed:
 
-   :Description: Seed for the random number generator. Stored Python-side as
-      :class:`numpy.uint32`; cast internally to a signed ``INTEGER*4`` for the
-      Fortran CLI and reinterpreted as ``uint_least32_t`` by the C KISS RNG,
-      so a ``np.uint32`` value round-trips bit-exactly.
+   :Description: RNG entropy for the simulation.  Stored Python-side as a
+      **canonical string** holding the :class:`numpy.random.SeedSequence`
+      entropy — a bare decimal (a legacy ``uint32``, which "just works") or a
+      ``base58:``-prefixed full-width value (see :mod:`lysis.tools.seedcodec`).
+      At execution the entropy is split into a per-task 32-bit seed via
+      ``SeedSequence(entropy).generate_state(...)``; that ``uint32`` is cast to a
+      signed ``INTEGER*4`` for the Fortran CLI and reinterpreted as
+      ``uint_least32_t`` by the C KISS RNG, so it round-trips bit-exactly.
+      **Width contract:** 32-bit legacy seed *or* wider OS entropy in →
+      32-bit per-task seed out.
 
-   :Default Value: 0 (randomly drawn)
+   :Default Value: ``"0"`` (the deterministic legacy seed).  A **blank** seed
+      cell in the input CSV is the "no seed" sentinel: ``init-experiment`` then
+      draws fresh OS entropy and records it (see ``experiment_init``).
 
    :Units: None
 
-   :Python Name: ``micro_seed`` (Fortran ``INTEGER*4`` bits reinterpreted as ``np.uint32``)
+   :Python Name: ``micro_seed`` (canonical entropy string; per-task seed is a
+      Fortran ``INTEGER*4`` whose bits are reinterpreted as ``np.uint32``)

--- a/docs/source/usage/run_microscale.rst
+++ b/docs/source/usage/run_microscale.rst
@@ -117,6 +117,22 @@ Options
     multiple runs write to the same directory and their output files would
     otherwise collide.
 
+.. option:: --num-children N
+
+    Number of Slurm array tasks to split the microscale simulations across
+    (must be **>= 2**).  The run's ``micro_simulations`` are partitioned across
+    the tasks, and each task draws its own per-task seed from the run's recorded
+    entropy.  Defaults to 10.  Only meaningful with ``--slurm``.
+
+.. option:: --direct
+
+    Legacy reproduction only.  Feed the seed straight to the Fortran KISS RNG
+    with **no** :class:`numpy.random.SeedSequence` split, and stamp a
+    ``seed_scheme = "direct"`` provenance attribute on the HDF5 file.  Use this
+    only to reproduce historical runs whose ``uint32`` seed was passed directly
+    to the binary; new runs should use the default ``split`` scheme.  See
+    :ref:`random-seeds`.
+
 Examples
 ~~~~~~~~
 

--- a/src/lysis/cli/init_experiment.py
+++ b/src/lysis/cli/init_experiment.py
@@ -51,10 +51,21 @@ from lysis.cli._provenance import allow_dirty_option, enforce_lysis_clean
         "WARNING: all existing data in the folder will be lost."
     ),
 )
+@click.option(
+    "--random-entropy",
+    is_flag=True,
+    default=False,
+    help=(
+        "Draw a fresh random micro_seed/macro_seed for every Run, ignoring any "
+        "value in the CSV. By default a fresh value is drawn only for blank seed "
+        "cells; an explicit seed is always respected."
+    ),
+)
 @allow_dirty_option
 @click.pass_context
 def init_experiment(
-    ctx, csv_path, data_root, name, description, dry_run, no_progress, force, allow_dirty,
+    ctx, csv_path, data_root, name, description, dry_run, no_progress, force,
+    random_entropy, allow_dirty,
 ):
     """Initialise an Experiment from a parameter CSV file.
 
@@ -96,11 +107,13 @@ def init_experiment(
             if not no_progress:
                 with console.status("Validating parameters..."):
                     exp = Experiment.from_csv(
-                        csv_path, data_root, name=name, description=description, dry_run=True
+                        csv_path, data_root, name=name, description=description,
+                        dry_run=True, random_entropy=random_entropy,
                     )
             else:
                 exp = Experiment.from_csv(
-                    csv_path, data_root, name=name, description=description, dry_run=True
+                    csv_path, data_root, name=name, description=description,
+                    dry_run=True, random_entropy=random_entropy,
                 )
         except (ParameterConflict, UnderdeterminedParameters, ValueError) as exc:
             _print_error(console, csv_path, exc)
@@ -130,7 +143,8 @@ def init_experiment(
 
     try:
         exp = Experiment.from_csv(
-            csv_path, data_root, name=name, description=description, dry_run=False
+            csv_path, data_root, name=name, description=description,
+            dry_run=False, random_entropy=random_entropy,
         )
     except FileExistsError as exc:
         stem = os.path.splitext(os.path.basename(csv_path))[0]

--- a/src/lysis/cli/init_macroscale.py
+++ b/src/lysis/cli/init_macroscale.py
@@ -12,6 +12,7 @@ In both cases the microscale datasets must already contain completed simulation
 results so that ``forced_unbind`` can be computed automatically.
 """
 
+import dataclasses
 import os
 import sys
 
@@ -19,6 +20,7 @@ import click
 
 from lysis.cli import cli
 from lysis.cli._provenance import allow_dirty_option, enforce_lysis_clean
+from lysis.tools.seedcodec import encode_seed, random_entropy as _draw_entropy
 
 
 def _coerce_value(val_str: str):
@@ -76,9 +78,21 @@ def _coerce_value(val_str: str):
         "WARNING: any existing macroscale simulation data will be lost."
     ),
 )
+@click.option(
+    "--random-entropy",
+    is_flag=True,
+    default=False,
+    help=(
+        "Draw a fresh random macro_seed for every run, overriding whatever is "
+        "stored in experiment.json (folder mode) or the default/--param value "
+        "(single-file mode)."
+    ),
+)
 @allow_dirty_option
 @click.pass_context
-def init_macroscale(ctx, path, params, dry_run, no_progress, force, allow_dirty):
+def init_macroscale(
+    ctx, path, params, dry_run, no_progress, force, random_entropy, allow_dirty
+):
     """Initialise macroscale structure in one or more HDF5 files.
 
     PATH may be an experiment folder (initialises all runs) or a single HDF5
@@ -122,11 +136,13 @@ def init_macroscale(ctx, path, params, dry_run, no_progress, force, allow_dirty)
     # ── Dispatch: folder or single H5 file ───────────────────────────────
     if path_obj.is_dir():
         _init_experiment_folder(
-            ctx, console, path_obj, param_overrides, dry_run, no_progress, force
+            ctx, console, path_obj, param_overrides, dry_run, no_progress, force,
+            random_entropy,
         )
     elif path_obj.suffix == ".h5":
         _init_single_h5(
-            ctx, console, path_obj, param_overrides, dry_run, no_progress, force
+            ctx, console, path_obj, param_overrides, dry_run, no_progress, force,
+            random_entropy,
         )
     else:
         console.print(
@@ -139,7 +155,10 @@ def init_macroscale(ctx, path, params, dry_run, no_progress, force, allow_dirty)
 # ─── Folder mode ──────────────────────────────────────────────────────────────
 
 
-def _init_experiment_folder(ctx, console, folder_path, param_overrides, dry_run, no_progress, force):
+def _init_experiment_folder(
+    ctx, console, folder_path, param_overrides, dry_run, no_progress, force,
+    random_entropy=False,
+):
     """Initialise macroscale for every run in an experiment folder."""
     from lysis.config.experiment import Experiment
     from lysis.dataio.datastore import DataStore
@@ -174,9 +193,18 @@ def _init_experiment_folder(ctx, console, folder_path, param_overrides, dry_run,
                     _check_microscale_ready(ds, run.run_code)
                 results.append((run.run_code, "dry-run OK"))
             else:
+                macro_params = run.macro_params
+                if random_entropy:
+                    macro_params = dataclasses.replace(
+                        macro_params, macro_seed=encode_seed(_draw_entropy())
+                    )
+                    console.print(
+                        f"[cyan]{run.run_code}:[/cyan] fresh macro_seed "
+                        f"{macro_params.macro_seed}"
+                    )
                 with DataStore(run.run_code, exp.path, mode="a") as ds:
                     # initialize_macroscale() stamps macro init provenance.
-                    ds.initialize_macroscale(run.macro_params, force=force)
+                    ds.initialize_macroscale(macro_params, force=force)
                 results.append((run.run_code, "initialized"))
         except Exception as exc:
             errors.append((run.run_code, str(exc)))
@@ -190,7 +218,10 @@ def _init_experiment_folder(ctx, console, folder_path, param_overrides, dry_run,
 # ─── Single H5 mode ───────────────────────────────────────────────────────────
 
 
-def _init_single_h5(ctx, console, h5_path, param_overrides, dry_run, no_progress, force):
+def _init_single_h5(
+    ctx, console, h5_path, param_overrides, dry_run, no_progress, force,
+    random_entropy=False,
+):
     """Initialise macroscale for a single HDF5 file."""
     from lysis.config.paramcheck import load_macro_params
     from lysis.dataio.datastore import DataStore
@@ -223,6 +254,14 @@ def _init_single_h5(ctx, console, h5_path, param_overrides, dry_run, no_progress
         console.print(f"[bold red]Error in --param overrides:[/bold red] {exc}")
         ctx.exit(1)
         return
+
+    if random_entropy:
+        macro_params = dataclasses.replace(
+            macro_params, macro_seed=encode_seed(_draw_entropy())
+        )
+        console.print(
+            f"[cyan]{run_code}:[/cyan] fresh macro_seed {macro_params.macro_seed}"
+        )
 
     if dry_run:
         console.print(

--- a/src/lysis/cli/parameters.py
+++ b/src/lysis/cli/parameters.py
@@ -34,7 +34,7 @@ _DEFAULT_PARAMS = [
     ("total_time",            "macro",    "minutes",    "{:.0f}"),
     ("time_step",             "macro",    None,         "{:1.3e}"),
     ("total_time_steps",      "macro",    None,         "{:,}"),
-    ("macro_seed",            "macro",    None,         "{:,}"),
+    ("macro_seed",            "macro",    None,         None),
     ("save_interval",         "macro",    None,         "{:.0f}"),
     ("number_of_saves",       "macro",    None,         "{:,}"),
     # ---- Micro physical -----------------------------------------------
@@ -55,7 +55,7 @@ _DEFAULT_PARAMS = [
     ("snap_proportion",       "micro",   None,          "{:.4f}"),
     # ---- Micro run controls -------------------------------------------
     ("micro_simulations",     "micro",   None,          "{:,}"),
-    ("micro_seed",            "micro",   None,          "{:,}"),
+    ("micro_seed",            "micro",   None,          None),
 ]
 
 # Computed (virtual) parameters not directly stored on any params object

--- a/src/lysis/cli/run_micro.py
+++ b/src/lysis/cli/run_micro.py
@@ -104,14 +104,25 @@ from lysis.tools.slurm import DEFAULT_MODULES, parse_sbatch_tokens
 @click.option(
     "--num-children",
     "num_children",
-    type=click.IntRange(min=0),
+    type=click.IntRange(min=2),
     default=10,
     show_default=True,
     metavar="N",
     help=(
-        "Number of Slurm array tasks to split microscale simulations across.  "
-        "Set to 0 to use the legacy single-child path.  "
-        "Only meaningful with --slurm."
+        "Number of Slurm array tasks to split microscale simulations across "
+        "(must be >= 2).  Only meaningful with --slurm."
+    ),
+)
+@click.option(
+    "--direct",
+    "direct",
+    is_flag=True,
+    default=False,
+    help=(
+        "Legacy reproduction: feed the seed straight to the Fortran KISS RNG "
+        "with no SeedSequence interposition, and stamp seed_scheme='direct' "
+        "into the HDF5 provenance.  Use only to reproduce historical runs that "
+        "passed a raw uint32 seed directly to the binary."
     ),
 )
 @click.option(
@@ -179,7 +190,7 @@ from lysis.tools.slurm import DEFAULT_MODULES, parse_sbatch_tokens
 @allow_commit_mismatch_option
 @click.pass_context
 def run_micro(ctx, target_path, executable, use_slurm, partition, staging_root,
-              fast_tmp_root, keep_tmpdir, file_code, num_children, modules,
+              fast_tmp_root, keep_tmpdir, file_code, num_children, direct, modules,
               fortran_commit, sbatch_tokens, allow_stale_binary, allow_dirty,
               allow_commit_mismatch):
     """Execute the Fortran microscale simulation for a Run or Experiment.
@@ -266,7 +277,7 @@ def run_micro(ctx, target_path, executable, use_slurm, partition, staging_root,
         if use_slurm:
             from lysis.tools.slurm import submit_micro_slurm_job
 
-            nc_arg = None if num_children == 0 else num_children
+            nc_arg = num_children
 
             try:
                 sbatch_overrides = parse_sbatch_tokens(sbatch_tokens)
@@ -285,6 +296,7 @@ def run_micro(ctx, target_path, executable, use_slurm, partition, staging_root,
                         keep_tmpdir=keep_tmpdir,
                         out_code=file_code,
                         num_children=nc_arg,
+                        direct=direct,
                         modules=modules,
                         sbatch_overrides=sbatch_overrides,
                         historical_backend_attrs=historical_provenance,
@@ -313,6 +325,7 @@ def run_micro(ctx, target_path, executable, use_slurm, partition, staging_root,
                         hdf5_path,
                         executable,
                         out_file_code=file_code,
+                        direct=direct,
                         allow_stale_binary=allow_stale_binary,
                         skip_binary_verification=(
                             historical_provenance is not None

--- a/src/lysis/config/constants.py
+++ b/src/lysis/config/constants.py
@@ -122,6 +122,12 @@ class Const:
         # build that matches the current source tree.  The commit SHA itself
         # lives in ``backend_commit``.
         self.BACKEND_HISTORICAL_ATTR = "backend_historical"
+        # Records the RNG seeding scheme when it departs from the default
+        # SeedSequence "split".  Stamped (``"direct"``) by ``run-micro
+        # --direct`` for legacy reproduction, where the seed is fed straight
+        # to the Fortran KISS RNG with no SeedSequence interposition.  Absent
+        # ⇒ "split".  This is a provenance stamp, not a dataspec dataset.
+        self.SEED_SCHEME_ATTR = "seed_scheme"
         self.LYSIS_ALLOW_STALE_BINARY_ENV = "LYSIS_ALLOW_STALE_BINARY"
         self.LYSIS_ALLOW_DIRTY_ENV = "LYSIS_ALLOW_DIRTY"
         self.LYSIS_ALLOW_COMMIT_MISMATCH_ENV = "LYSIS_ALLOW_COMMIT_MISMATCH"

--- a/src/lysis/config/experiment.py
+++ b/src/lysis/config/experiment.py
@@ -48,6 +48,7 @@ timestamp-based code is used.  Any row absent from the CSV is treated as
 import csv
 import inspect
 import json
+import logging
 import math
 import os
 from datetime import datetime
@@ -57,6 +58,7 @@ from typing import Any
 
 from ..dataio.datastore import DataStore
 from ..dataio.fileops import _params_json_default
+from ..tools.seedcodec import encode_seed, random_entropy as _draw_entropy
 from .param_resolver import (
     ParameterConflict,
     UnderdeterminedParameters,
@@ -69,6 +71,8 @@ from .run import Run
 
 
 __all__ = ["Experiment"]
+
+logger = logging.getLogger(__name__)
 
 # ─── Column classification helpers ───────────────────────────────────────────
 
@@ -295,6 +299,7 @@ class Experiment:
         name: str | None = None,
         description: str = "",
         dry_run: bool = False,
+        random_entropy: bool = False,
     ) -> "Experiment":
         """Parse a parameter CSV and initialise an Experiment.
 
@@ -339,6 +344,11 @@ class Experiment:
         :param dry_run: If ``True``, validate and resolve parameters but do
             **not** create any files or folders.
         :type dry_run: bool
+        :param random_entropy: If ``True``, draw a fresh ``micro_seed`` /
+            ``macro_seed`` entropy for every Run, ignoring any value in the CSV.
+            When ``False`` (default), a fresh value is drawn only for cells left
+            **blank**; an explicit seed in the CSV is respected.
+        :type random_entropy: bool
         :returns: :class:`Experiment` instance with all Runs populated.
         :rtype: Experiment
         :raises FileExistsError: If the experiment folder already exists (only
@@ -411,6 +421,25 @@ class Experiment:
             }
             run_code = raw_run_codes[col_idx] or _make_run_code(base_ts, col_idx)
             run_desc = row.get("run_description", "").strip()
+
+            # Resolve the "no seed" sentinel: a blank CSV cell (the seed key is
+            # absent from *_provided) — or --random-entropy — means "draw fresh
+            # OS entropy and record it", so the run is reproducible from here on
+            # rather than silently deterministic.  An explicit seed is respected.
+            if random_entropy or "micro_seed" not in micro_provided:
+                micro_provided["micro_seed"] = encode_seed(_draw_entropy())
+                logger.info(
+                    "Run %s: drew fresh micro_seed entropy %s",
+                    run_code,
+                    micro_provided["micro_seed"],
+                )
+            if random_entropy or "macro_seed" not in macro_provided:
+                macro_provided["macro_seed"] = encode_seed(_draw_entropy())
+                logger.info(
+                    "Run %s: drew fresh macro_seed entropy %s",
+                    run_code,
+                    macro_provided["macro_seed"],
+                )
 
             try:
                 resolved_micro = resolve_micro_params(micro_provided)

--- a/src/lysis/config/parameters.py
+++ b/src/lysis/config/parameters.py
@@ -87,6 +87,7 @@ from pint import Quantity
 
 from .constants import ureg, Q_
 from ..tools.util import dict_to_formatted_str
+from ..tools.seedcodec import parse_seed, encode_seed
 
 
 ################################
@@ -669,8 +670,13 @@ class MicroParameters(Parameters):
     :Units: None
     :Fortran: simulations"""
 
-    micro_seed: np.uint32 = np.uint32(0)
-    """Seed for the random number generator
+    micro_seed: str = "0"
+    """Seed (entropy) for the random number generator.
+
+    Stored as a canonical string holding the :class:`numpy.random.SeedSequence`
+    entropy: a bare decimal (legacy ``uint32``, just-works) or a ``base58:``-prefixed
+    full-width value. See :mod:`lysis.tools.seedcodec`. A blank CSV cell at init draws
+    fresh entropy; the dataclass default ``"0"`` is the deterministic legacy seed.
 
     :Units: None
     :Fortran: seed|uint32"""
@@ -714,12 +720,12 @@ class MicroParameters(Parameters):
             during object construction.
         """
 
-        # Normalise seed to np.uint32 by bit pattern (handles Python int /
-        # np.int32 / float from JSON / signed-negative legacy values).
+        # Canonicalise the seed to its entropy string form (accepts int /
+        # np.uint32 / decimal str / base58: str / signed-negative legacy values).
         object.__setattr__(
             self,
             "micro_seed",
-            np.uint32(int(self.micro_seed) & 0xFFFFFFFF),
+            encode_seed(parse_seed(self.micro_seed)),
         )
 
         # One protofibril is two fibrinogens
@@ -795,6 +801,17 @@ class MicroParameters(Parameters):
             / self.nodes_in_micro_row**2
             * self.fibrin_conc_per_fiber,
         )
+
+    def seed_as_int(self) -> int:
+        """Return the RNG entropy as a non-negative integer.
+
+        Decodes the canonical :attr:`micro_seed` string (bare decimal or
+        ``base58:`` form) for feeding to :class:`numpy.random.SeedSequence`.
+
+        :return: The integer entropy.
+        :rtype: int
+        """
+        return parse_seed(self.micro_seed)
 
 
 @dataclass(frozen=True)
@@ -1039,8 +1056,13 @@ class MacroParameters(Parameters):
     :Units: None
     :Fortran: num_t"""
 
-    macro_seed: np.uint32 = np.uint32(0)
-    """Seed for the random number generator
+    macro_seed: str = "0"
+    """Seed (entropy) for the random number generator.
+
+    Stored as a canonical string holding the :class:`numpy.random.SeedSequence`
+    entropy: a bare decimal (legacy ``uint32``, just-works) or a ``base58:``-prefixed
+    full-width value. See :mod:`lysis.tools.seedcodec`. A blank CSV cell at init draws
+    fresh entropy; the dataclass default ``"0"`` is the deterministic legacy seed.
 
     :Units: None
     :Fortran: seed|uint32"""
@@ -1144,12 +1166,12 @@ class MacroParameters(Parameters):
             This method should never be called manually. It runs automatically
             during object construction.
         """
-        # Normalise seed to np.uint32 by bit pattern (handles Python int /
-        # np.int32 / float from JSON / signed-negative legacy values).
+        # Canonicalise the seed to its entropy string form (accepts int /
+        # np.uint32 / decimal str / base58: str / signed-negative legacy values).
         object.__setattr__(
             self,
             "macro_seed",
-            np.uint32(int(self.macro_seed) & 0xFFFFFFFF),
+            encode_seed(parse_seed(self.macro_seed)),
         )
 
         object.__setattr__(
@@ -1206,7 +1228,9 @@ class MacroParameters(Parameters):
             self, "total_time_steps", int(self.total_time / self.time_step)
         )
 
-        # Set the state
+        # Set the state.  The KISS RNG's fourth state word is the seed as a
+        # uint32; fold the (possibly wide) entropy to its low 32 bits.  For a
+        # per-simulation seed (a uint32 drawn from SeedSequence) this is identity.
         object.__setattr__(
             self,
             "state",
@@ -1214,7 +1238,7 @@ class MacroParameters(Parameters):
                 np.uint32(129281),
                 np.uint32(362436069),
                 np.uint32(123456789),
-                self.macro_seed,
+                np.uint32(parse_seed(self.macro_seed) & 0xFFFFFFFF),
             ),
         )
 
@@ -1223,6 +1247,17 @@ class MacroParameters(Parameters):
         object.__setattr__(
             self, "number_of_saves", int(self.total_time / self.save_interval) + 1
         )
+
+    def seed_as_int(self) -> int:
+        """Return the RNG entropy as a non-negative integer.
+
+        Decodes the canonical :attr:`macro_seed` string (bare decimal or
+        ``base58:`` form) for feeding to :class:`numpy.random.SeedSequence`.
+
+        :return: The integer entropy.
+        :rtype: int
+        """
+        return parse_seed(self.macro_seed)
 
     @classmethod
     def calculate_forced_unbind(

--- a/src/lysis/execution/fortran.py
+++ b/src/lysis/execution/fortran.py
@@ -17,6 +17,7 @@ parameter-class-specific hooks.
 """
 
 import inspect
+import logging
 import os
 import shutil
 import subprocess
@@ -32,9 +33,13 @@ import numpy as np
 
 from pint import Quantity
 
+from ..config.constants import CONST
 from ..config.run import Run
 from ..dataio.datastore import DataStore
+from ..tools.seedcodec import parse_seed
 from .base import SimulationRunner
+
+logger = logging.getLogger(__name__)
 
 
 #: Dataspec version produced by the Fortran microscale binary.
@@ -92,6 +97,12 @@ class FortranRunner(SimulationRunner):
     out_file_code: AnyStr = ""
     index: int = None
     num_children: int = None
+    #: When True, the seed is fed straight to the Fortran KISS RNG with no
+    #: :class:`numpy.random.SeedSequence` interposition — the legacy
+    #: ``seed_scheme="direct"`` path, used by ``run-micro --direct`` to
+    #: reproduce historical runs.  Also stamps the ``seed_scheme`` provenance
+    #: attr at import time.  Defaults to False (the SeedSequence "split" path).
+    direct: bool = False
     #: When True, a mismatch between the Fortran binary's embedded build
     #: stamp and the current ``src/fortran/`` source state downgrades from
     #: a :class:`~lysis.tools.provenance.StaleBinaryError` to a loud
@@ -316,7 +327,12 @@ class FortranRunner(SimulationRunner):
         they are no longer routed through this property.
         """
         info = getattr(self, "_binary_check_info", None) or {}
-        return {k: v for k, v in info.items() if k != "banner"}
+        attrs = {k: v for k, v in info.items() if k != "banner"}
+        # Record the non-default seeding scheme as provenance.  Absence of the
+        # attr implies the default "split"; we only stamp the direct case.
+        if self.direct:
+            attrs[CONST.SEED_SCHEME_ATTR] = "direct"
+        return attrs
 
     def _write_stale_banner(self, fh) -> None:
         """Write the stale-binary banner to *fh* if the preflight was overridden.
@@ -394,12 +410,24 @@ class FortranRunner(SimulationRunner):
         Converts the relevant parameter object to a list of command-line
         arguments compatible with the Fortran program.  Handles:
 
-        - RNG seed splitting when :attr:`index` is set.
+        - RNG seed resolution: the stored entropy (a canonical string, see
+          :mod:`lysis.tools.seedcodec`) is decoded and **always** turned into
+          an explicit ``uint32`` ``--seed`` for the Fortran binary, so the
+          binary's compiled-in default is never silently relied upon.
         - Unit conversions for :class:`pint.Quantity` objects.
         - Index adjustments for parameters with a ``"-1"`` Fortran-name suffix
           (Python 0-based → Fortran 1-based).
         - Scaling for parameters with a ``"*100"`` Fortran-name suffix.
         - Only non-default parameters are included.
+
+        **Seed width contract.**  The persisted seed field holds the full
+        :class:`numpy.random.SeedSequence` entropy (32-bit legacy value or
+        wider OS entropy).  In the default ``split`` scheme a per-task
+        ``uint32`` is drawn via ``SeedSequence(entropy).generate_state(...)``;
+        in the :attr:`direct` scheme the entropy is folded to its low 32 bits
+        and passed straight through (no SeedSequence).  Either way the value
+        handed to Fortran is a 32-bit seed, reinterpreted to a signed
+        ``INTEGER*4`` by the ``|uint32`` branch of :meth:`_params_to_arguments`.
 
         .. note::
             When :attr:`index` is not ``None`` this method mutates
@@ -411,12 +439,13 @@ class FortranRunner(SimulationRunner):
         :rtype: list[str]
         """
         params = asdict(self._get_params())
+        seed_field = self._seed_field()
+        entropy = parse_seed(params[seed_field])
 
-        # Seed splitting for parallel (multi-node) runs
+        # Partition the simulation count across array tasks (index set).  Done
+        # before drawing the seed so _seed_split_count reads the original count.
         if self.index is not None:
-            stream = np.random.SeedSequence(params[self._seed_field()])
             split_count = self._seed_split_count(params)  # read before mutation
-            seeds = stream.generate_state(split_count)
             sim_field = self._simulations_field()
             if self.num_children is None:
                 # Legacy: one simulation per task.
@@ -428,8 +457,20 @@ class FortranRunner(SimulationRunner):
                 total = int(params[sim_field])
                 k = self.num_children
                 params[sim_field] = total // k + (1 if self.index < total % k else 0)
-            params[self._seed_field()] = seeds[self.index]
             self.out_file_code = self.out_file_code + f"__{self.index:02}"
+        else:
+            split_count = 1
+
+        # Resolve the entropy to an explicit per-task uint32 seed.
+        if self.direct:
+            # Legacy reproduction: the raw entropy goes straight to KISS, with
+            # no SeedSequence.  Every task in a partition shares this seed.
+            seed = np.uint32(entropy & 0xFFFFFFFF)
+            logger.info("seed_scheme=direct: raw seed %d -> Fortran", int(seed))
+        else:
+            seeds = np.random.SeedSequence(entropy).generate_state(split_count)
+            seed = seeds[self.index if self.index is not None else 0]
+        params[seed_field] = seed
 
         arguments = self._base_arguments()
         arguments += self._params_to_arguments(params)

--- a/src/lysis/execution/fortran_macro.py
+++ b/src/lysis/execution/fortran_macro.py
@@ -489,9 +489,11 @@ class FortranMacro(FortranRunner):
         if self.index is None:
             self._write_setup_files(data_dir)
 
-        # Determine simulation range
+        # Determine simulation range.  The persisted macro_seed is a canonical
+        # entropy string; decode it before seeding so the Fortran and Python
+        # macro backends draw the identical per-simulation seed stream.
         n_sims = self.run.macro_params.macro_simulations
-        macro_seed = self.run.macro_params.macro_seed
+        macro_seed = self.run.macro_params.seed_as_int()
         seeds = np.random.SeedSequence(macro_seed).generate_state(n_sims)
 
         sims = [self.index] if self.index is not None else list(range(n_sims))

--- a/src/lysis/execution/fortran_micro.py
+++ b/src/lysis/execution/fortran_micro.py
@@ -126,6 +126,7 @@ class FortranMicro(FortranRunner):
         out_file_code: str = "",
         index: "int | None" = None,
         num_children: "int | None" = None,
+        direct: bool = False,
         allow_stale_binary: bool = False,
         skip_binary_verification: bool = False,
         historical_backend_attrs: "dict | None" = None,
@@ -153,6 +154,10 @@ class FortranMicro(FortranRunner):
             the children (see :class:`~lysis.execution.fortran.FortranRunner`
             for details).  Defaults to ``None`` (legacy single-sim-per-task).
         :type num_children: int, optional
+        :param direct: Use the legacy ``seed_scheme="direct"`` path — feed the
+            seed straight to the Fortran KISS RNG with no SeedSequence, and
+            stamp ``seed_scheme="direct"`` provenance.  Defaults to ``False``.
+        :type direct: bool, optional
         :param allow_stale_binary: Downgrade a stamp mismatch between the
             Fortran binary and ``src/fortran/`` from
             :class:`~lysis.tools.provenance.StaleBinaryError` to a
@@ -211,6 +216,7 @@ class FortranMicro(FortranRunner):
             out_file_code=out_file_code,
             index=index,
             num_children=num_children,
+            direct=direct,
             allow_stale_binary=allow_stale_binary,
             skip_binary_verification=skip_binary_verification,
             historical_backend_attrs=historical_backend_attrs,

--- a/src/lysis/macroscale.py
+++ b/src/lysis/macroscale.py
@@ -248,11 +248,15 @@ class MacroscaleSim:
         # entropy string; decode it to an integer for the RNG.
         macro_seed = run.macro_params.seed_as_int()
         if run.macro_params.duplicate_fortran:
-            # If we are copying the Fortran code step-by-step,
-            # we want to use the same RNG which is the KISS C code
-            self.rng = KissRandomGenerator(macro_seed)
+            # If we are copying the Fortran code step-by-step, we want to use the
+            # same RNG, which is the KISS C code.  KISS seeds a uint32 state word
+            # via ``ctypes.c_uint`` (which raises OverflowError beyond 2**32-1),
+            # so fold a wide OS entropy to its low 32 bits — matching ``state[3]``
+            # in :meth:`MacroParameters.__post_init__`.
+            self.rng = KissRandomGenerator(macro_seed & 0xFFFFFFFF)
         else:
-            # Use NumPy's default RNG (Mersenne Twister) for native mode
+            # Use NumPy's default RNG (Mersenne Twister) for native mode; it
+            # accepts the full-width entropy directly.
             self.rng = np.random.default_rng(seed=macro_seed)
 
         # Initialize the Binding Time Factory which will generate random binding times for the simulation

--- a/src/lysis/macroscale.py
+++ b/src/lysis/macroscale.py
@@ -244,14 +244,16 @@ class MacroscaleSim:
         self.logger = logging.getLogger(__name__)
         self.logger.debug(f"Initializing MacroscaleSim")
 
-        # Initialize pseudorandom number generator
+        # Initialize pseudorandom number generator.  macro_seed is a canonical
+        # entropy string; decode it to an integer for the RNG.
+        macro_seed = run.macro_params.seed_as_int()
         if run.macro_params.duplicate_fortran:
             # If we are copying the Fortran code step-by-step,
             # we want to use the same RNG which is the KISS C code
-            self.rng = KissRandomGenerator(run.macro_params.macro_seed)
+            self.rng = KissRandomGenerator(macro_seed)
         else:
             # Use NumPy's default RNG (Mersenne Twister) for native mode
-            self.rng = np.random.default_rng(seed=abs(run.macro_params.macro_seed))
+            self.rng = np.random.default_rng(seed=macro_seed)
 
         # Initialize the Binding Time Factory which will generate random binding times for the simulation
         # We use the factory to generate these times in batches, giving us faster amortized run times

--- a/src/lysis/tools/seedcodec.py
+++ b/src/lysis/tools/seedcodec.py
@@ -1,0 +1,152 @@
+"""Encode and decode RNG seed entropy for the ``micro_seed`` / ``macro_seed`` fields.
+
+The seed fields persist the *entropy* handed to :class:`numpy.random.SeedSequence`.
+A single field carries two interchangeable textual forms, disambiguated on read so
+the stored representation never needs a dataspec version bump:
+
+- **Bare decimal** (e.g. ``"12345"``) — a plain integer entropy.  A legacy
+  ``np.uint32`` seed is a bare decimal, so old files and hand-written CSV cells
+  reproduce with no conversion.
+- **``base58:``-prefixed** (e.g. ``"base58:3xK9q"``) — a full-width entropy drawn
+  from the OS, encoded compactly so a human can copy or retype it.
+
+Both forms decode to one non-negative Python ``int`` fed to ``SeedSequence``, so the
+Fortran and Python backends stay bit-identical (they share this single parse).
+
+Encoding policy (:func:`encode_seed`): values that fit in 32 bits stay bare decimal
+(legacy-friendly); wider entropy is emitted as ``base58:``.
+
+Base58 uses the **Bitcoin alphabet** (omitting the visually ambiguous ``0``, ``O``,
+``I``, ``l``) and operates on the integer directly (repeated division by 58), *not*
+on a byte string — so there is no leading-zero-byte convention to worry about; the
+integer ``0`` encodes to the first alphabet character (``"1"``).
+
+Negative integers are interpreted as 32-bit two's-complement and folded to their
+``uint32`` bit pattern (``x & 0xFFFFFFFF``), matching the ``|uint32`` Fortran tag and
+preserving reproduction of legacy signed-seed values.
+"""
+
+__all__ = ["parse_seed", "encode_seed", "random_entropy", "BASE58_PREFIX"]
+
+import numpy as np
+
+#: Sigil marking a Base58-encoded entropy payload.  ``:`` is not a Base58 character,
+#: is CSV- and shell-safe, and reads like a URI scheme.
+BASE58_PREFIX = "base58:"
+
+#: Bitcoin Base58 alphabet (no ``0``, ``O``, ``I``, ``l``).
+_ALPHABET = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
+_ALPHABET_INDEX = {ch: i for i, ch in enumerate(_ALPHABET)}
+
+#: 32-bit mask used to fold signed-negative legacy seeds to their uint32 bit pattern.
+_UINT32_MASK = 0xFFFFFFFF
+
+
+def _normalize_int(value: int) -> int:
+    """Fold a signed integer to its ``uint32`` bit pattern; pass non-negatives through.
+
+    :param value: An integer seed/entropy value.
+    :type value: int
+    :return: ``value & 0xFFFFFFFF`` when ``value`` is negative, else ``value``.
+    :rtype: int
+    """
+    return value & _UINT32_MASK if value < 0 else value
+
+
+def _b58encode_int(value: int) -> str:
+    """Encode a non-negative integer as Base58 (Bitcoin alphabet).
+
+    :param value: A non-negative integer.
+    :type value: int
+    :return: The Base58 representation; ``0`` encodes to ``"1"``.
+    :rtype: str
+    :raises ValueError: If ``value`` is negative.
+    """
+    if value < 0:
+        raise ValueError(f"cannot Base58-encode a negative integer: {value}")
+    if value == 0:
+        return _ALPHABET[0]
+    digits = []
+    while value:
+        value, rem = divmod(value, 58)
+        digits.append(_ALPHABET[rem])
+    return "".join(reversed(digits))
+
+
+def _b58decode_int(payload: str) -> int:
+    """Decode a Base58 (Bitcoin alphabet) string to a non-negative integer.
+
+    :param payload: The Base58 characters (without the ``base58:`` prefix).
+    :type payload: str
+    :return: The decoded non-negative integer.
+    :rtype: int
+    :raises ValueError: If ``payload`` is empty or contains a non-Base58 character.
+    """
+    if not payload:
+        raise ValueError("empty Base58 payload")
+    result = 0
+    for ch in payload:
+        try:
+            result = result * 58 + _ALPHABET_INDEX[ch]
+        except KeyError:
+            raise ValueError(
+                f"invalid Base58 character {ch!r} in seed payload {payload!r}"
+            ) from None
+    return result
+
+
+def parse_seed(token) -> int:
+    """Parse a stored/typed seed into the non-negative integer entropy.
+
+    Accepts an integer (legacy numeric HDF5 attr) or a string in one of two forms:
+    a bare decimal, or a ``base58:``-prefixed Base58 payload.  The sigil match is
+    case-insensitive; the payload is case-sensitive.  Negative integers (legacy
+    signed seeds) are folded to their ``uint32`` bit pattern.
+
+    :param token: An ``int``/:class:`numpy.integer`, or a ``str`` seed.
+    :type token: int or numpy.integer or str
+    :return: The non-negative integer entropy to feed to ``SeedSequence``.
+    :rtype: int
+    :raises ValueError: If ``token`` is an empty/blank string or malformed.
+    :raises TypeError: If ``token`` is neither an integer nor a string.
+    """
+    if isinstance(token, (int, np.integer)):
+        return _normalize_int(int(token))
+    if isinstance(token, str):
+        text = token.strip()
+        if not text:
+            raise ValueError("blank seed string has no entropy to parse")
+        if text[: len(BASE58_PREFIX)].lower() == BASE58_PREFIX:
+            return _b58decode_int(text[len(BASE58_PREFIX):])
+        try:
+            return _normalize_int(int(text, 10))
+        except ValueError:
+            raise ValueError(f"malformed seed token: {token!r}") from None
+    raise TypeError(f"seed must be an int or str, got {type(token).__name__}")
+
+
+def encode_seed(value) -> str:
+    """Encode an integer entropy into its canonical stored string form.
+
+    Values that fit in 32 bits are kept as a bare decimal (legacy-friendly); wider
+    entropy is emitted in ``base58:`` form.  ``parse_seed(encode_seed(n)) == n`` for
+    every non-negative ``n`` (and for negative ``n`` after the ``uint32`` fold).
+
+    :param value: The integer entropy to encode.
+    :type value: int or numpy.integer
+    :return: The canonical seed string.
+    :rtype: str
+    """
+    n = _normalize_int(int(value))
+    if n <= _UINT32_MASK:
+        return str(n)
+    return BASE58_PREFIX + _b58encode_int(n)
+
+
+def random_entropy() -> int:
+    """Draw fresh OS entropy via :class:`numpy.random.SeedSequence`.
+
+    :return: A non-negative integer drawn from a freshly seeded ``SeedSequence``.
+    :rtype: int
+    """
+    return int(np.random.SeedSequence().entropy)

--- a/src/lysis/tools/slurm.py
+++ b/src/lysis/tools/slurm.py
@@ -647,6 +647,9 @@ class _SlurmJobSpec:
     out_file_code: str
     in_file_code: Optional[str] = None
     num_children: Optional[int] = None
+    #: Forward the legacy ``seed_scheme="direct"`` path into each array
+    #: task's ``from_hdf5(...)`` call (micro only).  Defaults to False.
+    direct: bool = False
 
 
 #: Template for the master Python script in array mode (both scales).
@@ -811,6 +814,8 @@ def _runner_init_line(
     args.append("index=int(os.environ['SLURM_ARRAY_TASK_ID'])")
     if spec.num_children is not None:
         args.append(f"num_children={spec.num_children}")
+    if spec.direct:
+        args.append("direct=True")
     if skip_binary_verification:
         args.append("skip_binary_verification=True")
     if source_stamp is not None and not skip_binary_verification:
@@ -1496,7 +1501,7 @@ def wait_for_jobs(job_ids: List[int], poll_interval: int = 30) -> None:
         remaining = [j for j in remaining if str(j) in running_ids]
 
 
-def _micro_spec(num_children: int, out_code: str) -> _SlurmJobSpec:
+def _micro_spec(num_children: int, out_code: str, direct: bool = False) -> _SlurmJobSpec:
     """Build the microscale array-mode dispatch spec."""
     return _SlurmJobSpec(
         scale="micro",
@@ -1509,6 +1514,7 @@ def _micro_spec(num_children: int, out_code: str) -> _SlurmJobSpec:
         out_file_code=out_code,
         in_file_code=None,
         num_children=num_children,
+        direct=direct,
     )
 
 
@@ -1572,6 +1578,7 @@ def submit_micro_slurm_job(
     keep_tmpdir: bool = False,
     out_code: str = "",
     num_children: Optional[int] = None,
+    direct: bool = False,
     modules: str = DEFAULT_MODULES,
     sbatch_overrides: Optional[Mapping[str, Optional[str]]] = None,
     historical_backend_attrs: Optional[dict] = None,
@@ -1671,9 +1678,9 @@ def submit_micro_slurm_job(
     # Array path: delegate to the unified array-mode dispatch.
     # ------------------------------------------------------------------
     if num_children is not None:
-        if num_children < 1:
+        if num_children < 2:
             raise ValueError(
-                f"num_children must be >= 1 when set, got {num_children}"
+                f"num_children must be >= 2 when set, got {num_children}"
             )
         from lysis.config.run import Run  # noqa: PLC0415
         run_check = Run(str(hdf5_path.parent), run_code=run_code)
@@ -1685,7 +1692,7 @@ def submit_micro_slurm_job(
                 f"({total_sims}) for run {run_code!r}; cannot split "
                 f"{total_sims} simulations across {num_children} tasks."
             )
-        spec = _micro_spec(num_children, out_code)
+        spec = _micro_spec(num_children, out_code, direct=direct)
         return submit_slurm_job(
             spec, hdf5_path, executable, staging_root_dir,
             partition=partition, fast_tmp_root=fast_tmp_root,

--- a/tests/cli/test_init_macroscale.py
+++ b/tests/cli/test_init_macroscale.py
@@ -206,6 +206,25 @@ class TestInitMacroscaleFolderMode:
         assert "test-run-00" in result.output
         assert "test-run-01" in result.output
 
+    def test_folder_mode_default_keeps_recorded_seed(self, runner, experiment_dir):
+        """Without --random-entropy the recorded macro_seed ('0') is preserved."""
+        runner.invoke(cli, ["init-macroscale", str(experiment_dir)])
+        with DataStore("test-run-00", str(experiment_dir), mode="r") as ds:
+            assert ds.macro_params.macro_seed == "0"
+
+    def test_folder_mode_random_entropy_draws_fresh(self, runner, experiment_dir):
+        """--random-entropy stamps a fresh, distinct macro_seed per run."""
+        result = runner.invoke(
+            cli, ["init-macroscale", str(experiment_dir), "--random-entropy"]
+        )
+        assert result.exit_code == 0, result.output
+        seeds = {}
+        for run_code in ["test-run-00", "test-run-01"]:
+            with DataStore(run_code, str(experiment_dir), mode="r") as ds:
+                seeds[run_code] = ds.macro_params.macro_seed
+        assert all(s != "0" for s in seeds.values())
+        assert seeds["test-run-00"] != seeds["test-run-01"]
+
     def test_folder_mode_param_override_warns(self, runner, experiment_dir):
         """--param is ignored in folder mode; a warning should be printed."""
         result = runner.invoke(

--- a/tests/cli/test_run_micro.py
+++ b/tests/cli/test_run_micro.py
@@ -338,10 +338,11 @@ class TestRunMicroSlurm:
         assert mock_submit.call_args.kwargs.get("num_children") == 10
 
     @patch("lysis.tools.slurm.submit_micro_slurm_job", return_value=1)
-    def test_num_children_zero_is_translated_to_none(
-        self, mock_submit, runner, micro_hdf5
+    @pytest.mark.parametrize("bad", ["0", "1"])
+    def test_num_children_below_two_rejected(
+        self, mock_submit, runner, micro_hdf5, bad
     ):
-        """``--num-children 0`` selects the legacy single-child path."""
+        """``--num-children`` of 0 or 1 is rejected (only >= 2 is allowed)."""
         result = runner.invoke(
             cli,
             [
@@ -351,11 +352,12 @@ class TestRunMicroSlurm:
                 "/bin/micro.exe",
                 "--slurm",
                 "--num-children",
-                "0",
+                bad,
             ],
         )
-        assert result.exit_code == 0, result.output
-        assert mock_submit.call_args.kwargs.get("num_children") is None
+        assert result.exit_code != 0
+        assert "x>=2" in result.output or "is not in the range" in result.output
+        mock_submit.assert_not_called()
 
     @patch("lysis.tools.slurm.submit_micro_slurm_job", return_value=1)
     def test_modules_default_is_forwarded(self, mock_submit, runner, micro_hdf5):

--- a/tests/cli/test_run_micro.py
+++ b/tests/cli/test_run_micro.py
@@ -120,6 +120,27 @@ class TestRunMicroLocal:
         assert call_args.args[1] == "/bin/micro.exe"
 
     @patch("lysis.execution.fortran_micro.FortranMicro")
+    def test_direct_default_false(self, mock_cls, runner, micro_hdf5):
+        """Without --direct, the runner is built with direct=False."""
+        mock_cls.from_hdf5.return_value = MagicMock()
+        result = runner.invoke(
+            cli, ["run-micro", str(micro_hdf5), "--executable", "/bin/micro.exe"]
+        )
+        assert result.exit_code == 0, result.output
+        assert mock_cls.from_hdf5.call_args.kwargs.get("direct") is False
+
+    @patch("lysis.execution.fortran_micro.FortranMicro")
+    def test_direct_flag_forwarded(self, mock_cls, runner, micro_hdf5):
+        """--direct threads direct=True into FortranMicro.from_hdf5."""
+        mock_cls.from_hdf5.return_value = MagicMock()
+        result = runner.invoke(
+            cli,
+            ["run-micro", str(micro_hdf5), "--executable", "/bin/micro.exe", "--direct"],
+        )
+        assert result.exit_code == 0, result.output
+        assert mock_cls.from_hdf5.call_args.kwargs.get("direct") is True
+
+    @patch("lysis.execution.fortran_micro.FortranMicro")
     def test_calls_run_full(self, mock_cls, runner, micro_hdf5):
         mock_fm = MagicMock()
         mock_cls.from_hdf5.return_value = mock_fm
@@ -336,6 +357,23 @@ class TestRunMicroSlurm:
         )
         assert result.exit_code == 0, result.output
         assert mock_submit.call_args.kwargs.get("num_children") == 10
+
+    @patch("lysis.tools.slurm.submit_micro_slurm_job", return_value=1)
+    def test_direct_forwarded_to_submit(self, mock_submit, runner, micro_hdf5):
+        """--direct threads direct=True into submit_micro_slurm_job."""
+        result = runner.invoke(
+            cli,
+            [
+                "run-micro",
+                str(micro_hdf5),
+                "--executable",
+                "/bin/micro.exe",
+                "--slurm",
+                "--direct",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert mock_submit.call_args.kwargs.get("direct") is True
 
     @patch("lysis.tools.slurm.submit_micro_slurm_job", return_value=1)
     @pytest.mark.parametrize("bad", ["0", "1"])

--- a/tests/config/test_experiment.py
+++ b/tests/config/test_experiment.py
@@ -630,3 +630,68 @@ class TestExperimentRenameRun:
         with open(os.path.join(exp.path, "experiment.json")) as fh:
             meta = json.load(fh)
         assert old_code in [r["run_code"] for r in meta["runs"]]
+
+
+# ─── Seed entropy resolution (blank cell / --random-entropy) ─────────────────
+
+
+def _one_row_csv(tmp_path, micro_seed, macro_seed):
+    """Write a single-run CSV with the given (possibly blank) seed cells."""
+    micro = _default_micro_row()
+    macro = _default_macro_row()
+    micro["micro_seed"] = micro_seed
+    macro["macro_seed"] = macro_seed
+    row = {**micro, **macro, "run_code": "seed-run", "run_description": ""}
+    csv_path = tmp_path / "seed_exp.csv"
+    _write_minimal_csv(csv_path, [row])
+    return csv_path
+
+
+class TestSeedEntropy:
+    """from_csv resolves the blank-cell / --random-entropy seed sentinel."""
+
+    def test_blank_seed_draws_fresh_distinct(self, tmp_path):
+        """Two inits from a blank-seed CSV draw different, non-zero base58 seeds."""
+        csv_path = _one_row_csv(tmp_path, micro_seed="", macro_seed="")
+        data_root = tmp_path / "out"
+        data_root.mkdir()
+        s1 = Experiment.from_csv(csv_path, data_root, name="a", dry_run=True)
+        s2 = Experiment.from_csv(csv_path, data_root, name="a", dry_run=True)
+        m1 = s1.runs[0].micro_params.micro_seed
+        m2 = s2.runs[0].micro_params.micro_seed
+        assert m1 != m2
+        assert m1 != "0" and m2 != "0"
+        assert m1.startswith("base58:") and m2.startswith("base58:")
+        # Macro seed is resolved too.
+        assert s1.runs[0].macro_params.macro_seed.startswith("base58:")
+
+    def test_explicit_seed_respected(self, tmp_path):
+        """A non-blank seed cell is preserved verbatim, no fresh draw."""
+        csv_path = _one_row_csv(tmp_path, micro_seed="12345", macro_seed="6789")
+        data_root = tmp_path / "out"
+        data_root.mkdir()
+        exp = Experiment.from_csv(csv_path, data_root, name="a", dry_run=True)
+        assert exp.runs[0].micro_params.micro_seed == "12345"
+        assert exp.runs[0].macro_params.macro_seed == "6789"
+
+    def test_random_entropy_overrides_explicit_seed(self, tmp_path):
+        """random_entropy=True ignores an explicit CSV seed and draws fresh."""
+        csv_path = _one_row_csv(tmp_path, micro_seed="12345", macro_seed="6789")
+        data_root = tmp_path / "out"
+        data_root.mkdir()
+        exp = Experiment.from_csv(
+            csv_path, data_root, name="a", dry_run=True, random_entropy=True
+        )
+        assert exp.runs[0].micro_params.micro_seed != "12345"
+        assert exp.runs[0].macro_params.macro_seed != "6789"
+
+    def test_resolved_seed_persists_to_hdf5(self, tmp_path):
+        """The drawn micro_seed is written into the run's HDF5 params (not '0')."""
+        csv_path = _one_row_csv(tmp_path, micro_seed="", macro_seed="")
+        data_root = tmp_path / "out"
+        data_root.mkdir()
+        exp = Experiment.from_csv(csv_path, data_root, name="a")
+        with DataStore("seed-run", exp.path, mode="r") as ds:
+            stored = ds.micro_params.micro_seed
+        assert stored == exp.runs[0].micro_params.micro_seed
+        assert stored != "0"

--- a/tests/config/test_parameters.py
+++ b/tests/config/test_parameters.py
@@ -89,32 +89,43 @@ class TestMicroParametersCustomInit:
         assert micro.micro_simulations == 1_000
 
     def test_override_micro_seed(self):
-        """micro_seed can be overridden."""
+        """micro_seed can be overridden; canonicalised to its string form."""
         micro = _micro(micro_seed=42)
-        assert micro.micro_seed == 42
+        assert micro.micro_seed == "42"
+        assert micro.seed_as_int() == 42
 
-    def test_micro_seed_default_is_uint32(self):
-        """Default micro_seed has dtype np.uint32."""
+    def test_micro_seed_default_is_canonical_string(self):
+        """Default micro_seed is the canonical entropy string ``"0"``."""
         micro = _micro()
-        assert isinstance(micro.micro_seed, np.uint32)
+        assert micro.micro_seed == "0"
+        assert micro.seed_as_int() == 0
 
-    def test_micro_seed_override_normalised_to_uint32(self):
-        """Plain-int override is normalised to np.uint32."""
+    def test_micro_seed_override_canonicalised_to_string(self):
+        """Plain-int override is stored as a bare decimal string."""
         micro = _micro(micro_seed=42)
-        assert isinstance(micro.micro_seed, np.uint32)
-        assert micro.micro_seed == np.uint32(42)
+        assert isinstance(micro.micro_seed, str)
+        assert micro.micro_seed == "42"
 
     def test_micro_seed_negative_wraps_bitwise(self):
         """Negative int override is reinterpreted as the uint32 bit pattern."""
         micro = _micro(micro_seed=-1)
-        assert isinstance(micro.micro_seed, np.uint32)
-        assert micro.micro_seed == np.uint32(0xFFFFFFFF)
+        assert micro.seed_as_int() == 0xFFFFFFFF
+        assert micro.micro_seed == str(0xFFFFFFFF)
 
     def test_micro_seed_high_bit_preserved(self):
-        """High-bit int override is preserved bit-for-bit as uint32."""
+        """High-bit int override is preserved bit-for-bit through seed_as_int."""
         micro = _micro(micro_seed=0x80000001)
-        assert isinstance(micro.micro_seed, np.uint32)
-        assert micro.micro_seed == np.uint32(0x80000001)
+        assert micro.seed_as_int() == 0x80000001
+        assert micro.micro_seed == str(0x80000001)
+
+    def test_micro_seed_base58_round_trips(self):
+        """A wide base58: entropy survives construction and decodes back."""
+        from lysis.tools.seedcodec import encode_seed
+
+        wide = 0x0123456789ABCDEF0123456789ABCDEF
+        micro = _micro(micro_seed=encode_seed(wide))
+        assert micro.micro_seed.startswith("base58:")
+        assert micro.seed_as_int() == wide
 
     def test_override_diss_const_tPA_woPLG(self):
         """diss_const_tPA_woPLG override propagates into unbind_rate_tPA_woPLG."""
@@ -445,24 +456,27 @@ class TestMacroParametersCustomInit:
         macro = _macro(macro_seed=12345)
         assert macro.state[3] == 12345
 
-    def test_macro_seed_default_is_uint32(self):
-        """Default macro_seed has dtype np.uint32."""
+    def test_macro_seed_default_is_canonical_string(self):
+        """Default macro_seed is the canonical entropy string ``"0"``."""
         macro = _macro()
-        assert isinstance(macro.macro_seed, np.uint32)
+        assert macro.macro_seed == "0"
+        assert macro.seed_as_int() == 0
 
     def test_macro_seed_negative_wraps_bitwise(self):
         """Negative int override is reinterpreted as the uint32 bit pattern."""
         macro = _macro(macro_seed=-1)
-        assert isinstance(macro.macro_seed, np.uint32)
-        assert macro.macro_seed == np.uint32(0xFFFFFFFF)
-        # The RNG state tuple mirrors the normalised value.
+        assert macro.seed_as_int() == 0xFFFFFFFF
+        assert macro.macro_seed == str(0xFFFFFFFF)
+        # The RNG state tuple mirrors the uint32-folded value.
         assert macro.state[3] == np.uint32(0xFFFFFFFF)
 
     def test_macro_seed_high_bit_preserved(self):
-        """High-bit int override is preserved bit-for-bit as uint32."""
+        """High-bit int override is preserved bit-for-bit through seed_as_int."""
         macro = _macro(macro_seed=0xDEADBEEF)
-        assert isinstance(macro.macro_seed, np.uint32)
-        assert macro.macro_seed == np.uint32(0xDEADBEEF)
+        assert macro.seed_as_int() == 0xDEADBEEF
+        assert macro.macro_seed == str(0xDEADBEEF)
+        # state[3] folds the entropy to its uint32 bit pattern.
+        assert macro.state[3] == np.uint32(0xDEADBEEF)
 
     def test_macro_state_tuple_elements_are_uint32(self):
         """All four RNG state entries are np.uint32."""

--- a/tests/execution/test_fortran.py
+++ b/tests/execution/test_fortran.py
@@ -322,6 +322,80 @@ class TestExecCommandTemplate:
         assert cmd[cmd.index("--seed") + 1] == "-559038737"
 
 
+class TestSeedScheme:
+    """seed_scheme split (default) vs direct, and the reproducibility contract."""
+
+    def _seed_token(self, runner):
+        cmd = runner.exec_command()
+        assert "--seed" in cmd
+        return cmd[cmd.index("--seed") + 1]
+
+    def test_single_task_always_emits_explicit_seed(self, tmp_run):
+        """A default single-task run emits --seed (never Fortran's compiled default)."""
+        cls = _make_stub_class()
+        runner = cls(run=tmp_run, executable="/x", index=None)
+        cmd = runner.exec_command()
+        assert "--seed" in cmd
+
+    def test_split_is_deterministic_for_same_entropy(self, tmp_path):
+        """Same recorded entropy → identical per-task seeds (reproducible)."""
+        cls = _make_stub_class()
+        seeds_a, seeds_b = [], []
+        for store in (seeds_a, seeds_b):
+            r = Run(str(tmp_path))
+            r.initialize_micro_param({"micro_seed": 0xABCDEF})
+            for i in range(4):
+                runner = cls(run=r, executable="/x", index=i, num_children=4)
+                store.append(self._seed_token(runner))
+        assert seeds_a == seeds_b
+
+    def test_recorded_entropy_round_trips(self, tmp_path):
+        """Re-supplying a recorded entropy reproduces the byte-identical seed."""
+        cls = _make_stub_class()
+        from lysis.tools.seedcodec import encode_seed, random_entropy
+
+        recorded = encode_seed(random_entropy())  # a base58: wide value
+        tokens = []
+        for _ in range(2):
+            r = Run(str(tmp_path))
+            r.initialize_micro_param({"micro_seed": recorded})
+            runner = cls(run=r, executable="/x", index=2, num_children=8)
+            tokens.append(self._seed_token(runner))
+        assert tokens[0] == tokens[1]
+
+    def test_base58_entropy_resolves_to_uint32_seed(self, tmp_path):
+        """A wide base58: entropy still yields a valid signed-int32 --seed token."""
+        cls = _make_stub_class()
+        from lysis.tools.seedcodec import encode_seed
+
+        r = Run(str(tmp_path))
+        r.initialize_micro_param(
+            {"micro_seed": encode_seed(0x0123456789ABCDEF0123456789ABCDEF)}
+        )
+        runner = cls(run=r, executable="/x", index=None)
+        token = self._seed_token(runner)
+        assert -(2**31) <= int(token) < 2**31  # fits signed INTEGER*4
+
+    def test_split_does_not_stamp_seed_scheme(self, stub_runner):
+        """The default split scheme leaves no seed_scheme provenance attr."""
+        from lysis.config.constants import CONST
+
+        assert CONST.SEED_SCHEME_ATTR not in stub_runner._backend_hdf5_attrs
+
+    def test_direct_passes_raw_seed_and_stamps_scheme(self, tmp_path):
+        """direct=True bypasses SeedSequence and stamps seed_scheme='direct'."""
+        from lysis.config.constants import CONST
+
+        cls = _make_stub_class()
+        r = Run(str(tmp_path))
+        r.initialize_micro_param({"micro_seed": np.uint32(0x80000001)})
+        runner = cls(run=r, executable="/x", index=None, direct=True)
+        token = self._seed_token(runner)
+        # raw uint32 0x80000001 → signed int32 -2147483647 (no SeedSequence)
+        assert token == "-2147483647"
+        assert runner._backend_hdf5_attrs.get(CONST.SEED_SCHEME_ATTR) == "direct"
+
+
 # ---------------------------------------------------------------------------
 # skip_binary_verification (historical-build path)
 # ---------------------------------------------------------------------------

--- a/tests/execution/test_fortran.py
+++ b/tests/execution/test_fortran.py
@@ -110,10 +110,17 @@ class TestExecCommandTemplate:
         assert "--outFileCode" in cmd
 
     def test_default_params_only_base_args(self, stub_runner):
-        """With all-default params only base args should appear."""
+        """All-default params: base args plus the always-emitted explicit --seed.
+
+        Single-task runs now derive an explicit seed via
+        ``SeedSequence(entropy).generate_state(1)[0]`` so the Fortran binary
+        never silently falls back to its compiled-in default.
+        """
         cmd = stub_runner.exec_command()
-        # base: executable + --runCode + code + --outFileCode + ""  = 5 elements
-        assert len(cmd) == 5
+        # base: executable + --runCode + code + --outFileCode + ""  = 5 elements,
+        # plus --seed <value> = 7.
+        assert len(cmd) == 7
+        assert "--seed" in cmd
 
     def test_non_default_param_included(self, tmp_path):
         """A non-default param must appear as a CLI flag."""
@@ -200,7 +207,7 @@ class TestExecCommandTemplate:
         assert runner.out_file_code == "__02"
 
     def test_index_two_correct_seed(self, tmp_run):
-        seed = tmp_run.micro_params.micro_seed
+        seed = tmp_run.micro_params.seed_as_int()
         stream = np.random.SeedSequence(seed)
         expected_seed = int(np.int32(stream.generate_state(3)[2]))
 
@@ -260,7 +267,7 @@ class TestExecCommandTemplate:
 
     def test_seed_split_count_returns_num_children_when_set(self, tmp_run):
         """When num_children is set, every sibling draws from the same-sized stream."""
-        seed = tmp_run.micro_params.micro_seed
+        seed = tmp_run.micro_params.seed_as_int()
         stream = np.random.SeedSequence(seed)
         seeds = stream.generate_state(10)
 
@@ -292,8 +299,8 @@ class TestExecCommandTemplate:
         r = Run(str(tmp_path))
         r.initialize_micro_param({"micro_seed": high_bit_seed})
         cls = _make_stub_class()
-        # index=None → no SeedSequence split, seed flows through as-is.
-        runner = cls(run=r, executable="/bin/stub.exe", index=None)
+        # direct=True → no SeedSequence split, the raw uint32 flows through.
+        runner = cls(run=r, executable="/bin/stub.exe", index=None, direct=True)
         cmd = runner.exec_command()
 
         expected = str(
@@ -308,7 +315,8 @@ class TestExecCommandTemplate:
         r = Run(str(tmp_path))
         r.initialize_micro_param({"micro_seed": np.uint32(0xDEADBEEF)})
         cls = _make_stub_class()
-        runner = cls(run=r, executable="/bin/stub.exe", index=None)
+        # direct=True → the raw uint32 flows through to the |uint32 signed cast.
+        runner = cls(run=r, executable="/bin/stub.exe", index=None, direct=True)
         cmd = runner.exec_command()
         assert "--seed" in cmd
         assert cmd[cmd.index("--seed") + 1] == "-559038737"

--- a/tests/execution/test_fortran_macro.py
+++ b/tests/execution/test_fortran_macro.py
@@ -157,7 +157,7 @@ class TestFortranMacroExecCommand:
     def test_seed_split_uses_macro_simulations(self, tmp_run):
         """Seed split count for FortranMacro must equal macro_simulations."""
         n_sims = tmp_run.macro_params.macro_simulations
-        seed = tmp_run.macro_params.macro_seed
+        seed = tmp_run.macro_params.seed_as_int()
 
         stream = np.random.SeedSequence(seed)
         expected_seed = int(np.int32(stream.generate_state(n_sims)[0]))

--- a/tests/execution/test_fortran_micro.py
+++ b/tests/execution/test_fortran_micro.py
@@ -95,11 +95,16 @@ class TestFortranMicroExecCommand:
         assert tmp_run.run_code in cmd
 
     def test_default_params_no_extra_flags(self, tmp_run):
-        """With all-default params the command should only have --runCode and --outFileCode."""
+        """All-default params: base args plus the always-emitted explicit --seed.
+
+        Single-task runs now derive an explicit seed via SeedSequence so the
+        Fortran binary never falls back to its compiled-in default.
+        """
         fm = FortranMicro(run=tmp_run, executable="/bin/micro.exe")
         cmd = fm.exec_command()
-        # Only executable + 4 elements: --runCode, run_code, --outFileCode, ""
-        assert len(cmd) == 5
+        # executable + --runCode, run_code, --outFileCode, "" (5) + --seed <v> (2)
+        assert len(cmd) == 7
+        assert "--seed" in cmd
 
     def test_non_default_param_included(self, tmp_path):
         """A non-default constructor param must appear in the command."""
@@ -168,7 +173,7 @@ class TestFortranMicroExecCommand:
 
     def test_index_two_uses_correct_seed(self, tmp_run):
         """index=2 must derive seed from SeedSequence at position 2."""
-        seed = tmp_run.micro_params.micro_seed
+        seed = tmp_run.micro_params.seed_as_int()
         stream = np.random.SeedSequence(seed)
         expected_seed = int(np.int32(stream.generate_state(3)[2]))
 
@@ -832,7 +837,9 @@ class TestFortranBinaryExecution:
             pass
 
         hdf5_path = tmp_path / f"{run_code}.h5"
-        fm = FortranMicro.from_hdf5(hdf5_path, binary)
+        # The fixture reference was produced by feeding _FIXTURE_SEED straight to
+        # the binary, so reproduce it with direct=True (no SeedSequence split).
+        fm = FortranMicro.from_hdf5(hdf5_path, binary, direct=True)
         data_dir = fm.exec_in_workdir(tmp_path)
         fm.import_results(data_dir, keep_tmpdir=True)
         return hdf5_path

--- a/tests/test_macroscale.py
+++ b/tests/test_macroscale.py
@@ -145,6 +145,59 @@ def sim(run_with_data):
 
 
 # ---------------------------------------------------------------------------
+#  RNG seed handling
+# ---------------------------------------------------------------------------
+
+
+class TestMacroscaleSeed:
+    """MacroscaleSim decodes the entropy string and folds it for KISS."""
+
+    _WIDE = 0x0123456789ABCDEF0123456789ABCDEF  # 128-bit, exceeds uint32
+
+    def test_native_rng_accepts_wide_entropy(self, tmp_path):
+        """The default_rng path takes the full-width entropy without error."""
+        from lysis.tools.seedcodec import encode_seed
+
+        run = _make_run_and_datastore(
+            tmp_path, macro_overrides={"macro_seed": encode_seed(self._WIDE)}
+        )
+        sim = MacroscaleSim(run)  # must not raise
+        assert sim.rng is not None
+
+    def test_kiss_rng_folds_wide_entropy_to_uint32(self, tmp_path):
+        """The KISS path folds a wide base58: entropy to a uint32-range seed.
+
+        KISS seeds a uint32 state word via ``ctypes.c_uint``, which raises
+        OverflowError beyond ``2**32-1``.  The KissRandomGenerator C library is
+        mocked here so the test exercises only the fold (its shared-library path
+        is a separate, pre-existing concern), asserting the value handed to KISS
+        is the low 32 bits — matching ``state[3]``.
+        """
+        from unittest.mock import patch
+
+        from lysis.tools.seedcodec import encode_seed
+
+        run = _make_run_and_datastore(
+            tmp_path,
+            macro_overrides={
+                "macro_seed": encode_seed(self._WIDE),
+                "duplicate_fortran": True,
+            },
+        )
+        # Return a real Generator so the rest of __init__ (molecule placement)
+        # works; we only care about the seed value handed to KISS.
+        with patch(
+            "lysis.macroscale.KissRandomGenerator",
+            return_value=np.random.default_rng(0),
+        ) as mock_kiss:
+            MacroscaleSim(run)
+        seed_arg = mock_kiss.call_args.args[0]
+        assert seed_arg == (self._WIDE & 0xFFFFFFFF)
+        assert 0 <= seed_arg <= 0xFFFFFFFF
+        assert run.macro_params.state[3] == np.uint32(self._WIDE & 0xFFFFFFFF)
+
+
+# ---------------------------------------------------------------------------
 #  Initialization tests
 # ---------------------------------------------------------------------------
 

--- a/tests/tools/test_seedcodec.py
+++ b/tests/tools/test_seedcodec.py
@@ -1,0 +1,116 @@
+"""Unit tests for :mod:`lysis.tools.seedcodec`.
+
+Cover the public API and the Base58 helpers:
+
+* ``encode_seed`` / ``parse_seed`` — round-trip across the 32-bit boundary, the
+  decimal-vs-``base58:`` representation policy, legacy-int and signed-negative input,
+  case-insensitive sigil, and malformed-input rejection.
+* ``_b58encode_int`` / ``_b58decode_int`` — alphabet correctness, zero, round-trip.
+* ``random_entropy`` — wide, distinct draws.
+"""
+
+import numpy as np
+import pytest
+
+from lysis.tools.seedcodec import (
+    BASE58_PREFIX,
+    _b58decode_int,
+    _b58encode_int,
+    encode_seed,
+    parse_seed,
+    random_entropy,
+)
+
+_UINT32_MAX = 0xFFFFFFFF
+_WIDE = 0x0123456789ABCDEF0123456789ABCDEF  # 128-bit
+
+
+class TestRoundTrip:
+    """parse_seed(encode_seed(n)) == n across the representation boundary."""
+
+    @pytest.mark.parametrize(
+        "n", [0, 1, 12345, _UINT32_MAX, _UINT32_MAX + 1, _WIDE, 2**128 - 1]
+    )
+    def test_round_trip(self, n):
+        assert parse_seed(encode_seed(n)) == n
+
+    def test_small_values_stay_decimal(self):
+        """Values that fit in 32 bits encode as a bare decimal string."""
+        assert encode_seed(0) == "0"
+        assert encode_seed(12345) == "12345"
+        assert encode_seed(_UINT32_MAX) == str(_UINT32_MAX)
+
+    def test_wide_values_use_base58(self):
+        """Values beyond 32 bits encode with the base58: sigil."""
+        encoded = encode_seed(_UINT32_MAX + 1)
+        assert encoded.startswith(BASE58_PREFIX)
+        assert parse_seed(encoded) == _UINT32_MAX + 1
+
+
+class TestParseSeed:
+    """parse_seed accepts ints, decimals, and base58: strings; rejects junk."""
+
+    def test_bare_decimal(self):
+        assert parse_seed("12345") == 12345
+
+    def test_legacy_int(self):
+        assert parse_seed(99) == 99
+        assert parse_seed(np.uint32(99)) == 99
+
+    def test_negative_int_folds_to_uint32(self):
+        """A signed-negative legacy seed maps to its uint32 bit pattern."""
+        assert parse_seed(-1) == _UINT32_MAX
+        assert parse_seed(-559038737) == 0xDEADBEEF
+        assert parse_seed("-559038737") == 0xDEADBEEF
+
+    def test_base58_sigil_case_insensitive(self):
+        payload = encode_seed(_WIDE)[len(BASE58_PREFIX):]
+        assert parse_seed("base58:" + payload) == _WIDE
+        assert parse_seed("BASE58:" + payload) == _WIDE
+
+    def test_whitespace_trimmed(self):
+        assert parse_seed("  4242  ") == 4242
+
+    @pytest.mark.parametrize("bad", ["", "   ", "not-a-number", "12x34", "base58:"])
+    def test_malformed_raises(self, bad):
+        with pytest.raises(ValueError):
+            parse_seed(bad)
+
+    def test_base58_invalid_char_raises(self):
+        """0, O, I, l are not in the Base58 alphabet."""
+        with pytest.raises(ValueError):
+            parse_seed("base58:0OIl")
+
+    def test_wrong_type_raises(self):
+        with pytest.raises(TypeError):
+            parse_seed(1.5)
+
+
+class TestBase58Helpers:
+    """Direct checks on the integer Base58 codec."""
+
+    def test_zero_is_first_char(self):
+        assert _b58encode_int(0) == "1"
+        assert _b58decode_int("1") == 0
+
+    def test_negative_encode_raises(self):
+        with pytest.raises(ValueError):
+            _b58encode_int(-1)
+
+    def test_empty_decode_raises(self):
+        with pytest.raises(ValueError):
+            _b58decode_int("")
+
+    @pytest.mark.parametrize("n", [0, 1, 57, 58, 59, 12345, _WIDE])
+    def test_int_round_trip(self, n):
+        assert _b58decode_int(_b58encode_int(n)) == n
+
+
+class TestRandomEntropy:
+    """random_entropy draws wide, distinct values."""
+
+    def test_distinct_and_wide(self):
+        draws = {random_entropy() for _ in range(8)}
+        assert len(draws) == 8
+        assert all(d >= 0 for d in draws)
+        assert max(draws) > _UINT32_MAX  # SeedSequence entropy is ~128-bit


### PR DESCRIPTION
Fixes #97.

## Summary

`FortranRunner` fed the stored `micro_seed`/`macro_seed` straight into `np.random.SeedSequence(...)` but never treated the "no seed" value as "draw fresh entropy". Because the field defaulted to `np.uint32(0)` and `SeedSequence(0)` is fully deterministic, leaving a seed unset made every run on every machine byte-identical — reproducible *by accident*, hiding the absence of randomness.

This PR (negotiated with the maintainer, pre-v1.0.0) relocates the sentinel to the input layer and makes the seed a canonical **entropy string**, landing the v1.0.0 end-state rather than a band-aid.

## What changed

- **`seedcodec`** (new `src/lysis/tools/seedcodec.py`): encodes the `SeedSequence` entropy as a single string — a **bare decimal** (a legacy `uint32`, which "just works" with no conversion) or a **`base58:`**-prefixed full-width value (compact, human-retypeable). Both decode to one non-negative int. Vendored big-integer Base58 (Bitcoin alphabet); signed-negative legacy seeds fold to their `uint32` bit pattern.
- **`micro_seed`/`macro_seed` are now canonical strings** (not `np.uint32`). `__post_init__` canonicalises via `seedcodec` instead of the lossy `& 0xFFFFFFFF` mask, so wide OS entropy is preserved while a bare int still parses — **no dataspec version bump, no converter** (the permissive reader handles legacy numeric attrs). `seed_as_int()` added for the execution layer.
- **Blank-cell sentinel at init**: `Experiment.from_csv` treats a blank `micro_seed`/`macro_seed` CSV cell (or the new `--random-entropy` flag on `init-experiment`/`init-macroscale`) as "draw fresh OS entropy and record it", logged at INFO. An explicit seed is respected.
- **`exec_command` always splits** via `SeedSequence(entropy).generate_state(...)`: single-task runs pull `seeds[0]`, so the Fortran binary never silently falls back to its compiled-in default. The macro `exec_in_workdir` decodes via `seed_as_int()` so the Fortran and Python backends seed identically.
- **`run-micro --direct`**: legacy reproduction — feed the seed straight to the Fortran KISS RNG with no `SeedSequence`, and stamp a `seed_scheme="direct"` **provenance attr** (absence ⇒ "split"; not a dataspec dataset). Threaded through the Slurm array children. **`--num-children` now requires ≥ 2** (0/1 rejected).
- Fixed two seed consumers for the string field: the Python macro RNG init and the `lysis parameters` table formatter.

## Width contract

32-bit legacy seed **or** wider OS entropy in → 32-bit per-task seed out (round-trips through the `|uint32` signed-`INTEGER*4` Fortran cast).

## Verification

- **Full suite: 2078 passed, 16 skipped** (binaries rebuilt with `intel-compilers/2023`).
- The Fortran **binary-execution golden tests** confirm `--direct` reproduces legacy raw-seed output bit-for-bit.
- Docs build cleanly.
- New coverage: codec round-trip, blank-cell/`--random-entropy` fresh draws, explicit-seed regression, entropy round-trip reproducibility, split-vs-direct + `seed_scheme` stamping, `--num-children ≥ 2` rejection.

## Addresses the maintainer's design concerns

- **Legacy keys just-work** — a `uint32` is a bare-decimal entropy; no conversion, no lookup.
- **No dataspec break / no cross-backend (dev-1.1.0) divergence** — both backends share one `parse_seed` → `SeedSequence`.
- **No attribute sprawl** — the seed stays inside `Micro`/`MacroParameters`; only `seed_scheme` is a provenance stamp.

## Out of scope / follow-ups

- Per-sim micro seeding (awaits the Python microscale rewrite).
- v2.0.0 Parameters refactor: `seed_scheme` → Mechanism parameter.
- dev-1.1.0 merge touch-up: macro state was refactored into `_state.py`/`python_macro.py`; the seed math is identical, so this is a mechanical merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)