### PR TITLE
Fix --direct legacy seed wiring on the single-child Slurm micro path

### DIFF
--- a/docs/source/usage/run_microscale.rst
+++ b/docs/source/usage/run_microscale.rst
@@ -122,7 +122,9 @@ Options
     Number of Slurm array tasks to split the microscale simulations across
     (must be **>= 2**).  The run's ``micro_simulations`` are partitioned across
     the tasks, and each task draws its own per-task seed from the run's recorded
-    entropy.  Defaults to 10.  Only meaningful with ``--slurm``.
+    entropy.  Defaults to 10.  Only meaningful with ``--slurm``.  Ignored when
+    ``--direct`` is set (``--direct`` always uses the single-child path); a
+    warning is printed if you pass both explicitly.
 
 .. option:: --direct
 
@@ -132,6 +134,11 @@ Options
     only to reproduce historical runs whose ``uint32`` seed was passed directly
     to the binary; new runs should use the default ``split`` scheme.  See
     :ref:`random-seeds`.
+
+    ``--direct`` **always** uses the legacy single-child (non-array) execution
+    path.  Under ``--slurm`` it submits a single child job regardless of
+    ``--num-children`` (which is ignored), so every simulation in the run shares
+    the one raw ``uint32`` seed — exactly as the historical binary was invoked.
 
 Examples
 ~~~~~~~~

--- a/src/lysis/cli/run_micro.py
+++ b/src/lysis/cli/run_micro.py
@@ -277,8 +277,16 @@ def run_micro(ctx, target_path, executable, use_slurm, partition, staging_root,
         if use_slurm:
             from lysis.tools.slurm import submit_micro_slurm_job
 
-            # If we are using the "--direct" flag, then we are on the legacy path
+            # If we are using the "--direct" flag, then we are on the legacy
+            # single-child path; --num-children does not apply.  Warn only when
+            # the user explicitly set it (the option defaults to 10).
             if direct:
+                nc_source = ctx.get_parameter_source("num_children")
+                if nc_source is not None and nc_source.name != "DEFAULT":
+                    console.print(
+                        "[yellow]--direct uses the legacy single-child path; "
+                        "--num-children is ignored.[/yellow]"
+                    )
                 nc_arg = None
             else:
                 nc_arg = num_children

--- a/src/lysis/tools/slurm.py
+++ b/src/lysis/tools/slurm.py
@@ -498,6 +498,7 @@ FILE_CODE = $file_code
 BINARY_NAME = $binary_name
 KEEP_TMPDIR = $keep_tmpdir
 HISTORICAL_BACKEND_ATTRS = $historical_backend_attrs
+DIRECT = $direct
 
 # ---------------------------------------------------------------------------
 # Submit child jobs
@@ -541,6 +542,7 @@ fm = FortranMicro(
     executable=str(STAGING_DIR / BINARY_NAME),
     skip_binary_verification=(HISTORICAL_BACKEND_ATTRS is not None),
     historical_backend_attrs=HISTORICAL_BACKEND_ATTRS,
+    direct=DIRECT,
 )
 fm.import_results(
     data_dir,
@@ -569,6 +571,7 @@ def _generate_micro_master_py(
     binary_name: str,
     keep_tmpdir: bool,
     historical_backend_attrs: Optional[dict] = None,
+    direct: bool = False,
 ) -> str:
     """Return the content of the single-child micro master Python script.
 
@@ -580,6 +583,11 @@ def _generate_micro_master_py(
         ``<binary> --version`` query.  ``None`` (default) preserves the
         normal-mode behaviour.
     :type historical_backend_attrs: dict or None
+    :param direct: When ``True``, construct the master's ``FortranMicro``
+        with ``direct=True`` so ``import_results`` stamps
+        ``seed_scheme="direct"`` provenance into the HDF5 file.  Defaults
+        to ``False``.
+    :type direct: bool, optional
     """
     return _MICRO_MASTER_PY_TEMPLATE.substitute(
         staging_dir=repr(str(staging_dir)),
@@ -589,6 +597,7 @@ def _generate_micro_master_py(
         binary_name=repr(binary_name),
         keep_tmpdir=repr(keep_tmpdir),
         historical_backend_attrs=repr(historical_backend_attrs),
+        direct=repr(direct),
     )
 
 
@@ -1260,6 +1269,7 @@ def generate_micro_child_script(
     pythonpath: "Path | str | None" = None,
     source_stamp: Optional[tuple] = None,
     experiment: Optional[str] = None,
+    direct: bool = False,
 ) -> str:
     """Generate a Slurm bash script for a single child microscale Fortran job.
 
@@ -1335,6 +1345,12 @@ def generate_micro_child_script(
     :param experiment: Best-effort experiment identifier shown in the log
         header; ``None`` (default) renders as ``(unknown)``.
     :type experiment: str, optional
+    :param direct: When ``True``, bake ``direct=True`` into the generated
+        ``from_hdf5(...)`` call so the child folds the run seed to
+        ``uint32`` and feeds it straight to the Fortran KISS RNG
+        (``seed_scheme="direct"``) instead of the default
+        :class:`numpy.random.SeedSequence` split.  Defaults to ``False``.
+    :type direct: bool, optional
     :return: Slurm bash script text.
     :rtype: str
     :raises ImportError: If ``GooseSLURM`` is not installed.
@@ -1383,6 +1399,11 @@ def generate_micro_child_script(
     else:
         source_stamp_kwarg = ""
 
+    # Legacy reproduction: feed the raw uint32 seed straight to the Fortran
+    # KISS RNG with no SeedSequence split (mirrors the array-mode wiring in
+    # ``_build_runner_from_hdf5_line``).
+    direct_kwarg = ", direct=True" if direct else ""
+
     if fast_tmp_root is None:
         # ------------------------------------------------------------------
         # Single-tier: Fortran writes directly to the shared staging dir.
@@ -1401,7 +1422,7 @@ mkdir -p "${{staging_datadir}}" """
 {py} -c "
 from pathlib import Path
 from lysis.execution.fortran_micro import FortranMicro
-fm = FortranMicro.from_hdf5('{hdf5_path}', '{staging_dir}/{binary_name}', out_file_code='{out_code}'{skip_verify_kwarg}{source_stamp_kwarg})
+fm = FortranMicro.from_hdf5('{hdf5_path}', '{staging_dir}/{binary_name}', out_file_code='{out_code}'{skip_verify_kwarg}{source_stamp_kwarg}{direct_kwarg})
 fm.exec_in_workdir(Path('{staging_dir}'))
 " """
 
@@ -1431,7 +1452,7 @@ cp "{staging_dir}/{binary_name}" "${{local_work_dir}}/" """
 {py} -c "
 from pathlib import Path
 from lysis.execution.fortran_micro import FortranMicro
-fm = FortranMicro.from_hdf5('{hdf5_path}', '${{local_work_dir}}/{binary_name}', out_file_code='{out_code}'{skip_verify_kwarg}{source_stamp_kwarg})
+fm = FortranMicro.from_hdf5('{hdf5_path}', '${{local_work_dir}}/{binary_name}', out_file_code='{out_code}'{skip_verify_kwarg}{source_stamp_kwarg}{direct_kwarg})
 fm.exec_in_workdir(Path('${{local_work_dir}}'))
 " """
 
@@ -1634,6 +1655,14 @@ def submit_micro_slurm_job(
         across that many tasks.  ``None`` (default) selects the legacy
         single-child path.
     :type num_children: int, optional
+    :param direct: When ``True``, use the legacy ``seed_scheme="direct"``
+        path: the seed is folded to ``uint32`` and fed straight to the
+        Fortran KISS RNG (no :class:`numpy.random.SeedSequence` split), and
+        ``seed_scheme="direct"`` is stamped into the HDF5 provenance.
+        Threaded through to both the child and master scripts on the
+        single-child path and to the array tasks on the array path.
+        Defaults to ``False``.
+    :type direct: bool, optional
     :param modules: Space-separated list of LMod module specs (include a
         Fortran compiler module so the binary finds its runtime), baked into every generated script (master, array tasks,
         and the legacy single child).  Defaults to
@@ -1763,6 +1792,7 @@ def submit_micro_slurm_job(
         pythonpath=pythonpath,
         source_stamp=source_stamp,
         experiment=experiment,
+        direct=direct,
     )
     child_path = staging_dir / f"lysis-micro-child__{run_code}.sh"
     child_path.write_text(child_script)
@@ -1774,6 +1804,7 @@ def submit_micro_slurm_job(
     master_py_content = _generate_micro_master_py(
         staging_dir, hdf5_path, run_code, out_code, executable.name, keep_tmpdir,
         historical_backend_attrs=historical_backend_attrs,
+        direct=direct,
     )
     master_py_path = staging_dir / f"lysis-micro-master__{run_code}.py"
     master_py_path.write_text(master_py_content)

--- a/tests/cli/test_run_micro.py
+++ b/tests/cli/test_run_micro.py
@@ -374,6 +374,50 @@ class TestRunMicroSlurm:
         )
         assert result.exit_code == 0, result.output
         assert mock_submit.call_args.kwargs.get("direct") is True
+        # --direct forces the legacy single-child path: num_children -> None.
+        assert mock_submit.call_args.kwargs.get("num_children") is None
+
+    @patch("lysis.tools.slurm.submit_micro_slurm_job", return_value=1)
+    def test_direct_warns_when_num_children_explicit(
+        self, mock_submit, runner, micro_hdf5
+    ):
+        """Passing --num-children alongside --direct warns that it is ignored."""
+        result = runner.invoke(
+            cli,
+            [
+                "run-micro",
+                str(micro_hdf5),
+                "--executable",
+                "/bin/micro.exe",
+                "--slurm",
+                "--direct",
+                "--num-children",
+                "20",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert "ignored" in result.output
+        # The explicit 20 is discarded; the legacy single-child path runs.
+        assert mock_submit.call_args.kwargs.get("num_children") is None
+
+    @patch("lysis.tools.slurm.submit_micro_slurm_job", return_value=1)
+    def test_direct_no_warning_without_explicit_num_children(
+        self, mock_submit, runner, micro_hdf5
+    ):
+        """--direct alone (default --num-children) prints no ignored-warning."""
+        result = runner.invoke(
+            cli,
+            [
+                "run-micro",
+                str(micro_hdf5),
+                "--executable",
+                "/bin/micro.exe",
+                "--slurm",
+                "--direct",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert "ignored" not in result.output
 
     @patch("lysis.tools.slurm.submit_micro_slurm_job", return_value=1)
     @pytest.mark.parametrize("bad", ["0", "1"])

--- a/tests/tools/test_slurm.py
+++ b/tests/tools/test_slurm.py
@@ -264,6 +264,45 @@ class TestGenerateMicroChildScript:
             "module load intel-compilers/2024 SciPy-bundle/2023.07" in script
         )
 
+    def test_single_tier_direct_bakes_kwarg(self, tmp_path):
+        """direct=True must bake direct=True into the single-tier from_hdf5 call.
+
+        Regression for the PR #112 gap: the legacy single-child path
+        rerouted --direct here but dropped the seed_scheme="direct" wiring.
+        """
+        staging = tmp_path / "staging"
+        script = generate_micro_child_script(
+            staging, "run-01", tmp_path / "run-01.h5",
+            "/bin/micro.exe", "", direct=True,
+        )
+        assert ", direct=True" in script
+
+    def test_single_tier_no_direct_by_default(self, tmp_path):
+        staging = tmp_path / "staging"
+        script = generate_micro_child_script(
+            staging, "run-01", tmp_path / "run-01.h5",
+            "/bin/micro.exe", "",
+        )
+        assert "direct=True" not in script
+
+    def test_two_tier_direct_bakes_kwarg(self, tmp_path):
+        staging = tmp_path / "staging"
+        script = generate_micro_child_script(
+            staging, "run-01", tmp_path / "run-01.h5",
+            "/bin/micro.exe", "",
+            fast_tmp_root="/nvme/scratch", direct=True,
+        )
+        assert ", direct=True" in script
+
+    def test_two_tier_no_direct_by_default(self, tmp_path):
+        staging = tmp_path / "staging"
+        script = generate_micro_child_script(
+            staging, "run-01", tmp_path / "run-01.h5",
+            "/bin/micro.exe", "",
+            fast_tmp_root="/nvme/scratch",
+        )
+        assert "direct=True" not in script
+
 
 # ---------------------------------------------------------------------------
 # TestSubmitMicroChildJob
@@ -616,6 +655,44 @@ class TestSubmitMicroSlurmJob:
         staging_dir = list(staging_root.iterdir())[0]
         child_content = (staging_dir / "lysis-micro-child__run-01.sh").read_text()
         assert str(micro_hdf5) in child_content
+
+    @patch("lysis.tools.slurm.gs.sbatch", return_value=1)
+    def test_direct_threaded_into_child_and_master(
+        self, mock_sbatch, micro_hdf5, tmp_path
+    ):
+        """direct=True on the legacy single-child path must reach BOTH the
+        child (seed folding) and master (seed_scheme provenance) scripts.
+
+        Regression test for the PR #112 gap: --direct was rerouted to this
+        path but the direct flag was dropped before any script was written.
+        """
+        staging_root = tmp_path / "staging_root"
+        staging_root.mkdir()
+        submit_micro_slurm_job(
+            micro_hdf5, "/bin/micro.exe",
+            staging_root=staging_root, direct=True,
+        )
+        staging_dir = list(staging_root.iterdir())[0]
+        child_content = (staging_dir / "lysis-micro-child__run-01.sh").read_text()
+        master_content = (staging_dir / "lysis-micro-master__run-01.py").read_text()
+        assert ", direct=True" in child_content
+        assert "DIRECT = True" in master_content
+        assert "direct=DIRECT" in master_content
+
+    @patch("lysis.tools.slurm.gs.sbatch", return_value=1)
+    def test_direct_absent_by_default(self, mock_sbatch, micro_hdf5, tmp_path):
+        """Without direct=True the child stays on the default split scheme and
+        the master records DIRECT = False."""
+        staging_root = tmp_path / "staging_root"
+        staging_root.mkdir()
+        submit_micro_slurm_job(
+            micro_hdf5, "/bin/micro.exe", staging_root=staging_root
+        )
+        staging_dir = list(staging_root.iterdir())[0]
+        child_content = (staging_dir / "lysis-micro-child__run-01.sh").read_text()
+        master_content = (staging_dir / "lysis-micro-master__run-01.py").read_text()
+        assert "direct=True" not in child_content
+        assert "DIRECT = False" in master_content
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #113.

## Problem

`run-micro --direct` exists to reproduce legacy runs: feed the seed straight to the Fortran KISS RNG (fold entropy to `uint32`, **no** `SeedSequence` split) and stamp `seed_scheme="direct"` provenance.

PR #112 (commit `7803aaa`) rerouted all `--direct` calls to the legacy single-child Slurm path by forcing `nc_arg = None`, but that path in `src/lysis/tools/slurm.py` never threaded `direct` into the generated scripts. So for `run-micro --slurm --direct`:

- the **child** ran `FortranMicro.from_hdf5(...)` without `direct=` → the seed was SeedSequence-split (wrong) instead of folded to `uint32`;
- the **master** built `FortranMicro(...)` without `direct=True` → `import_results` never stamped `seed_scheme="direct"`.

The local (non-Slurm) and array Slurm paths already handled `direct` correctly — only the legacy single-child Slurm path was broken.

## Fix

- **`generate_micro_child_script`** — new `direct` param; bake `direct=True` into both the single-tier and two-tier `from_hdf5(...)` calls (the child resolves and folds the seed). Core fix.
- **`_generate_micro_master_py` / `_MICRO_MASTER_PY_TEMPLATE`** — new `DIRECT` substitution + `direct=DIRECT` in the master's `FortranMicro`, so `import_results` stamps the provenance.
- **`submit_micro_slurm_job`** — pass `direct=direct` to both legacy call sites. `fm_setup` left untouched (it only writes `params.json`; seed/provenance never flow through it).
- **CLI** (`run_micro.py`) — warn (via `ctx.get_parameter_source`) when `--num-children` is explicitly passed alongside `--direct`, since it is ignored.
- **Docs** (`run_microscale.rst`) — `--direct` now states it always uses the legacy single-child non-array path; `--num-children` notes it is ignored under `--direct`.

## Tests

6 new regression tests (child-script kwarg baking for both tiers, end-to-end `submit_micro_slurm_job(direct=True)` reading back the written child+master scripts, and the two CLI warning cases).

Full suite: **2088 passed, 16 skipped** (binaries rebuilt with `intel-compilers/2023`).